### PR TITLE
Allow Rulers with a Custom Dots Per Unit Setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - The look of the palette viewer can be customized via the ColorProvider interface. Supported model elements and properties are:
    - PaletteEntry (hover, selection) 
    - PaletteTemplateEntry (selection)
+ - Rulers can now be created with custom dots per unit settings. The `RulerProvider` interface has now a new unit constant `UNIT_CUSTOM`. When this is used the `RulerProvider` can provide via the new `getCustomRulerDPU()` an application specific dots per unit setting.
 
 ## Zest
  - Integration of Zest 2.0 development branch. See the [wiki](https://github.com/eclipse-gef/gef-classic/wiki/Zest#zest-2x) for more details. In case only default layout algorithms are used, the initial migration should be seamless. Otherwise the algorithms can be adapted to run in legacy mode by extending `AbstractLayoutAlgorithm.Zest1` or have to be re-implemented using the new API by extending `AbstractLayoutAlgorithm`. Note that this legacy mode will be removed in a future release. The following list contains the most significant, deprecated features:

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/RulerLayoutTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/RulerLayoutTests.java
@@ -52,7 +52,12 @@ public class RulerLayoutTests {
 		constraint = 42;
 		figure = new Figure();
 		dummy = new Figure();
-		container = new RulerFigure(true, RulerProvider.UNIT_CENTIMETERS);
+		container = new RulerFigure(true, new RulerProvider() {
+			@Override
+			public int getUnit() {
+				return RulerProvider.UNIT_CENTIMETERS;
+			}
+		});
 		container.add(figure, (Object) constraint);
 		container.add(dummy);
 		rulerLayout = (RulerLayout) container.getLayoutManager();

--- a/org.eclipse.gef/.settings/.api_filters
+++ b/org.eclipse.gef/.settings/.api_filters
@@ -16,6 +16,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/gef/rulers/RulerProvider.java" type="org.eclipse.gef.rulers.RulerProvider">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.gef.rulers.RulerProvider"/>
+                <message_argument value="UNIT_CUSTOM"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/gef/ui/actions/AlignmentRetargetAction.java" type="org.eclipse.gef.ui.actions.AlignmentRetargetAction">
         <filter id="571473929">
             <message_arguments>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -96,7 +96,7 @@ public class RulerEditPart extends AbstractGraphicalEditPart {
 	 */
 	@Override
 	protected IFigure createFigure() {
-		RulerFigure ruler = new RulerFigure(isHorizontal(), getRulerProvider().getUnit());
+		RulerFigure ruler = new RulerFigure(isHorizontal(), getRulerProvider());
 		if (ruler.getUnit() == RulerProvider.UNIT_PIXELS) {
 			ruler.setInterval(100, 2);
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
@@ -343,7 +343,7 @@ public class RulerFigure extends Figure {
 		return divsPerMajorMark;
 	}
 
-	private static int getMediumMakrerDivNum(int divsPerMajorMark) {
+	private static int getMediumMarkerDivNum(int divsPerMajorMark) {
 		return switch (divsPerMajorMark) {
 		case 20, 10, 5 -> 5;
 		case 16, 8 -> 4;

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -55,14 +55,18 @@ public class RulerFigure extends Figure {
 	private static final int BORDER_WIDTH = 3;
 
 	private boolean horizontal;
-	private int unit, interval, divisions;
+	private int unit;
+	private int interval;
+	private int divisions;
 	private double dpu = -1.0;
 
-	private ZoomListener zoomListener = newZoomValue -> handleZoomChanged();
+	private final ZoomListener zoomListener = newZoomValue -> handleZoomChanged();
+	private final RulerProvider rulerProvider;
 
-	public RulerFigure(boolean isHorizontal, int measurementUnit) {
+	public RulerFigure(boolean isHorizontal, RulerProvider rulerProvider) {
+		this.rulerProvider = rulerProvider;
 		setHorizontal(isHorizontal);
-		setUnit(measurementUnit);
+		setUnit(rulerProvider.getUnit());
 		setBackgroundColor(ColorConstants.listBackground);
 		setForegroundColor(ColorConstants.listForeground);
 		setOpaque(true);
@@ -71,14 +75,17 @@ public class RulerFigure extends Figure {
 
 	protected double getDPU() {
 		if (dpu <= 0) {
-			if (getUnit() == RulerProvider.UNIT_PIXELS) {
-				dpu = 1.0;
-			} else {
+			switch (getUnit()) {
+			case RulerProvider.UNIT_PIXELS -> dpu = 1.0;
+			case RulerProvider.UNIT_CUSTOM -> dpu = rulerProvider.getCustomRulerDPU();
+			default -> {
 				dpu = transposer.t(new Dimension(Display.getCurrent().getDPI())).height;
 				if (getUnit() == RulerProvider.UNIT_CENTIMETERS) {
 					dpu = dpu / 2.54;
 				}
 			}
+			}
+
 			if (zoomManager != null) {
 				dpu = dpu * zoomManager.getZoom();
 			}
@@ -137,11 +144,6 @@ public class RulerFigure extends Figure {
 	 */
 	@Override
 	protected void paintFigure(Graphics graphics) {
-		/*
-		 * @TODO:Pratik maybe you can break this method into a few methods. that might
-		 * make it a little easier to read and understand. plus, sub-classes could
-		 * customize certain parts.
-		 */
 		double dotsPerUnit = getDPU();
 		Rectangle clip = transposer.t(graphics.getClip(Rectangle.SINGLETON));
 		Rectangle figClientArea = transposer.t(getClientArea());
@@ -169,27 +171,7 @@ public class RulerFigure extends Figure {
 		 * horizontal and vertical rulers that are of the same height, the number of
 		 * units per major mark is the same.
 		 */
-		int unitsPerMajorMark = (int) (minPixelsBetweenMajorMarks / dotsPerUnit);
-		if (minPixelsBetweenMajorMarks % dotsPerUnit != 0.0) {
-			unitsPerMajorMark++;
-		}
-		if (interval > 0) {
-			/*
-			 * If the client specified how many units are to be displayed per major mark,
-			 * use that. If, however, showing that many units wouldn't leave enough room for
-			 * the text, than take its smallest multiple that would leave enough room.
-			 */
-			int intervalMultiple = interval;
-			while (intervalMultiple < unitsPerMajorMark) {
-				intervalMultiple += interval;
-			}
-			unitsPerMajorMark = intervalMultiple;
-		} else if (unitsPerMajorMark != 1 && unitsPerMajorMark % 2 != 0) {
-			// if the number of units per major mark is calculated dynamically,
-			// ensure that
-			// it is an even number.
-			unitsPerMajorMark++;
-		}
+		int unitsPerMajorMark = getUnitsPerMajorMark(dotsPerUnit);
 
 		/*
 		 * divsPerMajorMark indicates the number of divisions that a major mark should
@@ -197,45 +179,7 @@ public class RulerFigure extends Figure {
 		 * shown as having two parts. that means that there would be a marker showing
 		 * the beginning and end of the major marker and another right in the middle.
 		 */
-		int divsPerMajorMark;
-		if (divisions > 0 && dotsPerUnit * unitsPerMajorMark / divisions >= minPixelsBetweenMarks) {
-			/*
-			 * If the client has specified the number of divisions per major mark, use that
-			 * unless it would cause the minimum space between marks to be less than
-			 * minPixelsBetweenMarks
-			 */
-			divsPerMajorMark = divisions;
-		} else {
-			/*
-			 * If the client hasn't specified the number of divisions per major mark or the
-			 * one that the client has specified is invalid, then calculate it dynamically.
-			 * This algorithm will try to display 10 divisions per CM, and 16 per INCH.
-			 * However, if that puts the marks too close together (i.e., the space between
-			 * them is less than minPixelsBetweenMarks), then it keeps decreasing the number
-			 * of divisions by a factor of 2 until there is enough space between them.
-			 */
-			divsPerMajorMark = 2;
-			if (getUnit() == RulerProvider.UNIT_CENTIMETERS) {
-				divsPerMajorMark = 10;
-			} else if (getUnit() == RulerProvider.UNIT_INCHES) {
-				divsPerMajorMark = 8;
-			}
-			while (dotsPerUnit * unitsPerMajorMark / divsPerMajorMark < minPixelsBetweenMarks) {
-				divsPerMajorMark /= 2;
-				if (divsPerMajorMark == 0) {
-					break;
-				}
-			}
-			// This should never happen unless the client has specified a
-			// minPixelsBetweenMarks that is larger than
-			// minPixelsBetweenMajorMarks (which
-			// is calculated using the text's size -- size of the largest number
-			// to be
-			// displayed).
-			if (divsPerMajorMark == 0) {
-				divsPerMajorMark = 1;
-			}
-		}
+		int divsPerMajorMark = getDivsPerMajorMark(dotsPerUnit, unitsPerMajorMark);
 
 		/*
 		 * mediumMarkerDivNum is used to determine which mark (line drawn to indicate a
@@ -243,23 +187,7 @@ public class RulerFigure extends Figure {
 		 * then every mark will be of medium size. If its value is 5, then every 5th
 		 * mark will be of medium size (the rest being of small size).
 		 */
-		int mediumMarkerDivNum = 1;
-		switch (divsPerMajorMark) {
-		case 20:
-		case 10:
-		case 5:
-			mediumMarkerDivNum = 5;
-			break;
-		case 16:
-		case 8:
-			mediumMarkerDivNum = 4;
-			break;
-		case 4:
-			mediumMarkerDivNum = 2;
-			break;
-		case 2:
-			mediumMarkerDivNum = 1;
-		}
+		int mediumMarkerDivNum = getMediumMakrerDivNum(divsPerMajorMark);
 
 		/*
 		 * dotsPerDivision = number of pixels between each mark = number of pixels in a
@@ -273,15 +201,13 @@ public class RulerFigure extends Figure {
 		 */
 		int startMark = (int) (clippedBounds.y / (dotsPerUnit * unitsPerMajorMark)) * divsPerMajorMark;
 		if (clippedBounds.y < 0) {
-			// -2 / 10 = 0, not -1. so, if the top of the clip is negative, we
-			// need to move
+			// -2 / 10 = 0, not -1. so, if the top of the clip is negative, we need to move
 			// the startMark back by a whole major mark.
 			startMark -= divsPerMajorMark;
 		}
-		// endMark is the first non-visible mark (doesn't have to be a major
-		// mark) that is
-		// beyond the end of the clip region
-		int endMark = (int) (((clippedBounds.y + clippedBounds.height) / dotsPerDivision)) + 1;
+		// endMark is the first non-visible mark (doesn't have to be a major mark) that
+		// is beyond the end of the clip region
+		int endMark = (int) ((clippedBounds.y + clippedBounds.height) / dotsPerDivision) + 1;
 		int leading = FigureUtilities.getFontMetrics(getFont()).getLeading();
 		Rectangle forbiddenZone = new Rectangle();
 		for (int div = startMark; div <= endMark; div++) {
@@ -290,54 +216,16 @@ public class RulerFigure extends Figure {
 			if (div % divsPerMajorMark == 0) {
 				String num = "" + (div / divsPerMajorMark) * unitsPerMajorMark; //$NON-NLS-1$
 				if (isHorizontal()) {
-					Dimension numSize = FigureUtilities.getStringExtents(num, getFont());
-					/*
-					 * If the width is even, we want to increase it by 1. This will ensure that when
-					 * marks are erased because they are too close to the number, they are erased
-					 * from both sides of that number.
-					 */
-					if (numSize.width % 2 == 0) {
-						numSize.width++;
-					}
-					Point textLocation = new Point(y - (numSize.width / 2), clippedBounds.x + textMargin - leading);
-					forbiddenZone.setLocation(textLocation);
-					forbiddenZone.setSize(numSize);
-					forbiddenZone.expand(1, 1);
-					graphics.fillRectangle(forbiddenZone);
-					// Uncomment the following line of code if you want to see a
-					// line at
-					// the exact position of the major mark
-					// graphics.drawLine(y, clippedBounds.x, y, clippedBounds.x
-					// + clippedBounds.width);
-					graphics.drawText(num, textLocation);
+					drawHorizontalMajorMark(graphics, clippedBounds, leading, forbiddenZone, y, num);
 				} else {
-					Image numImage = ImageUtilities.createRotatedImageOfString(num, getFont(), getForegroundColor(),
-							getBackgroundColor());
-					Point textLocation = new Point(clippedBounds.x + textMargin, y - (numImage.getBounds().height / 2));
-					forbiddenZone.setLocation(textLocation);
-					forbiddenZone.setSize(numImage.getBounds().width, numImage.getBounds().height);
-					forbiddenZone.expand(1, 1 + (numImage.getBounds().height % 2 == 0 ? 1 : 0));
-					graphics.fillRectangle(forbiddenZone);
-					graphics.drawImage(numImage, textLocation);
-					numImage.dispose();
+					drawVerticalMajorMark(graphics, clippedBounds, forbiddenZone, y, num);
 				}
 			} else if ((div % divsPerMajorMark) % mediumMarkerDivNum == 0) {
-				// this is a medium mark, so its length should be longer than
-				// the small marks
-				Point start = transposer.t(new Point((clippedBounds.getRight().x - mediumMarkWidth) / 2, y));
-				Point end = transposer
-						.t(new Point(((clippedBounds.getRight().x - mediumMarkWidth) / 2) + mediumMarkWidth, y));
-				if (!forbiddenZone.contains(start)) {
-					graphics.drawLine(start, end);
-				}
+				// this is a medium mark, so its length should be longer than the small marks
+				drawMediumMark(graphics, clippedBounds, forbiddenZone, y);
 			} else {
 				// small mark
-				Point start = transposer.t(new Point((clippedBounds.getRight().x - smallMarkWidth) / 2, y));
-				Point end = transposer
-						.t(new Point(((clippedBounds.getRight().x - smallMarkWidth) / 2) + smallMarkWidth, y));
-				if (!forbiddenZone.contains(start)) {
-					graphics.drawLine(start, end);
-				}
+				drawSmallMark(graphics, clippedBounds, forbiddenZone, y);
 			}
 		}
 		// paint the border
@@ -345,6 +233,124 @@ public class RulerFigure extends Figure {
 		graphics.setForegroundColor(ColorConstants.buttonDarker);
 		graphics.drawLine(transposer.t(clippedBounds.getTopRight().translate(-1, -1)),
 				transposer.t(clippedBounds.getBottomRight().translate(-1, -1)));
+	}
+
+	private void drawHorizontalMajorMark(Graphics graphics, Rectangle clippedBounds, int leading,
+			Rectangle forbiddenZone, int y, String num) {
+		Dimension numSize = FigureUtilities.getStringExtents(num, getFont());
+		// If the width is even, we want to increase it by 1. This will ensure that when
+		// marks are erased because they are too close to the number, they are erased
+		// from both sides of that number.
+		if (numSize.width % 2 == 0) {
+			numSize.width++;
+		}
+		Point textLocation = new Point(y - (numSize.width / 2), clippedBounds.x + textMargin - leading);
+		forbiddenZone.setLocation(textLocation);
+		forbiddenZone.setSize(numSize);
+		forbiddenZone.expand(1, 1);
+		graphics.fillRectangle(forbiddenZone);
+		// Uncomment the following line of code if you want to see a line at the exact
+		// position of the major mark
+		// graphics.drawLine(y, clippedBounds.x, y, clippedBounds.x +
+		// clippedBounds.width);
+		graphics.drawText(num, textLocation);
+	}
+
+	private void drawVerticalMajorMark(Graphics graphics, Rectangle clippedBounds, Rectangle forbiddenZone, int y,
+			String num) {
+		Image numImage = ImageUtilities.createRotatedImageOfString(num, getFont(), getForegroundColor(),
+				getBackgroundColor());
+		Point textLocation = new Point(clippedBounds.x + textMargin, y - (numImage.getBounds().height / 2));
+		forbiddenZone.setLocation(textLocation);
+		forbiddenZone.setSize(numImage.getBounds().width, numImage.getBounds().height);
+		forbiddenZone.expand(1, 1 + (numImage.getBounds().height % 2 == 0 ? 1 : 0));
+		graphics.fillRectangle(forbiddenZone);
+		graphics.drawImage(numImage, textLocation);
+		numImage.dispose();
+	}
+
+	private void drawMediumMark(Graphics graphics, Rectangle clippedBounds, Rectangle forbiddenZone, int y) {
+		Point start = transposer.t(new Point((clippedBounds.getRight().x - mediumMarkWidth) / 2, y));
+		Point end = transposer.t(new Point(((clippedBounds.getRight().x - mediumMarkWidth) / 2) + mediumMarkWidth, y));
+		if (!forbiddenZone.contains(start)) {
+			graphics.drawLine(start, end);
+		}
+	}
+
+	private void drawSmallMark(Graphics graphics, Rectangle clippedBounds, Rectangle forbiddenZone, int y) {
+		Point start = transposer.t(new Point((clippedBounds.getRight().x - smallMarkWidth) / 2, y));
+		Point end = transposer.t(new Point(((clippedBounds.getRight().x - smallMarkWidth) / 2) + smallMarkWidth, y));
+		if (!forbiddenZone.contains(start)) {
+			graphics.drawLine(start, end);
+		}
+	}
+
+	private int getUnitsPerMajorMark(double dotsPerUnit) {
+		int unitsPerMajorMark = (int) (minPixelsBetweenMajorMarks / dotsPerUnit);
+		if (minPixelsBetweenMajorMarks % dotsPerUnit != 0.0) {
+			unitsPerMajorMark++;
+		}
+		if (interval > 0) {
+			// If the client specified how many units are to be displayed per major mark,
+			// use that. If, however, showing that many units wouldn't leave enough room for
+			// the text, than take its smallest multiple that would leave enough room.
+			int intervalMultiple = interval;
+			while (intervalMultiple < unitsPerMajorMark) {
+				intervalMultiple += interval;
+			}
+			unitsPerMajorMark = intervalMultiple;
+		} else if (unitsPerMajorMark != 1 && unitsPerMajorMark % 2 != 0) {
+			// if the number of units per major mark is calculated dynamically, ensure that
+			// it is an even number.
+			unitsPerMajorMark++;
+		}
+		return unitsPerMajorMark;
+	}
+
+	private int getDivsPerMajorMark(double dotsPerUnit, int unitsPerMajorMark) {
+		int divsPerMajorMark;
+		if (divisions > 0 && dotsPerUnit * unitsPerMajorMark / divisions >= minPixelsBetweenMarks) {
+			// If the client has specified the number of divisions per major mark, use that
+			// unless it would cause the minimum space between marks to be less than
+			// minPixelsBetweenMarks
+			return divisions;
+		}
+		// If the client hasn't specified the number of divisions per major mark or the
+		// one that the client has specified is invalid, then calculate it dynamically.
+		// This algorithm will try to display 10 divisions per CM, and 16 per INCH.
+		// However, if that puts the marks too close together (i.e., the space between
+		// them is less than minPixelsBetweenMarks), then it keeps decreasing the number
+		// of divisions by a factor of 2 until there is enough space between them.
+		divsPerMajorMark = 2;
+		if (getUnit() == RulerProvider.UNIT_CENTIMETERS) {
+			divsPerMajorMark = 10;
+		} else if (getUnit() == RulerProvider.UNIT_INCHES) {
+			divsPerMajorMark = 8;
+		}
+		while (dotsPerUnit * unitsPerMajorMark / divsPerMajorMark < minPixelsBetweenMarks) {
+			divsPerMajorMark /= 2;
+			if (divsPerMajorMark == 0) {
+				break;
+			}
+		}
+		// This should never happen unless the client has specified a
+		// minPixelsBetweenMarks that is larger than minPixelsBetweenMajorMarks (which
+		// is calculated using the text's size -- size of the largest number to be
+		// displayed).
+		if (divsPerMajorMark == 0) {
+			divsPerMajorMark = 1;
+		}
+		return divsPerMajorMark;
+	}
+
+	private static int getMediumMakrerDivNum(int divsPerMajorMark) {
+		return switch (divsPerMajorMark) {
+		case 20, 10, 5 -> 5;
+		case 16, 8 -> 4;
+		case 4 -> 2;
+		case 2 -> 1;
+		default -> 1;
+		};
 	}
 
 	public void setDrawFocus(boolean drawFocus) {

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
@@ -187,7 +187,7 @@ public class RulerFigure extends Figure {
 		 * then every mark will be of medium size. If its value is 5, then every 5th
 		 * mark will be of medium size (the rest being of small size).
 		 */
-		int mediumMarkerDivNum = getMediumMakrerDivNum(divsPerMajorMark);
+		int mediumMarkerDivNum = getMediumMarkerDivNum(divsPerMajorMark);
 
 		/*
 		 * dotsPerDivision = number of pixels between each mark = number of pixels in a

--- a/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerProvider.java
@@ -79,6 +79,15 @@ public abstract class RulerProvider {
 	 * Constant indicating that the ruler should display pixel count.
 	 */
 	public static final int UNIT_PIXELS = 2;
+	/**
+	 * Constant indicating that the ruler should display a custom unit per pixel
+	 * count.
+	 *
+	 * The unit per pixel count shall be provided via {@link #getCustomRulerDPU()}.
+	 *
+	 * @since 3.20
+	 */
+	public static final int UNIT_CUSTOM = 3;
 
 	/**
 	 * A list of <code>RulerChangeListener</code>s that have to be notified of
@@ -181,6 +190,21 @@ public abstract class RulerProvider {
 	@SuppressWarnings("static-method")
 	public Command getCreateGuideCommand(int position) {
 		return UnexecutableCommand.INSTANCE;
+	}
+
+	/**
+	 * When the unit to be used for the ruler is {@link #UNIT_CUSTOM} clients need
+	 * to override this method to return the pixel dots per unit to be used for this
+	 * ruler. Clients should override this method to return
+	 *
+	 * @return the dots per unit for the ruler, default is 1 which is equal to use
+	 *         {@link #UNIT_PIXELS}.
+	 *
+	 * @since 3.20
+	 */
+	@SuppressWarnings("static-method")
+	public int getCustomRulerDPU() {
+		return 1;
 	}
 
 	/**


### PR DESCRIPTION
With this change the API of the RulerProvider class is extended with a custom dots per unit setting. This allows clients to use our default Ruler Figure adjusted to application specific resolutions and drawing scales.

As part of this change the RulerFigure was cleaned by splitting the paintFigure method in several methods for increased readability and maintainability.

Bugzilla entry: https://bugs.eclipse.org/bugs/show_bug.cgi?id=105493