### PR TITLE
Exclude "source" features from "tycho-source-plugin" execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,9 @@
 						<plugin id="org.eclipse.gef.doc.isv" />
 						<plugin id="org.eclipse.zest.doc.isv" />
 						<!-- also possible to exclude feature-->
+						<feature id="org.eclipse.draw2d.source" />
+						<feature id="org.eclipse.gef.source" />
+						<feature id="org.eclipse.zest.source" />
 					  </excludes>
 					</configuration>
 				  </execution>


### PR DESCRIPTION
Those features are automatically generated by Tycho and contain the source bundles of the binary feature they mirror.

It therefore doesn't make any sense to generate source features of the source features which currently leads to the warnings:

> [WARNING] The following referenced features have missing sources
> org.eclipse.draw2d.source_3.22.0.202411052148
> org.eclipse.gef.source_3.22.0.202411052148
> org.eclipse.zest.source_3.22.0.202411052148