### PR TITLE
Publish build results from Jenkins to GitHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,6 +98,7 @@ BRANCH_NAME=${env.BRANCH_NAME}
   post {
     always {
       junit allowEmptyResults: true, testResults: '**/target/surefire-reports/*.xml'
+      discoverGitReferenceBuild referenceJob: 'build-classic/master'
       recordIssues publishAllIssues: true, tools: [java(), mavenConsole(), javaDoc()]
     }
 


### PR DESCRIPTION
Main goal is to analyze what steps need to be taken to have the Jenkins build results like compiler warnings and Maven problems be published to the GitHub checks.