### PR TITLE
Improve EventListenerList Performance Bugzilla #255534

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/EventListenerList.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/EventListenerList.java
@@ -50,8 +50,7 @@ public final class EventListenerList {
 	 * @return whether this list contains a listener of type <i>c</i>
 	 */
 	public synchronized <T> boolean containsListener(Class<T> c) {
-		Deque<Object> specListeners = listeners.get(c);
-		return specListeners != null && !specListeners.isEmpty();
+		return listeners.containsKey(c);
 	}
 
 	/**


### PR DESCRIPTION
By separating the event listener types into individual lists and using a map the startup performance could be greatly reduced. It is for small number of EditParts (i.e., 2000) already twice as fast as the previous implementation.
Furthermore iterating through the event listeners is simpler and most probably also faster.

The work is based on the patch submitted by Iwan Birrer to the following Bugzilla entry:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=255534