### PR TITLE
Make drawer and tool entry figures configurable via PaletteCustomizer

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,6 +36,7 @@ import org.eclipse.gef.internal.InternalImages;
 import org.eclipse.gef.internal.ui.palette.PaletteColorUtil;
 import org.eclipse.gef.palette.PaletteDrawer;
 import org.eclipse.gef.palette.PaletteTemplateEntry;
+import org.eclipse.gef.ui.palette.PaletteCustomizer;
 import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
 import org.eclipse.gef.ui.palette.editparts.IPinnableEditPart;
 import org.eclipse.gef.ui.palette.editparts.PaletteAnimator;
@@ -82,6 +83,11 @@ public class DrawerEditPart extends PaletteEditPart implements IPinnableEditPart
 		});
 
 		fig.getScrollpane().getContents().addLayoutListener(getPaletteAnimator());
+
+		PaletteCustomizer customizer = getViewer().getCustomizer();
+		if (customizer != null) {
+			customizer.configure(fig);
+		}
 
 		return fig;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/IColorPalette.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/IColorPalette.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.ui.palette;
+
+import org.eclipse.swt.graphics.Color;
+
+public interface IColorPalette {
+	Color getSelectedColor();
+
+	Color getHoverColor();
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/IDrawerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/IDrawerFigure.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.ui.palette;
+
+import org.eclipse.draw2d.Clickable;
+import org.eclipse.draw2d.IFigure;
+
+import org.eclipse.gef.internal.ui.palette.editparts.DrawerFigure;
+
+/**
+ * Public interface of the {@link DrawerFigure}.
+ *
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @noextend This interface is not intended to be extended by clients.
+ */
+public interface IDrawerFigure extends IFigure {
+	void setGradientPainter(IGradientPainter painter);
+
+	/**
+	 * @return The {@link Clickable} that is used to expand/collapse the drawer.
+	 */
+	Clickable getCollapseToggle();
+
+	/**
+	 * @return The content pane for this figure, i.e. the Figure to which children
+	 *         can be added.
+	 */
+	IFigure getContentPane();
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/IGradientPainter.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/IGradientPainter.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.ui.palette;
+
+import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.geometry.Rectangle;
+
+import org.eclipse.gef.internal.ui.palette.editparts.DrawerFigure;
+
+/**
+ * This interface can be used together with the {@link IDrawerFigure} and
+ * {@link PaletteCustomizer}, to adapt the the background painted in a
+ * {@link DrawerFigure}.
+ *
+ * @since 3.20
+ */
+public interface IGradientPainter {
+	/**
+	 * Paints the background gradient on the drawer toggle figure.
+	 *
+	 * @param g    the graphics object
+	 * @param rect the rectangle which the background gradient should cover
+	 */
+	void paint(Graphics g, Rectangle rect);
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/IToolEntryFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/IToolEntryFigure.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.ui.palette;
+
+import org.eclipse.draw2d.IFigure;
+
+/**
+ * Public interface of the
+ * {@link org.eclipse.gef.internal.ui.palette.editparts.ToolEntryEditPart.ToolEntryToggle}.
+ *
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @noextend This interface is not intended to be extended by clients.
+ */
+public interface IToolEntryFigure extends IFigure {
+	void setColorPalette(IColorPalette colorPalette);
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteCustomizer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteCustomizer.java
@@ -15,6 +15,8 @@ package org.eclipse.gef.ui.palette;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.gef.internal.ui.palette.editparts.DrawerEditPart;
+import org.eclipse.gef.internal.ui.palette.editparts.DrawerFigure;
 import org.eclipse.gef.palette.PaletteContainer;
 import org.eclipse.gef.palette.PaletteDrawer;
 import org.eclipse.gef.palette.PaletteEntry;
@@ -303,4 +305,19 @@ public abstract class PaletteCustomizer {
 	 */
 	public abstract void save();
 
+	/**
+	 * Called by the {@link DrawerEditPart#createFigure()} for every palette drawer
+	 * edit part, to allow clients to customize the created {@link DrawerFigure}
+	 * without accessing the internal class directly.
+	 *
+	 * @param drawerFigure The figure created for one of the palette drawers.
+	 * @since 3.20
+	 */
+	public void configure(IDrawerFigure drawerFigure) {
+		// may be overwritten by clients
+	}
+
+	public void configure(IToolEntryFigure drawerFigure) {
+		// may be overwritten by clients
+	}
 }


### PR DESCRIPTION
This adds the public interfaces IDrawerFigure and IToolEntryFigure, which are implemented by the figures created in the DrawerEditPart and ToolEntryEditPart, respectively.

Those interfaces can be accessed with with configure methods in the PaletteCustomizers. Clients can use them to adjust the figures without having to re-implement the palette editpart-factory and without having to reference the internal classes.