### PR TITLE
Prepared Eclipse GEF Classic for 3.23 Devlopements #627

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# GEF Classic 3.23.0
+
+## Draw2D
+
+## GEF
+
+## Zest
+
 # GEF Classic 3.22.0
 
 ## Draw2D

--- a/org.eclipse.draw2d-feature/feature.xml
+++ b/org.eclipse.draw2d-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.draw2d"
       label="%featureName"
-      version="3.22.0.qualifier"
+      version="3.23.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.draw2d.doc.isv/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.doc.isv/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.doc.isv; singleton:=true
-Bundle-Version: 3.13.300.qualifier
+Bundle-Version: 3.13.400.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Eclipse-LazyStart: true
+Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.swt;bundle-version="[3.2.0,4.0.0)";resolution:=optional,
  org.eclipse.platform.doc.isv;bundle-version="[3.2.0,5.0.0)";resolution:=optional

--- a/org.eclipse.draw2d.doc.isv/pom.xml
+++ b/org.eclipse.draw2d.doc.isv/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.eclipse.gef_root</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.20.0-SNAPSHOT</version>
+		<version>3.23.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.draw2d.plugins</groupId>
 	<artifactId>org.eclipse.draw2d.doc.isv</artifactId>
-	<version>3.13.300-SNAPSHOT</version>
+	<version>3.13.400-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<name>[bundle] GEF Classic Draw2d Developer Documentation</name>
 	<build>
@@ -51,7 +51,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.6</version>
+				<version>${maven-antrun-plugin.version}</version>
 				<executions>
 					<execution>
 						<?m2e ignore?>

--- a/org.eclipse.draw2d.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.examples
-Bundle-Version: 3.16.100.qualifier
+Bundle-Version: 3.16.200.qualifier
 Export-Package: gef.bugs;x-friends:="org.eclipse.draw2d.tests"
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.draw2d;bundle-version="[3.16.0,4.0.0)"

--- a/org.eclipse.draw2d.sdk-feature/feature.xml
+++ b/org.eclipse.draw2d.sdk-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.draw2d.sdk"
       label="%featureName"
-      version="3.22.0.qualifier"
+      version="3.23.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.draw2d"
       license-feature="org.eclipse.license"

--- a/org.eclipse.draw2d.tests/pom.xml
+++ b/org.eclipse.draw2d.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.gef_root</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.20.0-SNAPSHOT</version>
+		<version>3.23.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.draw2d.plugins</groupId>
 	<artifactId>org.eclipse.draw2d.tests</artifactId>

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d;singleton:=true
-Bundle-Version: 3.18.0.qualifier
+Bundle-Version: 3.18.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.draw2d,

--- a/org.eclipse.gef-feature/feature.xml
+++ b/org.eclipse.gef-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.gef"
       label="%featureName"
-      version="3.22.0.qualifier"
+      version="3.23.0.qualifier"
       provider-name="%providerName"
       image="eclipse_update_120.jpg"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.baseline/gef-classic-3.22.0.target
+++ b/org.eclipse.gef.baseline/gef-classic-3.22.0.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="GEF Classic 3.22.0 Base Line Target" sequenceNumber="1">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
+			<repository location="http://download.eclipse.org/cbi/updates/license"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2024-12"/>
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="0.0.0"/>
+		</location>
+	</locations>
+</target>

--- a/org.eclipse.gef.doc.isv/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.doc.isv; singleton:=true
-Bundle-Version: 3.13.700.qualifier
+Bundle-Version: 3.13.800.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)";resolution:=optional,

--- a/org.eclipse.gef.doc.isv/pom.xml
+++ b/org.eclipse.gef.doc.isv/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.eclipse.gef_root</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.20.0-SNAPSHOT</version>
+		<version>3.23.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.doc.isv</artifactId>
-	<version>3.13.700-SNAPSHOT</version>
+	<version>3.13.800-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<name>[bundle] GEF Classic GEF Developer Documentation</name>
 	<build>
@@ -51,7 +51,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.6</version>
+				<version>${maven-antrun-plugin.version}</version>
 				<executions>
 					<execution>
 						<?m2e ignore?>

--- a/org.eclipse.gef.examples-feature/feature.xml
+++ b/org.eclipse.gef.examples-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.gef.examples"
       label="%featureName"
