### PR TITLE
Make palette selection and hover colors customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ## GEF
  - _Linux Only_ The overlay scrolling of the palette can be configured via the _PaletteViewerPreferences.PREFERENCE_SCROLLBARS_MODE_ preference. Supported values are _SWT.NONE_ and _SWT.SCROLLBAR_OVERLAY_.
  - The refresh rate of the [TargetingTool](https://github.com/eclipse-gef/gef-classic/blob/master/org.eclipse.gef/src/org/eclipse/gef/tools/TargetingTool.java) class can be configured via the `setRefreshRate(int)` method. Events are then updated only once every given number of milliseconds, to reduce the CPU load when processing large amounts of update requests.
+ - The look of the palette viewer can be customized via the ColorPalette interface. Supported model elements and properties are:
+   - PaletteEntry (hover, selection) 
+   - PaletteTemplateEntry (selection)
 
 ## Zest
  - Integration of Zest 2.0 development branch. See the [wiki](https://github.com/eclipse-gef/gef-classic/wiki/Zest#zest-2x) for more details. In case only default layout algorithms are used, the initial migration should be seamless. Otherwise the algorithms can be adapted to run in legacy mode by extending `AbstractLayoutAlgorithm.Zest1` or have to be re-implemented using the new API by extending `AbstractLayoutAlgorithm`. Note that this legacy mode will be removed in a future release. The following list contains the most significant, deprecated features:

--- a/org.eclipse.gef.examples.shapes/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.shapes/META-INF/MANIFEST.MF
@@ -13,8 +13,12 @@ Require-Bundle: org.eclipse.gef;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.ui.views;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.ui.workbench;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.jface;bundle-version="[3.2.0,4.0.0)"
+ org.eclipse.jface;bundle-version="[3.2.0,4.0.0)",
+ org.eclipse.e4.core.contexts;bundle-version="[1.12.600,2.0.0)",
+ org.eclipse.e4.core.di.annotations;bundle-version="[1.8.400,2.0.0)",
+ org.eclipse.e4.ui.model.workbench;bundle-version="[2.4.300,3.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.gef.examples.shapes
+Model-Fragment: fragment.e4xmi
 

--- a/org.eclipse.gef.examples.shapes/build.properties
+++ b/org.eclipse.gef.examples.shapes/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2004, 2010 IBM Corporation and others.
+# Copyright (c) 2004, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials are made available under the 
 # terms of the Eclipse Public License 2.0 which is available at
@@ -17,7 +17,8 @@ bin.includes = plugin.xml,\
                shapes.gif,\
                about.html,\
                META-INF/,\
-               plugin.properties
+               plugin.properties,\
+               fragment.e4xmi
 src.includes = META-INF/,\
                about.html,\
                plugin.properties,\

--- a/org.eclipse.gef.examples.shapes/fragment.e4xmi
+++ b/org.eclipse.gef.examples.shapes/fragment.e4xmi
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="ASCII"?>
+<fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:commands="http://www.eclipse.org/ui/2010/UIModel/application/commands" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmlns:ui="http://www.eclipse.org/ui/2010/UIModel/application/ui" xmi:id="_NgZIIJVIEe-9Ku3Ok7Aflw">
+  <imports xsi:type="menu:Menu" xmi:id="_XpVcIJVKEe-9Ku3Ok7Aflw" elementId="org.eclipse.ui.main.menu"/>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_OIiGMJVIEe-9Ku3Ok7Aflw" featurename="handlers" parentElementId="xpath:/">
+    <elements xsi:type="commands:Handler" xmi:id="_SvOkgJVIEe-9Ku3Ok7Aflw" elementId="org.eclipse.gef.examples.shapes.handler.paletteHandler" contributionURI="bundleclass://org.eclipse.gef.examples.shapes/org.eclipse.gef.examples.shapes.handler.ColorPaletteHandler" command="_WIwFEJVIEe-9Ku3Ok7Aflw"/>
+  </fragments>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_Ug_dEJVIEe-9Ku3Ok7Aflw" featurename="commands" parentElementId="xpath:/">
+    <elements xsi:type="commands:Command" xmi:id="_WIwFEJVIEe-9Ku3Ok7Aflw" elementId="org.eclipse.gef.examples.shapes.command.paletteCommand" commandName="Use Custom Color Palette"/>
+  </fragments>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_DGMksJVJEe-9Ku3Ok7Aflw" featurename="menuContributions" parentElementId="xpath:/">
+    <elements xsi:type="menu:MenuContribution" xmi:id="_FRJZUJVJEe-9Ku3Ok7Aflw" elementId="org.eclipse.gef.examples.shapes.menucontribution.paletteMenu" positionInParent="after=edit" parentId="org.eclipse.ui.main.menu">
+      <children xsi:type="menu:Menu" xmi:id="_VaBhYJVJEe-9Ku3Ok7Aflw" elementId="org.eclipse.gef.examples.shapes.menu.palette" label="%menu.label.1">
+        <visibleWhen xsi:type="ui:ImperativeExpression" xmi:id="_5lzhoJVKEe-9Ku3Ok7Aflw" contributionURI="bundleclass://org.eclipse.gef.examples.shapes/org.eclipse.gef.examples.shapes.handler.ColorPaletteExpression"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_knZOAJVKEe-9Ku3Ok7Aflw" elementId="org.eclipse.gef.examples.shapes.handledmenuitem.usecustompalette" label="%handledmenuitem.label.1" enabled="false" type="Check" command="_WIwFEJVIEe-9Ku3Ok7Aflw"/>
+      </children>
+    </elements>
+  </fragments>
+</fragment:ModelFragments>

--- a/org.eclipse.gef.examples.shapes/plugin.properties
+++ b/org.eclipse.gef.examples.shapes/plugin.properties
@@ -12,3 +12,6 @@
 ###############################################################################
 Plugin.name=GEF Classic Shape Editor Example
 Plugin.providerName=Eclipse GEF
+
+menu.label.1 = Palette
+handledmenuitem.label.1 = Use Custom Color Palette

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/handler/ColorPaletteExpression.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/handler/ColorPaletteExpression.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.examples.shapes.handler;
+
+import org.eclipse.e4.core.contexts.Active;
+import org.eclipse.e4.core.di.annotations.Evaluate;
+import org.eclipse.e4.core.di.annotations.Optional;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
+import org.eclipse.ui.IEditorPart;
+
+import org.eclipse.gef.examples.shapes.ShapesEditor;
+
+/**
+ * This imperative expression is invoked by the {@code fragment.e4xmi} to check
+ * whether the {@code Palette} menu item is visible.
+ */
+public class ColorPaletteExpression {
+	@Evaluate
+	@SuppressWarnings("static-method")
+	public boolean test(@Optional @Active MPart activePart) {
+		if (activePart != null) {
+			return activePart.getContext().get(IEditorPart.class) instanceof ShapesEditor;
+		}
+		return false;
+	}
+}

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/handler/ColorPaletteHandler.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/handler/ColorPaletteHandler.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.examples.shapes.handler;
+
+import org.eclipse.e4.core.contexts.Active;
+import org.eclipse.e4.core.di.annotations.CanExecute;
+import org.eclipse.e4.core.di.annotations.Execute;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
+import org.eclipse.e4.ui.model.application.ui.menu.MMenuItem;
+import org.eclipse.ui.IEditorPart;
+
+import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.gef.ui.palette.PaletteViewer;
+
+import org.eclipse.gef.examples.shapes.ShapesEditor;
+import org.eclipse.gef.examples.shapes.palette.ShapesColorPalette;
+
+/**
+ * This handler manages the {@code Use Custom Palette} menu item which switches
+ * between the default and the custom palette theme.
+ */
+public class ColorPaletteHandler {
+	@Execute
+	@SuppressWarnings("static-method")
+	public void execute(@Active MPart activePart, MMenuItem menuItem) {
+		IEditorPart editorPart = activePart.getContext().get(IEditorPart.class);
+		GraphicalViewer graphicalViewer = editorPart.getAdapter(GraphicalViewer.class);
+		PaletteViewer paletteViewer = graphicalViewer.getEditDomain().getPaletteViewer();
+		if (menuItem.isSelected()) {
+			paletteViewer.setColorPalette(new ShapesColorPalette());
+		} else {
+			paletteViewer.setColorPalette(null);
+		}
+		paletteViewer.getControl().redraw();
+	}
+
+	@CanExecute
+	@SuppressWarnings("static-method")
+	public boolean canExecute(@Active MPart activePart) {
+		return activePart.getContext().get(IEditorPart.class) instanceof ShapesEditor;
+	}
+}

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/palette/ShapesColorPalette.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/palette/ShapesColorPalette.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.examples.shapes.palette;
+
+import org.eclipse.swt.graphics.Color;
+
+import org.eclipse.draw2d.ColorConstants;
+
+import org.eclipse.gef.ui.palette.DefaultColorPalette;
+
+/**
+ * Defines arbitrary colors that distinguish themselves from the default
+ * palette.
+ */
+public class ShapesColorPalette extends DefaultColorPalette {
+	@Override
+	public Color getSelectedColor() {
+		return ColorConstants.darkGreen;
+	}
+
+	@Override
+	public Color getHoverColor() {
+		return ColorConstants.cyan;
+	}
+}

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/ShapesDiagramTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/ShapesDiagramTests.java
@@ -22,11 +22,14 @@ import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
 import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditor;
 import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
 
+import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
 
 import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.test.swtbot.utils.SWTBotGefPalette;
+import org.eclipse.gef.ui.palette.ColorPalette;
 
 import org.junit.Test;
 
@@ -56,6 +59,20 @@ public class ShapesDiagramTests extends AbstractSWTBotEditorTests {
 		});
 
 		assertEquals(figure.getSize(), new Dimension(200, 200));
+	}
+
+	@Test
+	public void testCustomPalette() {
+		bot.menu("Palette").menu("Use Custom Color Palette").click();
+
+		SWTBotGefEditor editor = bot.gefEditor("shapesExample1.shapes");
+		editor.activateTool("Ellipse");
+
+		SWTBotGefPalette palette = new SWTBotGefPalette(editor.getSWTBotGefViewer());
+		ColorPalette colorPalette = palette.getColorPalette();
+
+		assertEquals(colorPalette.getHoverColor(), ColorConstants.cyan);
+		assertEquals(colorPalette.getSelectedColor(), ColorConstants.darkGreen);
 	}
 
 	@Override

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/utils/SWTBotGefPalette.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/utils/SWTBotGefPalette.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.test.swtbot.utils;
+
+import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
+import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefViewer;
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+
+import org.eclipse.gef.ui.palette.ColorPalette;
+import org.eclipse.gef.ui.palette.PaletteViewer;
+
+/**
+ * Convenience class to create an SWTBot instance over the palette viewer.
+ */
+public class SWTBotGefPalette extends SWTBotGefViewer {
+
+	public SWTBotGefPalette(SWTBotGefViewer gefViewer) throws WidgetNotFoundException {
+		super(getPaletteViewer(gefViewer));
+	}
+
+	private static PaletteViewer getPaletteViewer(SWTBotGefViewer gefViewer) {
+		SWTBotGefEditPart gefEditPart = gefViewer.rootEditPart();
+		return gefEditPart.part().getViewer().getEditDomain().getPaletteViewer();
+	}
+
+	public PaletteViewer getPaletteViewer() {
+		return (PaletteViewer) graphicalViewer;
+	}
+
+	public ColorPalette getColorPalette() {
+		return getPaletteViewer().getColorPalette();
+	}
+}

