### PR TITLE
Make "button" colors used inside the palette configurable

### DIFF
--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/handler/ColorProviderHandler.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/handler/ColorProviderHandler.java
@@ -42,7 +42,8 @@ public class ColorProviderHandler {
 		} else {
 			paletteViewer.setColorProvider(null);
 		}
-		paletteViewer.getControl().redraw();
+		// Redraw the FlyoutPaletteComposite
+		paletteViewer.getControl().getParent().getParent().redraw();
 	}
 
 	@CanExecute

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/palette/ShapesColorProvider.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/palette/ShapesColorProvider.java
@@ -33,4 +33,19 @@ public class ShapesColorProvider extends PaletteColorProvider {
 	public Color getListHoverBackgroundColor() {
 		return ColorConstants.cyan;
 	}
+
+	@Override
+	public Color getButton() {
+		return ColorConstants.lightGray;
+	}
+
+	@Override
+	public Color getButtonDarker() {
+		return ColorConstants.gray;
+	}
+
+	@Override
+	public Color getButtonDarkest() {
+		return ColorConstants.darkGray;
+	}
 }

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/ShapesDiagramTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/ShapesDiagramTests.java
@@ -73,6 +73,9 @@ public class ShapesDiagramTests extends AbstractSWTBotEditorTests {
 
 		assertEquals(colorProvider.getListHoverBackgroundColor(), ColorConstants.cyan);
 		assertEquals(colorProvider.getListSelectedBackgroundColor(), ColorConstants.darkGreen);
+		assertEquals(colorProvider.getButton(), ColorConstants.lightGray);
+		assertEquals(colorProvider.getButtonDarker(), ColorConstants.gray);
+		assertEquals(colorProvider.getButtonDarkest(), ColorConstants.darkGray);
 	}
 
 	@Override

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/PaletteColorUtil.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/PaletteColorUtil.java
@@ -26,12 +26,6 @@ import org.eclipse.draw2d.FigureUtilities;
  */
 public class PaletteColorUtil {
 
-	public static final Color WIDGET_BACKGROUND = ColorConstants.button;
-
-	public static final Color WIDGET_NORMAL_SHADOW = ColorConstants.buttonDarker;
-
-	public static final Color WIDGET_DARK_SHADOW = ColorConstants.buttonDarkest;
-
 	public static final Color WIDGET_LIST_BACKGROUND = ColorConstants.listBackground;
 
 	public static final Color INFO_FOREGROUND = ColorConstants.tooltipForeground;
@@ -39,35 +33,14 @@ public class PaletteColorUtil {
 	public static final Color ARROW_HOVER = new Color(null, 229, 229, 219);
 
 	public static final Color WIDGET_BACKGROUND_LIST_BACKGROUND_40 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_LIST_BACKGROUND, 0.4);
+			.mixColors(ColorConstants.button, PaletteColorUtil.WIDGET_LIST_BACKGROUND, 0.4);
 
 	public static final Color WIDGET_BACKGROUND_LIST_BACKGROUND_60 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_LIST_BACKGROUND, 0.6);
+			.mixColors(ColorConstants.button, PaletteColorUtil.WIDGET_LIST_BACKGROUND, 0.6);
 
 	public static final Color WIDGET_BACKGROUND_LIST_BACKGROUND_85 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_LIST_BACKGROUND, 0.85);
+			.mixColors(ColorConstants.button, PaletteColorUtil.WIDGET_LIST_BACKGROUND, 0.85);
 
 	public static final Color WIDGET_BACKGROUND_LIST_BACKGROUND_90 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_LIST_BACKGROUND, 0.9);
-
-	public static final Color WIDGET_BACKGROUND_NORMAL_SHADOW_40 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_NORMAL_SHADOW, 0.4);
-
-	public static final Color WIDGET_BACKGROUND_NORMAL_SHADOW_45 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_NORMAL_SHADOW, 0.45);
-
-	public static final Color WIDGET_BACKGROUND_NORMAL_SHADOW_65 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_NORMAL_SHADOW, 0.65);
-
-	public static final Color WIDGET_BACKGROUND_NORMAL_SHADOW_70 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_NORMAL_SHADOW, 0.7);
-
-	public static final Color WIDGET_BACKGROUND_NORMAL_SHADOW_80 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_NORMAL_SHADOW, 0.8);
-
-	public static final Color WIDGET_BACKGROUND_NORMAL_SHADOW_90 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_NORMAL_SHADOW, 0.9);
-
-	public static final Color WIDGET_BACKGROUND_NORMAL_SHADOW_95 = FigureUtilities
-			.mixColors(PaletteColorUtil.WIDGET_BACKGROUND, PaletteColorUtil.WIDGET_NORMAL_SHADOW, 0.95);
+			.mixColors(ColorConstants.button, PaletteColorUtil.WIDGET_LIST_BACKGROUND, 0.9);
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerFigure.java
@@ -28,7 +28,6 @@ import org.eclipse.draw2d.Clickable;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.CompoundBorder;
 import org.eclipse.draw2d.Figure;