-      version="3.22.0.qualifier"
+      version="3.23.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gef.examples.logic"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.examples.flow/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.flow/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.gef.examples.flow; singleton:=true
-Bundle-Version: 3.16.200.qualifier
+Bundle-Version: 3.16.300.qualifier
 Bundle-Activator: org.eclipse.gef.examples.flow.FlowPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples.logic/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.logic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.logic; singleton:=true
-Bundle-Version: 3.14.600.qualifier
+Bundle-Version: 3.14.700.qualifier
 Bundle-Activator: org.eclipse.gef.examples.logicdesigner.LogicPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples.shapes/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.shapes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.shapes; singleton:=true
-Bundle-Version: 3.15.200.qualifier
+Bundle-Version: 3.15.300.qualifier
 Bundle-Activator: org.eclipse.gef.examples.shapes.ShapesPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples.text/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.text; singleton:=true
-Bundle-Version: 3.15.300.qualifier
+Bundle-Version: 3.15.400.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.gef.examples.text,

--- a/org.eclipse.gef.sdk-feature/feature.xml
+++ b/org.eclipse.gef.sdk-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.gef.sdk"
       label="%featureName"
-      version="3.22.0.qualifier"
+      version="3.23.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gef"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.tests/pom.xml
+++ b/org.eclipse.gef.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.gef_root</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.20.0-SNAPSHOT</version>
+		<version>3.23.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.tests</artifactId>

--- a/org.eclipse.gef/.settings/.api_filters
+++ b/org.eclipse.gef/.settings/.api_filters
@@ -1,29 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.gef" version="2">
-    <resource path="src/org/eclipse/gef/handles/NonResizableHandleKit.java" type="org.eclipse.gef.handles.NonResizableHandleKit">
-        <filter id="354463860">
-            <message_arguments>
-                <message_argument value="org.eclipse.gef.handles.NonResizableHandleKit"/>
-                <message_argument value="NonResizableHandleKit()"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="src/org/eclipse/gef/handles/ResizableHandleKit.java" type="org.eclipse.gef.handles.ResizableHandleKit">
-        <filter id="354463860">
-            <message_arguments>
-                <message_argument value="org.eclipse.gef.handles.ResizableHandleKit"/>
-                <message_argument value="ResizableHandleKit()"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="src/org/eclipse/gef/rulers/RulerProvider.java" type="org.eclipse.gef.rulers.RulerProvider">
-        <filter id="336658481">
-            <message_arguments>
-                <message_argument value="org.eclipse.gef.rulers.RulerProvider"/>
-                <message_argument value="UNIT_CUSTOM"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/gef/ui/actions/AlignmentRetargetAction.java" type="org.eclipse.gef.ui.actions.AlignmentRetargetAction">
         <filter id="571473929">
             <message_arguments>
@@ -93,20 +69,6 @@
             <message_arguments>
                 <message_argument value="LabelRetargetAction"/>
                 <message_argument value="RedoRetargetAction"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="src/org/eclipse/gef/ui/actions/SelectionAction.java" type="org.eclipse.gef.ui.actions.SelectionAction">
-        <filter id="354463860">
-            <message_arguments>
-                <message_argument value="org.eclipse.gef.ui.actions.SelectionAction"/>
-                <message_argument value="SelectionAction(IWorkbenchPart)"/>
-            </message_arguments>
-        </filter>
-        <filter id="354463860">
-            <message_arguments>
-                <message_argument value="org.eclipse.gef.ui.actions.SelectionAction"/>
-                <message_argument value="SelectionAction(IWorkbenchPart, int)"/>
             </message_arguments>
         </filter>
     </resource>

--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef; singleton:=true
-Bundle-Version: 3.20.0.qualifier
+Bundle-Version: 3.20.100.qualifier
 Bundle-Activator: org.eclipse.gef.internal.InternalGEFPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.zest-feature/feature.xml
+++ b/org.eclipse.zest-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.zest"
       label="%featureName"
-      version="3.22.0.qualifier"
+      version="3.23.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.zest.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.core;singleton:=true
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.14.0.qualifier
+Bundle-Version: 1.14.100.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.draw2d;visibility:=reexport

