### PR TITLE
Correct version of parent pom on "promotion" module

### DIFF
--- a/promotion/pom.xml
+++ b/promotion/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.gef_root</groupId>
     <artifactId>org.eclipse.gef.releng</artifactId>
-    <version>3.20.0-SNAPSHOT</version>
+    <version>3.23.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gef.promotion</artifactId>


### PR DESCRIPTION
This module is only build on the "master" Jenkins build, which is why no error was thrown when raising the version of the parent pom.