-import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
@@ -54,10 +53,6 @@ import org.eclipse.gef.ui.palette.editparts.PaletteToolbarLayout;
  * @author Pratik Shah
  */
 public class DrawerFigure extends Figure {
-
-	/** Foreground color constant **/
-	protected static final Color FG_COLOR = FigureUtilities.mixColors(PaletteColorUtil.WIDGET_NORMAL_SHADOW,
-			PaletteColorUtil.WIDGET_BACKGROUND);
 
 	/** Scrollpane border constant for icon and column layout mode **/
 	protected static final Border SCROLL_PANE_BORDER = new MarginBorder(2, 2, 2, 2);
@@ -114,13 +109,13 @@ public class DrawerFigure extends Figure {
 			r.setBounds(figure.getBounds()).shrink(insets);
 
 			// draw top border of drawer figure
-			g.setForegroundColor(PaletteColorUtil.WIDGET_NORMAL_SHADOW);
+			g.setForegroundColor(colorProvider.getButtonDarker());
 			g.drawLine(r.getTopLeft(), r.getTopRight());
 			g.setForegroundColor(ColorConstants.listBackground);
 			g.drawLine(r.getTopLeft().getTranslated(0, 1), r.getTopRight().getTranslated(0, 1));
 			r.shrink(new Insets(2, 0, 0, 0));
 			if (isExpanded()) {
-				g.setForegroundColor(PaletteColorUtil.WIDGET_BACKGROUND_NORMAL_SHADOW_65);
+				g.setForegroundColor(colorProvider.getButtonDarker(0.65));
 				g.drawLine(r.getLocation(), r.getTopRight());
 				r.shrink(new Insets(1, 0, 0, 0));
 			}
@@ -172,7 +167,7 @@ public class DrawerFigure extends Figure {
 		drawerLabel = new Label();
 		drawerLabel.setLabelAlignment(Label.LEFT);
 
-		pinFigure = new PinFigure();
+		pinFigure = new PinFigure(colorProvider);
 
 		title.add(pinFigure, BorderLayout.RIGHT);
 		title.add(drawerLabel, BorderLayout.CENTER);
@@ -218,8 +213,8 @@ public class DrawerFigure extends Figure {
 			g.fillRectangle(rect);
 		} else if (collapseToggle.getModel().isMouseOver()) {
 			Color color1 = PaletteColorUtil.WIDGET_BACKGROUND_LIST_BACKGROUND_60;
-			Color color2 = PaletteColorUtil.WIDGET_BACKGROUND_NORMAL_SHADOW_90;
-			Color color3 = PaletteColorUtil.WIDGET_BACKGROUND_NORMAL_SHADOW_95;
+			Color color2 = colorProvider.getButtonDarker(0.9);
+			Color color3 = colorProvider.getButtonDarker(0.95);
 			Color color4 = PaletteColorUtil.WIDGET_BACKGROUND_LIST_BACKGROUND_90;
 
 			g.setForegroundColor(color1);
@@ -235,7 +230,7 @@ public class DrawerFigure extends Figure {
 			g.fillGradient(rect.x, rect.bottom() - 2, rect.width, 2, true);
 		} else {
 			g.setForegroundColor(PaletteColorUtil.WIDGET_BACKGROUND_LIST_BACKGROUND_85);
-			g.setBackgroundColor(PaletteColorUtil.WIDGET_BACKGROUND_NORMAL_SHADOW_45);
+			g.setBackgroundColor(colorProvider.getButtonDarker(0.45));
 			g.fillGradient(rect, true);
 		}
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteScrollBar.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteScrollBar.java
@@ -129,7 +129,7 @@ public final class PaletteScrollBar extends ScrollBar {
 				PointList innerPoints = transpose(down ? INNER_DOWN_TRIANGLE : INNER_UP_TRIANGLE);
 				g.setBackgroundColor(PaletteColorUtil.WIDGET_LIST_BACKGROUND);
 				g.fillPolygon(outerPoints);
-				g.setBackgroundColor(PaletteColorUtil.WIDGET_DARK_SHADOW);
+				g.setBackgroundColor(colorProvider.getButtonDarkest());
 				g.fillPolygon(innerPoints);
 				g.translate(getLocation().getNegated());
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2010 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,11 +13,8 @@
 
 package org.eclipse.gef.internal.ui.palette.editparts;
 
-import org.eclipse.swt.graphics.Color;
-
 import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.ButtonModel;
-import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.ImageFigure;
 import org.eclipse.draw2d.Label;
@@ -25,7 +22,7 @@ import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.Toggle;
 
 import org.eclipse.gef.internal.InternalImages;
-import org.eclipse.gef.internal.ui.palette.PaletteColorUtil;
+import org.eclipse.gef.ui.palette.PaletteColorProvider;
 import org.eclipse.gef.ui.palette.PaletteMessages;
 
 /**
@@ -36,13 +33,12 @@ import org.eclipse.gef.ui.palette.PaletteMessages;
  */
 public class PinFigure extends Toggle {
 
-	private static final Color PIN_HOTSPOT_COLOR = FigureUtilities.mixColors(PaletteColorUtil.WIDGET_LIST_BACKGROUND,
-			PaletteColorUtil.WIDGET_NORMAL_SHADOW, 0.60);
-
 	private static final Border TOOLTIP_BORDER = new MarginBorder(0, 2, 1, 0);
+	private final PaletteColorProvider colorProvider;
 
-	public PinFigure() {
+	public PinFigure(PaletteColorProvider colorProvider) {
 		super(new ImageFigure(InternalImages.get(InternalImages.IMG_UNPINNED)));
+		this.colorProvider = colorProvider;
 		setRolloverEnabled(true);
 		setRequestFocusEnabled(false);
 		Label tooltip = new Label(PaletteMessages.TOOLTIP_PIN_FIGURE);
@@ -74,7 +70,7 @@ public class PinFigure extends Toggle {
 
 		ButtonModel model = getModel();
 		if (isRolloverEnabled() && model.isMouseOver()) {
-			graphics.setBackgroundColor(PIN_HOTSPOT_COLOR);
+			graphics.setBackgroundColor(colorProvider.getHotspotColor());
 			graphics.fillRoundRectangle(getClientArea().getCopy().shrink(1, 1), 3, 3);
 		}
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -105,7 +105,7 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements IPa
 
 	@Override
 	public IFigure createFigure() {
-		return new PinnablePaletteStackFigure();
+		return new PinnablePaletteStackFigure(getColorProvider());
 	}
 
 	@Override

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2010 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -34,6 +34,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.eclipse.gef.internal.ui.palette.PaletteColorUtil;
 import org.eclipse.gef.internal.ui.palette.editparts.ToolEntryEditPart.ToolEntryToggle;
+import org.eclipse.gef.ui.palette.PaletteColorProvider;
 import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
 
 /**
@@ -109,7 +110,7 @@ public class PinnablePaletteStackFigure extends Figure {
 				points[7] = middleY - 2;
 			}
 
-			graphics.setBackgroundColor(PaletteColorUtil.WIDGET_DARK_SHADOW);
+			graphics.setBackgroundColor(colorProvider.getButtonDarkest());
 			graphics.fillPolygon(points);
 
 			graphics.translate(getLocation().getNegated());
@@ -289,14 +290,18 @@ public class PinnablePaletteStackFigure extends Figure {
 
 	private final Rectangle headerBoundsLayoutHint = new Rectangle();
 
-	public PinnablePaletteStackFigure() {
+	private final PaletteColorProvider colorProvider;
+
+	public PinnablePaletteStackFigure(PaletteColorProvider colorProvider) {
+		this.colorProvider = colorProvider;
+
 		arrowFigure = new RolloverArrow();
 		arrowFigure.addChangeListener(clickableArrowListener);
 
 		headerFigure = new Figure();
 		headerFigure.add(arrowFigure);
 
-		pinFigure = new PinFigure();
+		pinFigure = new PinFigure(colorProvider);
 		pinFigure.setBorder(new MarginBorder(0, 0, 0, 2));
 
 		expandablePane = new Figure();
@@ -362,10 +367,10 @@ public class PinnablePaletteStackFigure extends Figure {
 			points.addPoint(pinAreaBounds.getTopLeft().getTranslated(0, 0));
 			points.addPoint(headerBounds.getBottomLeft());
 
-			g.setForegroundColor(PaletteColorUtil.WIDGET_BACKGROUND_NORMAL_SHADOW_40);
+			g.setForegroundColor(colorProvider.getButtonDarker(0.4));
 			g.drawPolygon(points);
 
-			g.setForegroundColor(PaletteColorUtil.WIDGET_BACKGROUND_NORMAL_SHADOW_80);
+			g.setForegroundColor(colorProvider.getButtonDarker(0.8));
 			Point pt = headerBounds.getTopLeft().getTranslated(0, 1);
 			g.drawPoint(pt.x, pt.y);
 			pt = headerBounds.getTopLeft().getTranslated(1, 0);
@@ -381,14 +386,14 @@ public class PinnablePaletteStackFigure extends Figure {
 			g.fillRectangle(headerBounds);
 
 			// draw top and bottom border lines of header figure
-			g.setForegroundColor(PaletteColorUtil.WIDGET_BACKGROUND_NORMAL_SHADOW_65);
+			g.setForegroundColor(colorProvider.getButtonDarker(0.65));
 			g.drawLine(headerBounds.getTopLeft(), headerBounds.getTopRight());
 			g.setForegroundColor(PaletteColorUtil.WIDGET_LIST_BACKGROUND);
 			g.drawLine(headerBounds.getBottomLeft().getTranslated(0, -2),
 					headerBounds.getBottomRight().getTranslated(0, -2));
 
 			// draw bottom border line of expandable pane
-			g.setForegroundColor(PaletteColorUtil.WIDGET_BACKGROUND_NORMAL_SHADOW_65);
+			g.setForegroundColor(colorProvider.getButtonDarker(0.65));
 			g.drawLine(paneBounds.getBottomLeft().getTranslated(0, -1),
 					paneBounds.getBottomRight().getTranslated(0, -1));
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SeparatorEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SeparatorEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -62,13 +62,13 @@ public class SeparatorEditPart extends PaletteEditPart {
 	 *
 	 * @author Pratik Shah
 	 */
-	static class SeparatorFigure extends Figure {
+	class SeparatorFigure extends Figure {
 		/**
 		 * @see org.eclipse.draw2d.IFigure#getPreferredSize(int, int)
 		 */
 		@Override
 		public Dimension getPreferredSize(int wHint, int hHint) {
-			if (getBackgroundColor().equals(PaletteColorUtil.WIDGET_BACKGROUND)) {
+			if (getBackgroundColor().equals(getColorProvider().getButton())) {
 				return new Dimension(wHint, 4);
 			}
 			return new Dimension(wHint, 5);
@@ -84,10 +84,10 @@ public class SeparatorEditPart extends PaletteEditPart {
 		protected void paintFigure(Graphics g) {
 			Rectangle r = getBounds().getShrinked(CROP);
 			if (getBackgroundColor().equals(PaletteColorUtil.WIDGET_LIST_BACKGROUND)) {
-				g.setForegroundColor(PaletteColorUtil.WIDGET_NORMAL_SHADOW);
+				g.setForegroundColor(getColorProvider().getButtonDarker());
 				g.drawLine(r.getLeft(), r.getRight());
 			} else {
-				g.setForegroundColor(PaletteColorUtil.WIDGET_NORMAL_SHADOW);
+				g.setForegroundColor(getColorProvider().getButtonDarker());
 				g.drawLine(r.getBottomLeft(), r.getTopLeft());
 				g.drawLine(r.getTopLeft(), r.getTopRight());
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolbarEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolbarEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2010 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -52,14 +52,14 @@ public class ToolbarEditPart extends GroupEditPart {
 				graphics.drawLine(getBounds().getTopLeft(), getBounds().getTopRight());
 
 				// draw bottom border
-				graphics.setForegroundColor(PaletteColorUtil.WIDGET_BACKGROUND_NORMAL_SHADOW_70);
+				graphics.setForegroundColor(getColorProvider().getButtonDarker(0.7));
 				graphics.drawLine(getBounds().getBottomLeft().getTranslated(0, -1),
 						getBounds().getBottomRight().getTranslated(0, -1));
 			}
 
 		};
 		figure.setOpaque(true);
-		figure.setBackgroundColor(PaletteColorUtil.WIDGET_BACKGROUND);
+		figure.setBackgroundColor(getColorProvider().getButton());
 		figure.setBorder(new MarginBorder(2, 1, 1, 1));
 
 		return figure;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -70,6 +70,7 @@ import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.Button;
 import org.eclipse.draw2d.ButtonBorder;
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.ColorProvider;
 import org.eclipse.draw2d.Cursors;
 import org.eclipse.draw2d.FocusEvent;
 import org.eclipse.draw2d.FocusListener;
@@ -652,6 +653,10 @@ public class FlyoutPaletteComposite extends Composite {
 		}
 	}
 
+	private ColorProvider getColorProvider() {
+		return pViewer != null ? pViewer.getColorProvider() : PaletteColorProvider.INSTANCE;
+	}
+
 	/**
 	 * FlyoutPreferences is used to save/load the preferences for the flyout
 	 * palette.
@@ -786,19 +791,19 @@ public class FlyoutPaletteComposite extends Composite {
 		private void paintSash(GC gc) {
 			Rectangle bounds = getBounds();
 			if (isInState(STATE_PINNED_OPEN)) {
-				gc.setBackground(PaletteColorUtil.WIDGET_BACKGROUND);
+				gc.setBackground(getColorProvider().getButton());
 				gc.fillRectangle(0, 0, bounds.width, bounds.height);
 
 				gc.setForeground(PaletteColorUtil.WIDGET_LIST_BACKGROUND);
 				gc.drawLine(0, 0, bounds.width, 0);
-				gc.setForeground(PaletteColorUtil.WIDGET_NORMAL_SHADOW);
+				gc.setForeground(getColorProvider().getButtonDarker());
 				gc.drawLine(0, bounds.height - 1, bounds.width - 1, bounds.height - 1);
 				gc.setForeground(PaletteColorUtil.WIDGET_LIST_BACKGROUND);
 				gc.drawLine(0, 0, 0, bounds.height);
-				gc.setForeground(PaletteColorUtil.WIDGET_NORMAL_SHADOW);
+				gc.setForeground(getColorProvider().getButtonDarker());
 				gc.drawLine(bounds.width - 1, 0, bounds.width - 1, bounds.height - 1);
 			} else {
-				gc.setForeground(PaletteColorUtil.WIDGET_NORMAL_SHADOW);
+				gc.setForeground(getColorProvider().getButtonDarker());
 				gc.drawLine(0, 0, 0, bounds.height);
 				gc.drawLine(bounds.width - 1, 0, bounds.width - 1, bounds.height);
 
@@ -1091,7 +1096,7 @@ public class FlyoutPaletteComposite extends Composite {
 		}
 	}
 
-	private static class TitleLabel extends Label {
+	private class TitleLabel extends Label {
 		protected static final Border BORDER = new MarginBorder(4, 3, 4, 3);
 		protected static final Border TOOL_TIP_BORDER = new MarginBorder(0, 2, 0, 2);
 
@@ -1121,11 +1126,11 @@ public class FlyoutPaletteComposite extends Composite {
 			org.eclipse.draw2d.geometry.Rectangle r = org.eclipse.draw2d.geometry.Rectangle.SINGLETON;
 			r.setBounds(getBounds());
 			graphics.setForegroundColor(PaletteColorUtil.WIDGET_LIST_BACKGROUND);
-			graphics.setBackgroundColor(PaletteColorUtil.WIDGET_BACKGROUND);
+			graphics.setBackgroundColor(getColorProvider().getButton());
 			graphics.fillGradient(r, true);
 
 			// draw bottom border
-			graphics.setForegroundColor(PaletteColorUtil.WIDGET_NORMAL_SHADOW);
+			graphics.setForegroundColor(getColorProvider().getButtonDarker());
 			graphics.drawLine(r.getBottomLeft().getTranslated(0, -1), r.getBottomRight().getTranslated(0, -1));
 
 			graphics.popState();
@@ -1251,7 +1256,7 @@ public class FlyoutPaletteComposite extends Composite {
 				triangle = new Triangle();
 				triangle.setOutline(true);
 				triangle.setBackgroundColor(PaletteColorUtil.WIDGET_LIST_BACKGROUND);
-				triangle.setForegroundColor(PaletteColorUtil.WIDGET_DARK_SHADOW);
+				triangle.setForegroundColor(getColorProvider().getButtonDarkest());
 				setContents(triangle);
 			}
 
@@ -1279,12 +1284,12 @@ public class FlyoutPaletteComposite extends Composite {
 				org.eclipse.draw2d.geometry.Rectangle r = org.eclipse.draw2d.geometry.Rectangle.SINGLETON;
 				r.setBounds(getBounds());
 				graphics.setForegroundColor(PaletteColorUtil.WIDGET_LIST_BACKGROUND);
-				graphics.setBackgroundColor(PaletteColorUtil.WIDGET_BACKGROUND);
+				graphics.setBackgroundColor(getColorProvider().getButton());
 				graphics.fillGradient(r, true);
 				graphics.popState();
 
 				// draw bottom border
-				graphics.setForegroundColor(PaletteColorUtil.WIDGET_NORMAL_SHADOW);
+				graphics.setForegroundColor(getColorProvider().getButtonDarker());
 				graphics.drawLine(r.getBottomLeft().getTranslated(0, -1), r.getBottomRight().getTranslated(0, -1));
 			}
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteColorProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteColorProvider.java
@@ -13,12 +13,18 @@
 
 package org.eclipse.gef.ui.palette;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.FigureUtilities;
 
 import org.eclipse.gef.GEFColorProvider;
+import org.eclipse.gef.internal.ui.palette.PaletteColorUtil;
+import org.eclipse.gef.internal.ui.palette.editparts.PinFigure;
 
 /**
  * Default colors used by the {@link PaletteViewer} which are used when painting
@@ -26,11 +32,16 @@ import org.eclipse.gef.GEFColorProvider;
  * colors. The color provider can be set via
  * {@link PaletteViewer#setColorProvider(PaletteColorProvider)}.
  *
+ * <em>Important</em> This class is still work-in-progress and new methods might
+ * be added in the future.
+ *
  * @since 3.20
  */
 public class PaletteColorProvider extends GEFColorProvider {
 	private static final Color HOVER_COLOR_HICONTRAST = new Color(null, 0, 128, 0);
 	private static final Color SELECTED_COLOR_HICONTRAST = new Color(null, 128, 0, 128);
+	private final Map<Double, Color> mixedButtonDarker = new HashMap<>();
+	private Color hotspotColor;
 
 	public static final PaletteColorProvider INSTANCE = new PaletteColorProvider();
 
@@ -62,5 +73,50 @@ public class PaletteColorProvider extends GEFColorProvider {
 			return HOVER_COLOR_HICONTRAST;
 		}
 		return ColorConstants.listHoverBackgroundColor;
+	}
+
+	@Override
+	public Color getButton() {
+		return ColorConstants.button;
+	}
+
+	@Override
+	public Color getButtonDarker() {
+		return ColorConstants.buttonDarker;
+	}
+
+	@Override
+	public Color getButtonDarkest() {
+		return ColorConstants.buttonDarkest;
+	}
+
+	/**
+	 * Returns the mix of {@link #getButton()} with {@link #getButtonDarker()} with
+	 * weight {@code weight}. This weight must be within the interval [0, 1].
+	 *
+	 * The mixed color is only calculated once and then cached. It is therefore
+	 * recommended to only call this method with constants, to avoid rounding errors
+	 * due to floating point arithmetic.
+	 *
+	 * @throws IllegalArgumentException if {@code weight} is outside the valid
+	 *                                  range.
+	 */
+	public final Color getButtonDarker(double weight) {
+		if (weight < 0 || weight > 1) {
+			throw new IllegalArgumentException("The weight %d must be within [0, 1]".formatted(weight)); //$NON-NLS-1$
+		}
+		return mixedButtonDarker.computeIfAbsent(weight,
+				ignore -> FigureUtilities.mixColors(getButton(), getButtonDarker(), weight));
+	}
+
+	/**
+	 * Returns the foreground color of the {@link PinFigure} when the cursor is over
+	 * the button.
+	 */
+	public final Color getHotspotColor() {
+		if (hotspotColor == null) {
+			hotspotColor = FigureUtilities.mixColors(PaletteColorUtil.WIDGET_LIST_BACKGROUND, getButtonDarker(), 0.60);
+		}
+		return hotspotColor;
 	}
 }


### PR DESCRIPTION
This removes the following constants from PaletteColorUtil and reroutes their references to the PaletteColorProvider:

- WIDGET_BACKGROUND -> getButton()
- WIDGET_NORMAL_SHADOW -> getButtonDarker()
- WIDGET_DARK_SHADOW -> getButtonDarkest()

The "mixed" getButtonDarker() colors are created via the new method getButtonDarker(double), where the value describes the weight with which the color from getButton() color is mixed with getButtonDarker().

In addition, hover color for the PinFigure is calculated via the new method getHoverColor().

Both new methods are marked as final, as they are derived from other colors.