### PR TITLE
Update to latest SonarQube scanner and exclude generated poms

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,6 +141,7 @@ def void mvn() {
            -Dcommit.id=$GIT_COMMIT \
            -Dbuild.type=$BUILD_TYPE \
            -Dorg.eclipse.justj.p2.manager.build.url=$JOB_URL \
+           -Dsonar.exclusions=**/.tycho-consumer-pom.xml \
            -Dsonar.projectKey=gef-classic \
            -Dsonar.organization=eclipse \
            clean \

--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,11 @@
 						</execution>
 					</executions>
 				</plugin>
+				<plugin>
+					<groupId>org.sonarsource.scanner.maven</groupId>
+					<artifactId>sonar-maven-plugin</artifactId>
+					<version>5.0.0.4389</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
The SonarQube version that is used by Maven has been relocated, leading to a warning at the start of the build. Furthermore, the "consumer poms" that are automatically created by Tycho are flagged as "missing blame information", as they haven't been comitted and should thus not be scanned.