### PR TITLE
Implement IGNORE_INVISIBLE_LAYOUT Zest Style for Zest 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## GEF
 
 ## Zest
+- The Zest Graph style have to be set via the `setGraphStyle()` method rather than the constructor. Reason being that otherwise, the same style is used to initialize the underlying `FigureCanvas`.
 
 # GEF Classic 3.22.0
 

--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.core;singleton:=true
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.14.100.qualifier
+Bundle-Version: 1.15.0.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.draw2d;visibility:=reexport

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalLayoutContext.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalLayoutContext.java
@@ -314,6 +314,9 @@ class InternalLayoutContext implements LayoutContext {
 				return true;
 			}
 		}
+		if (!item.isVisible()) {
+			return ZestStyles.checkStyle(container.getGraph().getGraphStyle(), ZestStyles.IGNORE_INVISIBLE_LAYOUT);
+		}
 		return false;
 	}
 

--- a/org.eclipse.zest.tests/.settings/.api_filters
+++ b/org.eclipse.zest.tests/.settings/.api_filters
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.zest.tests" version="2">
+    <resource path="src/org/eclipse/zest/tests/GraphTests.java" type="org.eclipse.zest.tests.GraphTests">
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="Graph"/>
+                <message_argument value="GraphTests"/>
+                <message_argument value="getLayoutContext()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphTests.java
@@ -17,7 +17,9 @@ import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
+import org.eclipse.zest.core.widgets.ZestStyles;
 import org.eclipse.zest.core.widgets.internal.ZestRootLayer;
+import org.eclipse.zest.layouts.interfaces.LayoutContext;
 
 import org.eclipse.draw2d.Figure;
 
@@ -137,4 +139,45 @@ public class GraphTests extends Assert {
 
 	}
 
+	/**
+	 * Check that the {@link ZestStyles#IGNORE_INVISIBLE_LAYOUT} style can be set
+	 * and used correctly.
+	 *
+	 * @See https://bugs.eclipse.org/bugs/show_bug.cgi?id=254584
+	 */
+	@Test
+	public void testInvisibleLayoutStyle() {
+		LayoutContext layoutContext = graph.getLayoutContext();
+		GraphNode node = graph.getNodes().get(0);
+		node.setVisible(false);
+		GraphConnection conn = graph.getConnections().get(0);
+		conn.setVisible(false);
+
+		assertEquals(layoutContext.getNodes().length, 2);
+		assertEquals(layoutContext.getConnections().length, 1);
+		assertEquals(layoutContext.getEntities().length, 2);
+		graph.setGraphStyle(ZestStyles.IGNORE_INVISIBLE_LAYOUT);
+		assertEquals(layoutContext.getNodes().length, 1);
+		assertEquals(layoutContext.getConnections().length, 0);
+		assertEquals(layoutContext.getEntities().length, 1);
+		graph.setGraphStyle(ZestStyles.NONE);
+		assertEquals(layoutContext.getNodes().length, 2);
+		assertEquals(layoutContext.getConnections().length, 1);
+		assertEquals(layoutContext.getEntities().length, 2);
+	}
+
+	/**
+	 * Check that the {@link ZestStyles#GESTURES_DISABLED} style can be set and used
+	 * correctly.
+	 *
+	 * @See https://bugs.eclipse.org/bugs/show_bug.cgi?id=254584
+	 */
+	@Test
+	public void testGestureStyle() {
+		assertEquals(graph.getListeners(SWT.Gesture).length, 2);
+		graph.setGraphStyle(ZestStyles.GESTURES_DISABLED);
+		assertEquals(graph.getListeners(SWT.Gesture).length, 0);
+		graph.setGraphStyle(ZestStyles.NONE);
+		assertEquals(graph.getListeners(SWT.Gesture).length, 2);
+	}
 }


### PR DESCRIPTION
With this change, invisible graph nodes and connections are ignored within the LayoutContext and therefore within the layout algorithms.

Note that as part of this change, the Zest styles are no longer set inside the Graph constructor, but via a separate setGraphStyle() method. This is because the constructor styles are also used for creating the underlying FigureCanvas, which would otherwise throw an exception due to the unsupported styles.

While it technically breaks compatibility, it is practically impossible to have used those styles up until now.

Fixes https://github.com/eclipse-gef/gef-classic/issues/608