### PR TITLE
Restore the return type of SelectionAction.getSelectedObjects()

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SelectionAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SelectionAction.java
@@ -72,7 +72,8 @@ public abstract class SelectionAction extends WorkbenchPartAction {
 	 *
 	 * @return A List containing the currently selected objects.
 	 */
-	protected List<?> getSelectedObjects() {
+	@SuppressWarnings("unchecked")
+	protected List<Object> getSelectedObjects() {
 		if (!(getSelection() instanceof IStructuredSelection)) {
 			return Collections.emptyList();
 		}


### PR DESCRIPTION
- The return type cannot be changed from List<Object>  to List<?> without breaking client calling or override this protected method.

https://github.com/eclipse-gef/gef-classic/pull/617