--- a/org.eclipse.gef/.settings/.api_filters
+++ b/org.eclipse.gef/.settings/.api_filters
@@ -126,6 +126,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/gef/ui/palette/DefaultColorPalette.java" type="org.eclipse.gef.ui.palette.DefaultColorPalette">
+        <filter comment="Default implementation for ColorPalette" id="576725006">
+            <message_arguments>
+                <message_argument value="ColorPalette"/>
+                <message_argument value="DefaultColorPalette"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/gef/ui/palette/DefaultPaletteViewerPreferences.java" type="org.eclipse.gef.ui.palette.DefaultPaletteViewerPreferences">
         <filter id="576725006">
             <message_arguments>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/PaletteColorUtil.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/PaletteColorUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2010 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,6 @@
 package org.eclipse.gef.internal.ui.palette;
 
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.FigureUtilities;
@@ -38,14 +37,6 @@ public class PaletteColorUtil {
 	public static final Color INFO_FOREGROUND = ColorConstants.tooltipForeground;
 
 	public static final Color ARROW_HOVER = new Color(null, 229, 229, 219);
-
-	private static final Color HOVER_COLOR = ColorConstants.listHoverBackgroundColor;
-
-	private static final Color SELECTED_COLOR = ColorConstants.listSelectedBackgroundColor;
-
-	private static final Color HOVER_COLOR_HICONTRAST = new Color(null, 0, 128, 0);
-
-	private static final Color SELECTED_COLOR_HICONTRAST = new Color(null, 128, 0, 128);
 
 	public static final Color WIDGET_BACKGROUND_LIST_BACKGROUND_40 = FigureUtilities
 			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_LIST_BACKGROUND, 0.4);