--- a/org.eclipse.zest.doc.isv/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.doc.isv/META-INF/MANIFEST.MF
@@ -2,10 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.doc.isv; singleton:=true
-Bundle-Version: 1.8.900.qualifier
+Bundle-Version: 1.8.1000.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Eclipse-LazyStart: true
+Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.swt;bundle-version="[3.2.0,4.0.0)";resolution:=optional,
  org.eclipse.jface;bundle-version="[3.2.0,4.0.0)";resolution:=optional,
  org.eclipse.draw2d;bundle-version="[3.16.0,4.0.0)";resolution:=optional,

--- a/org.eclipse.zest.doc.isv/pom.xml
+++ b/org.eclipse.zest.doc.isv/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.eclipse.gef_root</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.20.0-SNAPSHOT</version>
+		<version>3.23.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.zest.plugins</groupId>
 	<artifactId>org.eclipse.zest.doc.isv</artifactId>
-	<version>1.8.900-SNAPSHOT</version>
+	<version>1.8.1000-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<name>[bundle] GEF Classic Zest Developer Documentation</name>
 	<build>
@@ -51,7 +51,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.6</version>
+				<version>${maven-antrun-plugin.version}</version>
 				<executions>
 					<execution>
 						<?m2e ignore?>

--- a/org.eclipse.zest.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.examples
-Bundle-Version: 3.18.100.qualifier
+Bundle-Version: 3.18.200.qualifier
 Export-Package: org.eclipse.zest.examples.jface;x-friends:="org.eclipse.zest.tests",
  org.eclipse.zest.examples.swt;x-friends:="org.eclipse.zest.tests",
  org.eclipse.zest.examples.uml;x-friends:="org.eclipse.zest.tests"

--- a/org.eclipse.zest.layouts/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.layouts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.layouts;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.zest.layouts,

--- a/org.eclipse.zest.sdk-feature/feature.xml
+++ b/org.eclipse.zest.sdk-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.zest.sdk"
       label="%featureName"
-      version="3.22.0.qualifier"
+      version="3.23.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.zest.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.zest.tests/pom.xml
+++ b/org.eclipse.zest.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.gef_root</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.20.0-SNAPSHOT</version>
+		<version>3.23.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.zest.plugins</groupId>
 	<artifactId>org.eclipse.zest.tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,20 +5,20 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gef_root</groupId>
 	<artifactId>org.eclipse.gef.releng</artifactId>
-	<version>3.20.0-SNAPSHOT</version>
+	<version>3.23.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<!-- this is the parent POM from which all modules inherit common settings -->
 	<properties>
-		<maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
+		<maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>		
-		<cbi-plugins.version>1.5.0</cbi-plugins.version>
+		<cbi-plugins.version>1.5.2</cbi-plugins.version>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse-gef/gef-classic.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<comparator.repo>https://download.eclipse.org/tools/gef/classic/release/3.21.0</comparator.repo>
+		<comparator.repo>https://download.eclipse.org/tools/gef/classic/release/3.22.0</comparator.repo>
 		<surefire.timeout>300</surefire.timeout>
-		<asciidoctor-maven-plugin.version>2.2.4</asciidoctor-maven-plugin.version>
+		<asciidoctor-maven-plugin.version>3.1.1</asciidoctor-maven-plugin.version>
 		<jruby.version>9.4.5.0</jruby.version>
 	</properties>
 

--- a/target-platform/GEF_classic.target
+++ b/target-platform/GEF_classic.target
@@ -7,8 +7,9 @@
 <repository location="http://download.eclipse.org/cbi/updates/license"/>
 </location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/staging/2024-12"/>
-		<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+		<repository location="https://download.eclipse.org/staging/2025-03"/>
+		<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-03"/>
+	    <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="0.0.0"/>
 	</location>
 </locations>


### PR DESCRIPTION
 - Update the version number of all features to 3.23.0
 - Bump maintenance version number of all plugins
 - Update the target platform for the API baseline to GEF Classic 3.23.0
 - Update the pom file target platform checking to GEF Classic 3.23.0
 - Update the development target platform to Eclipse 2025-03
 - Added changelog entry
 - Removed outdated api problem filters

https://github.com/eclipse-gef/gef-classic/issues/627