### PR TITLE
Change "tycho.version" to "tycho-version" in promotion pom.xml as well

### DIFF
--- a/promotion/pom.xml
+++ b/promotion/pom.xml
@@ -35,7 +35,7 @@
           <plugin>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>tycho-eclipse-plugin</artifactId>
-            <version>${tycho.version}</version>
+            <version>${tycho-version}</version>
             <configuration>
             </configuration>
             <executions>


### PR DESCRIPTION
This property is used in the "promot" profile, which is only used for the master build and thus it didn't cause any issues on the branch builds.
Amends 19e9ec3ecd20b8ca5a802561f840618e974f34f4