### PR TITLE
Ignored warning of tests for deprecated methods

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/DimensionTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/DimensionTests.java
@@ -141,7 +141,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(template, testDimension);
 	}
 
-	@SuppressWarnings("static-method")
+	@SuppressWarnings({ "static-method", "removal" })
 	@Test
 	public void testExpand() {
 		// check work expand(Dimension)
@@ -238,7 +238,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(template, testDimension);
 	}
 
-	@SuppressWarnings("static-method")
+	@SuppressWarnings({ "static-method", "removal" })
 	@Test
 	public void testGetDifference() {
 		Dimension template1 = new Dimension(17, 18);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointTests.java
@@ -87,7 +87,7 @@ public class PointTests extends BaseTestCase {
 		assertEquals(-1, 2, new Point(-1, 2));
 	}
 
-	@SuppressWarnings("static-method")
+	@SuppressWarnings({ "static-method", "removal" })
 	@Test
 	public void testConstructorDoubleDouble() {
 		assertEquals((int) Math.PI, (int) -Math.E, new Point(Math.PI, -Math.E));
@@ -198,7 +198,7 @@ public class PointTests extends BaseTestCase {
 		assertEquals(5, new Point(-1, -2).getDistance(new Point(-5, 1)), 0);
 	}
 
-	@SuppressWarnings("static-method")
+	@SuppressWarnings({ "static-method", "removal" })
 	@Test
 	public void testGetDistanceOrthogonal() {
 		assertEquals(53, new Point(10, 20).getDistanceOrthogonal(new Point(51, 32)));

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RectangleTest.java
@@ -360,7 +360,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(-100, 200, 1024, 768, testRectangle);
 	}
 
-	@SuppressWarnings("static-method")
+	@SuppressWarnings({ "static-method", "removal" })
 	@Test
 	public void testCrop() {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
@@ -504,7 +504,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(2, 1, 4, 3, template);
 	}
 
-	@SuppressWarnings("static-method")
+	@SuppressWarnings({ "static-method", "removal" })
 	@Test
 	public void testUnionDimension() {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
@@ -768,7 +768,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(10, 10, 20, 30, rectangle);
 	}
 
-	@SuppressWarnings("static-method")
+	@SuppressWarnings({ "static-method", "removal" })
 	@Test
 	public void testGetCropped() {
 		// check work getCropped() with null Insets

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Label.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Label.java
@@ -144,7 +144,7 @@ public class Label extends Figure implements PositionConstants {
 
 		calculatePlacement();
 		calculateAlignment();
-		Dimension offset = getSize().getDifference(getPreferredSize());
+		Dimension offset = getSize().getShrinked(getPreferredSize());
 		offset.width += getTextSize().width - getSubStringTextSize().width;
 		switch (labelAlignment) {
 		case CENTER:

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Transform.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Transform.java
@@ -17,7 +17,12 @@ package org.eclipse.draw2d.geometry;
  */
 public class Transform {
 
-	private double scaleX = 1.0, scaleY = 1.0, dx, dy, cos = 1.0, sin;
+	private double scaleX = 1.0;
+	private double scaleY = 1.0;
+	private double dx;
+	private double dy;
+	private double cos = 1.0;
+	private double sin;
 
 	/**
 	 * Sets the value for the amount of scaling to be done along both axes.
@@ -83,7 +88,7 @@ public class Transform {
 		temp = x * cos - y * sin;
 		y = x * sin + y * cos;
 		x = temp;
-		return new Point(Math.round(x + dx), Math.round(y + dy));
+		return new Point((int) Math.round(x + dx), (int) Math.round(y + dy));
 	}
 
 }


### PR DESCRIPTION
As long as the deprecated methods are not removed the tests should stay. However the warning is only distracting from other problems therefore it is removed.