@@ -79,40 +70,4 @@ public class PaletteColorUtil {
 
 	public static final Color WIDGET_BACKGROUND_NORMAL_SHADOW_95 = FigureUtilities
 			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_NORMAL_SHADOW, 0.95);
-
-	/**
-	 * Gets the color to be used when hovering over palette items. The color differs
-	 * in high contrast mode.
-	 *
-	 * @return the hover color
-	 * @since 3.4
-	 */
-	public static Color getHoverColor() {
-		Display display = Display.getCurrent();
-		if (display == null) {
-			display = Display.getDefault();
-		}
-		if (display.getHighContrast()) {
-			return HOVER_COLOR_HICONTRAST;
-		}
-		return HOVER_COLOR;
-	}
-
-	/**
-	 * Gets the color to be used when selecting palette items. The color differs in
-	 * high contrast mode.
-	 *
-	 * @return the selected color
-	 * @since 3.4
-	 */
-	public static Color getSelectedColor() {
-		Display display = Display.getCurrent();
-		if (display == null) {
-			display = Display.getDefault();
-		}
-		if (display.getHighContrast()) {
-			return SELECTED_COLOR_HICONTRAST;
-		}
-		return SELECTED_COLOR;
-	}
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -65,7 +65,7 @@ public class DrawerEditPart extends PaletteEditPart implements IPinnableEditPart
 	 */
 	@Override
 	public IFigure createFigure() {
-		DrawerFigure fig = new DrawerFigure(getViewer().getControl()) {
+		DrawerFigure fig = new DrawerFigure(getViewer().getControl(), getColorPalette()) {
 			@Override
 			IFigure buildTooltip() {
 				return createToolTip();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerFigure.java
@@ -46,6 +46,7 @@ import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.eclipse.gef.internal.ui.palette.PaletteColorUtil;
+import org.eclipse.gef.ui.palette.ColorPalette;
 import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
 import org.eclipse.gef.ui.palette.editparts.PaletteToolbarLayout;
 
@@ -80,6 +81,7 @@ public class DrawerFigure extends Figure {
 	private boolean showPin = true;
 	private boolean skipNextEvent;
 	private EditPartTipHelper tipHelper;
+	private final ColorPalette colorPalette;
 
 	/**
 	 * This is the figure for the entire drawer label button.
@@ -139,12 +141,15 @@ public class DrawerFigure extends Figure {
 	/**
 	 * Constructor
 	 *
-	 * @param control The Control of the LWS to which this Figure belongs (it is
-	 *                used to display the drawer header with an EditPartTipHelper,
-	 *                if the header is not completely visible). It can be
-	 *                <code>null</code> (the tip won't be displayed).
+	 * @param control      The Control of the LWS to which this Figure belongs (it
+	 *                     is used to display the drawer header with an
+	 *                     EditPartTipHelper, if the header is not completely
+	 *                     visible). It can be <code>null</code> (the tip won't be
+	 *                     displayed).
+	 * @param colorPalette The color palette used for this figure.
 	 */
-	public DrawerFigure(final Control control) {
+	public DrawerFigure(final Control control, final ColorPalette colorPalette) {
+		this.colorPalette = colorPalette;
 		/*
 		 * A PaletteToolbarLayout is being used here instead of a ToolbarLayout so that
 		 * the ScrollPane can be stretched to take up vertical space. This affects
@@ -316,7 +321,7 @@ public class DrawerFigure extends Figure {
 		scrollpane.getViewport().setContentsTracksWidth(true);
 		scrollpane.setMinimumSize(new Dimension(0, 0));
 		scrollpane.setHorizontalScrollBarVisibility(ScrollPane.NEVER);
-		scrollpane.setVerticalScrollBar(new PaletteScrollBar());
+		scrollpane.setVerticalScrollBar(new PaletteScrollBar(colorPalette));
 		scrollpane.getVerticalScrollBar().setStepIncrement(20);
 		scrollpane.setLayoutManager(new OverlayScrollPaneLayout());
 		scrollpane.setContents(new Figure());

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteScrollBar.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteScrollBar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -35,6 +35,7 @@ import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.eclipse.gef.internal.ui.palette.PaletteColorUtil;
+import org.eclipse.gef.ui.palette.ColorPalette;
 
 public final class PaletteScrollBar extends ScrollBar {
 
@@ -81,7 +82,10 @@ public final class PaletteScrollBar extends ScrollBar {
 
 	protected Label upLabel;
 
-	public PaletteScrollBar() {
+	protected final ColorPalette colorPalette;
+
+	public PaletteScrollBar(ColorPalette colorPalette) {
+		this.colorPalette = colorPalette;
 	}
 
 	@Override
@@ -114,8 +118,8 @@ public final class PaletteScrollBar extends ScrollBar {
 				if (!getModel().isMouseOver()) {
 					g.drawImage(TRANSPARENCY, new Rectangle(0, 0, 1, 1), getBounds());
 				} else {
-					g.setBackgroundColor(getModel().isArmed() ? PaletteColorUtil.getSelectedColor()
-							: PaletteColorUtil.getHoverColor());
+					g.setBackgroundColor(getModel().isArmed() ? colorPalette.getSelectedColor()
+							: colorPalette.getHoverColor());
 					g.fillRectangle(getBounds());
 				}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/TemplateEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/TemplateEditPart.java
@@ -25,7 +25,6 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.gef.AccessibleEditPart;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.Request;
-import org.eclipse.gef.internal.ui.palette.PaletteColorUtil;
 import org.eclipse.gef.palette.PaletteEntry;
 import org.eclipse.gef.palette.PaletteTemplateEntry;
 import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
@@ -87,7 +86,7 @@ public class TemplateEditPart extends PaletteEditPart {
 				super.paintFigure(graphics);
 
 				if (isSelected()) {
-					graphics.setBackgroundColor(PaletteColorUtil.getSelectedColor());
+					graphics.setBackgroundColor(getColorPalette().getSelectedColor());
 				}
 				graphics.fillRoundRectangle(ToolEntryEditPart.getSelectionRectangle(getLayoutSetting(), this), 3, 3);
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolEntryEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolEntryEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -38,7 +38,6 @@ import org.eclipse.gef.AccessibleEditPart;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
-import org.eclipse.gef.internal.ui.palette.PaletteColorUtil;
 import org.eclipse.gef.palette.PaletteEntry;
 import org.eclipse.gef.palette.PaletteStack;
 import org.eclipse.gef.palette.ToolEntry;
@@ -278,10 +277,10 @@ public class ToolEntryEditPart extends PaletteEditPart {
 				ButtonModel model = getModel();
 
 				if (model.isSelected()) {
-					graphics.setBackgroundColor(PaletteColorUtil.getSelectedColor());
+					graphics.setBackgroundColor(getColorPalette().getSelectedColor());
 					graphics.fillRoundRectangle(getSelectionRectangle(getLayoutSetting(), customLabel), 3, 3);
 				} else if (model.isMouseOver() || showHoverFeedback) {
-					graphics.setBackgroundColor(PaletteColorUtil.getHoverColor());
+					graphics.setBackgroundColor(getColorPalette().getHoverColor());
 					graphics.fillRoundRectangle(getSelectionRectangle(getLayoutSetting(), customLabel), 3, 3);
 				}
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/ColorPalette.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/ColorPalette.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.ui.palette;
+
+import org.eclipse.swt.graphics.Color;
+
+/**
+ * This interface defines the colors that are used for painting the figures of
+ * the {@link PaletteViewer}. Clients may implement this class and assign it to
+ * their palette via {@link PaletteViewer#setColorPalette(ColorPalette)} to set
+ * their own color theme.
+ *
+ * <EM>IMPORTANT</EM>: This interface is <EM>not</EM> intended to be implemented
+ * by clients. Clients should inherit from {@link DefaultColorPalette}. New
+ * methods may be added in the future.
+ *
+ * @since 3.20
+ * @noextend This interface is not intended to be extended by clients.
+ * @noimplement This interface is not intended to be implemented by clients.
+ */
+public interface ColorPalette {
+	/**
+	 * Gets the color to be used when hovering over palette items. The color may
+	 * differ in high contrast mode.
+	 *
+	 * @return the hover color.
+	 */
+	Color getSelectedColor();
+
+	/**
+	 * Gets the color to be used when selecting palette items. The color may differ
+	 * in high contrast mode.
+	 *
+	 * @return the selected color.
+	 */
+	Color getHoverColor();
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/DefaultColorPalette.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/DefaultColorPalette.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.ui.palette;
+
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Display;
+
+import org.eclipse.draw2d.ColorConstants;
+
+/**
+ * Default colors used by the {@link PaletteViewer} which are used when painting
+ * the palette figures. Clients may extend this class to define their own
+ * colors. The color palette can be set via
+ * {@link PaletteViewer#setColorPalette(ColorPalette)}.
+ *
+ * @since 3.20
+ */
+public class DefaultColorPalette implements ColorPalette {
+	private static final Color HOVER_COLOR_HICONTRAST = new Color(null, 0, 128, 0);
+	private static final Color SELECTED_COLOR_HICONTRAST = new Color(null, 128, 0, 128);
+
+	public static final ColorPalette INSTANCE = new DefaultColorPalette();
+
+	protected DefaultColorPalette() {
+		// This class should never be instantiated directly but instead, the singleton
+		// should be used. It may however be extended by clients to define their own
+		// colors.
+	}
+
+	@Override
+	public Color getSelectedColor() {
+		Display display = Display.getCurrent();
+		if (display == null) {
+			display = Display.getDefault();
+		}
+		if (display.getHighContrast()) {
+			return SELECTED_COLOR_HICONTRAST;
+		}
+		return ColorConstants.listSelectedBackgroundColor;
+	}
+
+	@Override
+	public Color getHoverColor() {
+		Display display = Display.getCurrent();
+		if (display == null) {
+			display = Display.getDefault();
+		}
+		if (display.getHighContrast()) {
+			return HOVER_COLOR_HICONTRAST;
+		}
+		return ColorConstants.listHoverBackgroundColor;
+	}
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
@@ -96,6 +96,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	private PaletteViewerPreferences prefs = PREFERENCE_STORE;
 	private Font font = null;
 	private PaletteAnimator paletteAnimator;
+	private ColorPalette colorPalette = DefaultColorPalette.INSTANCE;
 
 	/**
 	 * Constructor
@@ -228,6 +229,16 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	 */
 	public PaletteViewerPreferences getPaletteViewerPreferences() {
 		return prefs;
+	}
+
+	/**
+	 * @return The color palette that is used for painting the figures of this
+	 *         viewer. If no palette has been set by the user,
+	 *         {@link DefaultColorPalette} is returned instead of {@code null}.
+	 * @since 3.20
+	 */
+	public ColorPalette getColorPalette() {
+		return colorPalette;
 	}
 
 	private ToolEntryEditPart getToolEntryEditPart(ToolEntry entry) {
@@ -461,6 +472,22 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 		this.prefs = prefs;
 		if (getControl() != null && !getControl().isDisposed()) {
 			this.prefs.addPropertyChangeListener(prefListener);
+		}
+	}
+
+	/**
+	 * Sets the color palette that is used for painting the figures of this viewer.
+	 * If {@code null} is passed as an argument, the palette is reset to its default
+	 * configuration.
+	 *
+	 * @param colorPalette The color palette for this viewer.
+	 * @since 3.20
+	 */
+	public void setColorPalette(ColorPalette colorPalette) {
+		if (colorPalette == null) {
+			this.colorPalette = DefaultColorPalette.INSTANCE;
+		} else {
+			this.colorPalette = colorPalette;
 		}
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
@@ -42,6 +42,7 @@ import org.eclipse.gef.palette.PaletteContainer;
 import org.eclipse.gef.palette.PaletteEntry;
 import org.eclipse.gef.palette.PaletteSeparator;
 import org.eclipse.gef.tools.SelectEditPartTracker;
+import org.eclipse.gef.ui.palette.ColorPalette;
 import org.eclipse.gef.ui.palette.PaletteMessages;
 import org.eclipse.gef.ui.palette.PaletteViewer;
 import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
@@ -345,6 +346,17 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart implemen
 	@Override
 	public PaletteViewer getViewer() {
 		return (PaletteViewer) super.getViewer();
+	}
+
+	/**
+	 * Convenience method that simply delegates to
+	 * {@link PaletteViewer#getColorPalette()}.
+	 *
+	 * @return The color palette used for this edit part.
+	 * @since 3.20
+	 */
+	protected final ColorPalette getColorPalette() {
+		return getViewer().getColorPalette();
 	}
 
 	/**


### PR DESCRIPTION
This defines a new ColorPalette interface that can be set in the PaletteViewer. The colors provided by this interface are then used in the palette figure for e.g. the tool entries.

Clients can extend the DefaultColorPalette to define their own colors and therefore change the look of the palette.