### PR TITLE
Fix deprecation warnings in Zest examples

### DIFF
--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/ContainerResizeGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/ContainerResizeGraphSnippet.java
@@ -13,8 +13,8 @@
 package org.eclipse.zest.examples.layouts;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
-import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
@@ -137,7 +137,7 @@ public class ContainerResizeGraphSnippet {
 		// GridLayoutAlgorithm(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
 		g.setLayoutAlgorithm(compositeLayoutAlgorithm, true);
 
-		g.addKeyListener(new KeyListener() {
+		g.addKeyListener(new KeyAdapter() {
 			boolean flip = true;
 
 			@Override
@@ -156,13 +156,6 @@ public class ContainerResizeGraphSnippet {
 				}
 
 			}
-
-			@Override
-			public void keyReleased(KeyEvent e) {
-				// TODO Auto-generated method stub
-
-			}
-
 		});
 
 		shell.open();

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/ContainersGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/ContainersGraphSnippet.java
@@ -66,9 +66,11 @@ public class ContainersGraphSnippet {
 		GraphContainer c2 = new GraphContainer(g, SWT.NONE);
 		c2.setText("USA");
 
-		GraphNode n1 = new GraphNode(c1, SWT.NONE, "Ian B.");
+		GraphNode n1 = new GraphNode(c1, SWT.NONE);
+		n1.setText("Ian B.");
 		n1.setSize(200, 100);
-		GraphNode n2 = new GraphNode(c2, SWT.NONE, "Chris A.");
+		GraphNode n2 = new GraphNode(c2, SWT.NONE);
+		n2.setText("Chris A.");
 		n2.setTooltip(tooltip);
 
 		GraphConnection connection = new GraphConnection(g, ZestStyles.CONNECTIONS_DIRECTED, n1, n2);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/CustomFigureGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/CustomFigureGraphSnippet.java
@@ -12,11 +12,9 @@
  ******************************************************************************/
 package org.eclipse.zest.examples.layouts;
 
-import java.util.Iterator;
-
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
@@ -25,6 +23,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.zest.core.widgets.CGraphNode;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
+import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
@@ -107,45 +106,38 @@ public class CustomFigureGraphSnippet {
 		shell.setSize(400, 400);
 
 		final Graph g = new Graph(shell, SWT.NONE);
-		g.addSelectionListener(new SelectionListener() {
-
+		g.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				Iterator iter = g.getSelection().iterator();
-				while (iter.hasNext()) {
-					Object o = iter.next();
-					if (o instanceof CGraphNode) {
-						IFigure figure = ((CGraphNode) o).getFigure();
+				for (GraphItem graphItem : g.getSelection()) {
+					if (graphItem instanceof CGraphNode graphNode) {
+						IFigure figure = graphNode.getFigure();
 						figure.setBackgroundColor(ColorConstants.blue);
 						figure.setForegroundColor(ColorConstants.blue);
 					}
 				}
-				iter = g.getNodes().iterator();
-				while (iter.hasNext()) {
-					Object o = iter.next();
-					if (o instanceof CGraphNode) {
-						if (!g.getSelection().contains(o)) {
-							((CGraphNode) o).getFigure().setBackgroundColor(ColorConstants.black);
-							((CGraphNode) o).getFigure().setForegroundColor(ColorConstants.black);
+				for (GraphNode graphItem : g.getNodes()) {
+					if (graphItem instanceof CGraphNode graphNode) {
+						if (!g.getSelection().contains(graphNode)) {
+							IFigure figure = graphNode.getFigure();
+							figure.setBackgroundColor(ColorConstants.black);
+							figure.setForegroundColor(ColorConstants.black);
 						}
 					}
 				}
 			}
-
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) {
-				// TODO Auto-generated method stub
-
-			}
 		});
 
-		Image zx = new Image(d, "zx.png");
-		Image ibull = new Image(d, "ibull.jpg");
+		Image zx = new Image(d, "zx.png"); //$NON-NLS-1$
+		Image ibull = new Image(d, "ibull.jpg"); //$NON-NLS-1$
 		CGraphNode n = new CGraphNode(g, SWT.NONE, createPersonFigure(zx));
 		CGraphNode n2 = new CGraphNode(g, SWT.NONE, createPersonFigure(ibull));
-		GraphNode n3 = new GraphNode(g, SWT.NONE, "PDE");
-		GraphNode n4 = new GraphNode(g, SWT.NONE, "Zest");
-		GraphNode n5 = new GraphNode(g, SWT.NONE, "PDE Viz tool");
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText("PDE");
+		GraphNode n4 = new GraphNode(g, SWT.NONE);
+		n4.setText("Zest");
+		GraphNode n5 = new GraphNode(g, SWT.NONE);
+		n5.setText("PDE Viz tool");
 
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n, n3);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/CustomLayout.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/CustomLayout.java
@@ -9,8 +9,8 @@ import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.layouts.LayoutAlgorithm;
+import org.eclipse.zest.layouts.algorithms.AbstractLayoutAlgorithm;
 import org.eclipse.zest.layouts.interfaces.EntityLayout;
-import org.eclipse.zest.layouts.interfaces.LayoutContext;
 
 /**
  * This snippet shows how to create a custom layout. This layout simply lays the
@@ -31,21 +31,17 @@ public class CustomLayout {
 
 		Graph g = new Graph(shell, SWT.NONE);
 
-		GraphNode n = new GraphNode(g, SWT.NONE, "Paper");
-		GraphNode n2 = new GraphNode(g, SWT.NONE, "Rock");
-		GraphNode n3 = new GraphNode(g, SWT.NONE, "Scissors");
+		GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText("Paper");
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText("Rock");
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText("Scissors");
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);
 
-		LayoutAlgorithm layoutAlgorithm = new LayoutAlgorithm() {
-			private LayoutContext context;
-
-			@Override
-			public void setLayoutContext(LayoutContext context) {
-				this.context = context;
-			}
-
+		LayoutAlgorithm layoutAlgorithm = new AbstractLayoutAlgorithm() {
 			@Override
 			public void applyLayout(boolean clean) {
 				EntityLayout[] entitiesToLayout = context.getEntities();

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/DAGExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/DAGExample.java
@@ -50,14 +50,20 @@ public class DAGExample {
 		g.setLayoutAlgorithm(algorithm, false);
 		g.setExpandCollapseManager(new DAGExpandCollapseManager());
 
-		GraphNode root = new GraphNode(g, SWT.NONE, "Root");
-		GraphNode a = new GraphNode(g, SWT.NONE, "A");
-		GraphNode b = new GraphNode(g, SWT.NONE, "B");
-		GraphNode c = new GraphNode(g, SWT.NONE, "C");
-		GraphNode e = new GraphNode(g, SWT.NONE, "D");
-
-		GraphNode f = new GraphNode(g, SWT.NONE, "E");
-		GraphNode h = new GraphNode(g, SWT.NONE, "F");
+		GraphNode root = new GraphNode(g, SWT.NONE);
+		root.setText("Root");
+		GraphNode a = new GraphNode(g, SWT.NONE);
+		a.setText("A");
+		GraphNode b = new GraphNode(g, SWT.NONE);
+		b.setText("B");
+		GraphNode c = new GraphNode(g, SWT.NONE);
+		c.setText("C");
+		GraphNode e = new GraphNode(g, SWT.NONE);
+		e.setText("D");
+		GraphNode f = new GraphNode(g, SWT.NONE);
+		f.setText("E");
+		GraphNode h = new GraphNode(g, SWT.NONE);
+		h.setText("F");
 
 		new GraphConnection(g, ZestStyles.CONNECTIONS_DIRECTED, root, a);
 		new GraphConnection(g, ZestStyles.CONNECTIONS_DIRECTED, root, b);
@@ -110,7 +116,7 @@ public class DAGExample {
 		Action expandAction = new Action() {
 			@Override
 			public void run() {
-				List selection = g.getSelection();
+				List<? extends GraphItem> selection = g.getSelection();
 				if (!selection.isEmpty()) {
 					GraphNode selected = (GraphNode) selection.get(0);
 					g.setExpanded(selected, true);
@@ -123,10 +129,10 @@ public class DAGExample {
 		Action collapseAction = new Action() {
 			@Override
 			public void run() {
-				List selection = g.getSelection();
+				List<? extends GraphItem> selection = g.getSelection();
 				if (!selection.isEmpty()) {
-					GraphItem selected = (GraphItem) selection.get(0);
-					g.setExpanded((GraphNode) selected, false);
+					GraphNode selected = (GraphNode) selection.get(0);
+					g.setExpanded(selected, false);
 				}
 			}
 		};

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/FilterGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/FilterGraphSnippet.java
@@ -47,14 +47,22 @@ public class FilterGraphSnippet {
 
 		final Graph graph = new Graph(shell, SWT.NONE);
 
-		GraphNode a = new GraphNode(graph, SWT.NONE, "Root");
-		GraphNode b = new GraphNode(graph, SWT.NONE, "B");
-		GraphNode c = new GraphNode(graph, SWT.NONE, "C");
-		GraphNode d = new GraphNode(graph, SWT.NONE, "D");
-		GraphNode e = new GraphNode(graph, SWT.NONE, "E");
-		GraphNode f = new GraphNode(graph, SWT.NONE, "F");
-		GraphNode g = new GraphNode(graph, SWT.NONE, "G");
-		GraphNode h = new GraphNode(graph, SWT.NONE, "H");
+		GraphNode a = new GraphNode(graph, SWT.NONE);
+		a.setText("Root");
+		GraphNode b = new GraphNode(graph, SWT.NONE);
+		b.setText("B");
+		GraphNode c = new GraphNode(graph, SWT.NONE);
+		c.setText("C");
+		GraphNode d = new GraphNode(graph, SWT.NONE);
+		d.setText("D");
+		GraphNode e = new GraphNode(graph, SWT.NONE);
+		e.setText("E");
+		GraphNode f = new GraphNode(graph, SWT.NONE);
+		f.setText("F");
+		GraphNode g = new GraphNode(graph, SWT.NONE);
+		g.setText("G");
+		GraphNode h = new GraphNode(graph, SWT.NONE);
+		h.setText("H");
 		GraphConnection connection = new GraphConnection(graph, ZestStyles.CONNECTIONS_DIRECTED, a, b);
 		connection.setData(Boolean.TRUE);
 		connection = new GraphConnection(graph, ZestStyles.CONNECTIONS_DIRECTED, a, c);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/FisheyeGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/FisheyeGraphSnippet.java
@@ -22,6 +22,7 @@ import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
+import org.eclipse.zest.examples.Messages;
 import org.eclipse.zest.layouts.algorithms.GridLayoutAlgorithm;
 
 /**
@@ -49,11 +50,14 @@ public class FisheyeGraphSnippet {
 		Graph g = new Graph(shell, SWT.NONE);
 		g.setConnectionStyle(ZestStyles.CONNECTIONS_DIRECTED);
 		for (int i = 0; i < 80; i++) {
-			GraphNode n1 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE, "Information");
+			GraphNode n1 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			n1.setText(Messages.Information);
 			n1.setImage(image1);
-			GraphNode n2 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE, "Warning");
+			GraphNode n2 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			n2.setText(Messages.Warning);
 			n2.setImage(image2);
-			GraphNode n3 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE, "Error");
+			GraphNode n3 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			n3.setText(Messages.Error);
 			n3.setImage(image3);
 			new GraphConnection(g, SWT.NONE, n1, n2);
 			new GraphConnection(g, SWT.NONE, n2, n3);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/RadialLayoutExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/RadialLayoutExample.java
@@ -22,11 +22,14 @@ public class RadialLayoutExample {
 
 		final Graph g = new Graph(shell, SWT.NONE);
 		g.setSize(500, 500);
-		GraphNode root = new GraphNode(g, SWT.NONE, "Root");
+		GraphNode root = new GraphNode(g, SWT.NONE);
+		root.setText("Root");
 		for (int i = 0; i < 3; i++) {
-			GraphNode n = new GraphNode(g, SWT.NONE, "1 - " + i);
+			GraphNode n = new GraphNode(g, SWT.NONE);
+			n.setText("1 - " + i);
 			for (int j = 0; j < 3; j++) {
-				GraphNode n2 = new GraphNode(g, SWT.NONE, "2 - " + j);
+				GraphNode n2 = new GraphNode(g, SWT.NONE);
+				n2.setText("2 - " + j);
 				new GraphConnection(g, SWT.NONE, n, n2).setWeight(-1);
 			}
 			new GraphConnection(g, SWT.NONE, root, n);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SimpleGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SimpleGraphSnippet.java
@@ -20,6 +20,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
+import org.eclipse.zest.examples.Messages;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 /**
@@ -44,9 +45,12 @@ public class SimpleGraphSnippet {
 
 		Graph g = new Graph(shell, SWT.NONE);
 
-		GraphNode n = new GraphNode(g, SWT.NONE, "Paper");
-		GraphNode n2 = new GraphNode(g, SWT.NONE, "Rock");
-		GraphNode n3 = new GraphNode(g, SWT.NONE, "Scissors");
+		GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText(Messages.Paper);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Rock);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Scissors);
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpaceTreeBuilding.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpaceTreeBuilding.java
@@ -68,7 +68,7 @@ public class SpaceTreeBuilding {
 		Action parentAction = new Action() {
 			@Override
 			public void run() {
-				List selection = g.getSelection();
+				List<? extends GraphItem> selection = g.getSelection();
 				if (!selection.isEmpty()) {
 					GraphNode selected = (GraphNode) selection.get(0);
 					parentNode = selected;
@@ -82,7 +82,7 @@ public class SpaceTreeBuilding {
 		Action childAction = new Action() {
 			@Override
 			public void run() {
-				List selection = g.getSelection();
+				List<? extends GraphItem> selection = g.getSelection();
 				if (!selection.isEmpty()) {
 					GraphNode selected = (GraphNode) selection.get(0);
 					childNode = selected;
@@ -96,7 +96,7 @@ public class SpaceTreeBuilding {
 		Action expandAction = new Action() {
 			@Override
 			public void run() {
-				List selection = g.getSelection();
+				List<? extends GraphItem> selection = g.getSelection();
 				if (!selection.isEmpty()) {
 					GraphNode selected = (GraphNode) selection.get(0);
 					g.setExpanded(selected, true);
@@ -109,10 +109,10 @@ public class SpaceTreeBuilding {
 		Action collapseAction = new Action() {
 			@Override
 			public void run() {
-				List selection = g.getSelection();
+				List<? extends GraphItem> selection = g.getSelection();
 				if (!selection.isEmpty()) {
-					GraphItem selected = (GraphItem) selection.get(0);
-					g.setExpanded((GraphNode) selected, false);
+					GraphNode selected = (GraphNode) selection.get(0);
+					g.setExpanded(selected, false);
 				}
 			}
 		};

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpaceTreeExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpaceTreeExample.java
@@ -14,6 +14,7 @@ import org.eclipse.zest.core.widgets.DefaultSubgraph;
 import org.eclipse.zest.core.widgets.DefaultSubgraph.TriangleSubgraphFactory;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
+import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
 import org.eclipse.zest.layouts.algorithms.SpaceTreeLayoutAlgorithm;
@@ -65,7 +66,8 @@ public class SpaceTreeExample {
 	}
 
 	private static GraphNode createTree(Graph g, String rootTitle, int depth, int breadth) {
-		GraphNode root = new GraphNode(g, SWT.NONE, rootTitle);
+		GraphNode root = new GraphNode(g, SWT.NONE);
+		root.setText(rootTitle);
 		if (depth > 0) {
 			for (int i = 0; i < breadth; i++) {
 				GraphNode child = createTree(g, rootTitle + i, depth - 1 - i, breadth - i);
@@ -83,7 +85,7 @@ public class SpaceTreeExample {
 	}
 
 	private static void fillContextMenu(IMenuManager menuMgr) {
-		List selection = g.getSelection();
+		List<? extends GraphItem> selection = g.getSelection();
 		if (selection.size() == 1) {
 			if (selection.get(0) instanceof GraphNode) {
 				final GraphNode node = (GraphNode) selection.get(0);
@@ -152,7 +154,8 @@ public class SpaceTreeExample {
 			Action addNode = new Action() {
 				@Override
 				public void run() {
-					new GraphNode(g, SWT.NONE, "new!");
+					GraphNode n = new GraphNode(g, SWT.NONE);
+					n.setText("new!");
 				}
 			};
 			addNode.setText("add node");

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpringLayoutExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpringLayoutExample.java
@@ -40,11 +40,14 @@ public class SpringLayoutExample {
 
 		final Graph g = new Graph(shell, SWT.BORDER);
 		g.setSize(500, 500);
-		GraphNode root = new GraphNode(g, SWT.NONE, "Root");
+		GraphNode root = new GraphNode(g, SWT.NONE);
+		root.setText("Root");
 		for (int i = 0; i < 3; i++) {
-			GraphNode n = new GraphNode(g, SWT.NONE, "1 - " + i);
+			GraphNode n = new GraphNode(g, SWT.NONE);
+			n.setText("1 - " + i);
 			for (int j = 0; j < 3; j++) {
-				GraphNode n2 = new GraphNode(g, SWT.NONE, "2 - " + j);
+				GraphNode n2 = new GraphNode(g, SWT.NONE);
+				n2.setText("2 - " + j);
 				new GraphConnection(g, SWT.NONE, n, n2).setWeight(-1);
 			}
 			new GraphConnection(g, SWT.NONE, root, n);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpringLayoutProgress.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpringLayoutProgress.java
@@ -15,11 +15,10 @@ package org.eclipse.zest.examples.layouts;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
-import org.eclipse.swt.events.MouseListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -29,6 +28,7 @@ import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
+import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
@@ -58,15 +58,22 @@ public class SpringLayoutProgress {
 		g.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 5, 5));
 		g.setSize(500, 500);
 
-		GraphNode aa = new GraphNode(g, SWT.NONE, "A");
-		GraphNode bb = new GraphNode(g, SWT.NONE, "B");
-		GraphNode cc = new GraphNode(g, SWT.NONE, "C");
+		GraphNode aa = new GraphNode(g, SWT.NONE);
+		aa.setText("A");
+		GraphNode bb = new GraphNode(g, SWT.NONE);
+		bb.setText("B");
+		GraphNode cc = new GraphNode(g, SWT.NONE);
+		cc.setText("C");
 
-		GraphNode dd = new GraphNode(g, SWT.NONE, "D");
-		GraphNode ee = new GraphNode(g, SWT.NONE, "E");
-		GraphNode ff = new GraphNode(g, SWT.NONE, "F");
+		GraphNode dd = new GraphNode(g, SWT.NONE);
+		dd.setText("D");
+		GraphNode ee = new GraphNode(g, SWT.NONE);
+		ee.setText("E");
+		GraphNode ff = new GraphNode(g, SWT.NONE);
+		ff.setText("F");
 
-		GraphNode root = new GraphNode(g, SWT.NONE, "Root");
+		GraphNode root = new GraphNode(g, SWT.NONE);
+		root.setText("Root");
 
 		new GraphConnection(g, SWT.NONE, root, aa);
 		new GraphConnection(g, SWT.NONE, root, bb);
@@ -89,9 +96,11 @@ public class SpringLayoutProgress {
 
 		for (int k = 0; k < 1; k++) {
 			for (int i = 0; i < 8; i++) {
-				GraphNode n = new GraphNode(g, SWT.NONE, "1 - " + i);
+				GraphNode n = new GraphNode(g, SWT.NONE);
+				n.setText("1 - " + i);
 				for (int j = 0; j < 5; j++) {
-					GraphNode n2 = new GraphNode(g, SWT.NONE, "2 - " + j);
+					GraphNode n2 = new GraphNode(g, SWT.NONE);
+					n2.setText("2 - " + j);
 					new GraphConnection(g, SWT.NONE, n, n2).setWeight(-1);
 					new GraphConnection(g, SWT.NONE, nodes[j % 3], n2);
 
@@ -100,68 +109,53 @@ public class SpringLayoutProgress {
 			}
 		}
 
-		List nodes2 = g.getNodes();
-		for (Object element : nodes2) {
+		List<? extends GraphItem> nodes2 = g.getNodes();
+		for (GraphItem element : nodes2) {
 			GraphNode node = (GraphNode) element;
 			node.setLocation(200, 200);
 		}
-		g.addMouseListener(new MouseListener() {
+		g.addMouseListener(new MouseAdapter() {
 
 			@Override
 			public void mouseUp(MouseEvent e) {
-				// TODO Auto-generated method stub
 				MouseDown = false;
 
 			}
 
 			@Override
 			public void mouseDown(MouseEvent e) {
-				// TODO Auto-generated method stub
 				MouseDown = true;
-
-			}
-
-			@Override
-			public void mouseDoubleClick(MouseEvent e) {
-				// TODO Auto-generated method stub
 
 			}
 		});
 
-		g.addSelectionListener(new SelectionListener() {
+		g.addSelectionListener(new SelectionAdapter() {
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				List selection = g.getSelection();
-				List graphNodes = g.getNodes();
-				for (Object graphNode : graphNodes) {
-					GraphNode node = (GraphNode) graphNode;
+				for (GraphNode node : g.getNodes()) {
 					if (!g.getSelection().contains(node)) {
 						node.unhighlight();
 					}
 				}
 
-				List connctions = g.getConnections();
-				for (Object connction : connctions) {
-					GraphConnection connection = (GraphConnection) connction;
+				for (GraphConnection connection : g.getConnections()) {
 					connection.unhighlight();
 					connection.setWeight(-1);
 				}
 
-				for (Object object : selection) {
+				for (GraphItem object : g.getSelection()) {
 					if (object instanceof GraphNode node) {
-						List sourceConnections = node.getSourceConnections();
-						for (Object sourceConnection : sourceConnections) {
-							GraphConnection connection = (GraphConnection) sourceConnection;
+						List<? extends GraphConnection> sourceConnections = node.getSourceConnections();
+						for (GraphConnection connection : sourceConnections) {
 							connection.getDestination().highlight();
 							connection.highlight();
 							connection.setWeight(10);
 
 						}
 
-						List target = node.getTargetConnections();
-						for (Object element : target) {
-							GraphConnection connection = (GraphConnection) element;
+						List<? extends GraphConnection> target = node.getTargetConnections();
+						for (GraphConnection connection : target) {
 							connection.getSource().highlight();
 							connection.highlight();
 							connection.setWeight(10);
@@ -171,12 +165,6 @@ public class SpringLayoutProgress {
 					}
 
 				}
-
-			}
-
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) {
-				// TODO Auto-generated method stub
 
 			}
 		});
@@ -213,7 +201,6 @@ public class SpringLayoutProgress {
 					try {
 						Thread.sleep(10);
 					} catch (InterruptedException e1) {
-						// TODO Auto-generated catch block
 						e1.printStackTrace();
 					}
 					Display.getCurrent().asyncExec(r);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SugiyamaLayoutExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SugiyamaLayoutExample.java
@@ -38,13 +38,20 @@ public class SugiyamaLayoutExample {
 		Graph g = new Graph(shell, SWT.NONE);
 		g.setConnectionStyle(ZestStyles.CONNECTIONS_DIRECTED);
 
-		GraphNode coal = new GraphNode(g, SWT.NONE, "Coal");
-		GraphNode ore = new GraphNode(g, SWT.NONE, "Ore");
-		GraphNode stone = new GraphNode(g, SWT.NONE, "Stone");
-		GraphNode metal = new GraphNode(g, SWT.NONE, "Metal");
-		GraphNode concrete = new GraphNode(g, SWT.NONE, "Concrete");
-		GraphNode machine = new GraphNode(g, SWT.NONE, "Machine");
-		GraphNode building = new GraphNode(g, SWT.NONE, "Building");
+		GraphNode coal = new GraphNode(g, SWT.NONE);
+		coal.setText("Coal");
+		GraphNode ore = new GraphNode(g, SWT.NONE);
+		ore.setText("Ore");
+		GraphNode stone = new GraphNode(g, SWT.NONE);
+		stone.setText("Stone");
+		GraphNode metal = new GraphNode(g, SWT.NONE);
+		metal.setText("Metal");
+		GraphNode concrete = new GraphNode(g, SWT.NONE);
+		concrete.setText("Concrete");
+		GraphNode machine = new GraphNode(g, SWT.NONE);
+		machine.setText("Machine");
+		GraphNode building = new GraphNode(g, SWT.NONE);
+		building.setText("Building");
 
 		new GraphConnection(g, SWT.NONE, coal, metal);
 		new GraphConnection(g, SWT.NONE, coal, concrete);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/TreeLayoutExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/TreeLayoutExample.java
@@ -46,16 +46,19 @@ public class TreeLayoutExample {
 		g.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 10, 10));
 		g.setSize(500, 500);
 
-		GraphNode root = new GraphNode(g, SWT.NONE, "Root");
+		GraphNode root = new GraphNode(g, SWT.NONE);
+		root.setText("Root");
 
 		GraphNode lastNode = null;
 		for (int i = 0; i < 3; i++) {
-			GraphNode n = new GraphNode(g, SWT.NONE, "1 - " + i);
+			GraphNode n = new GraphNode(g, SWT.NONE);
+			n.setText("1 - " + i);
 			if (lastNode != null) {
 				new GraphConnection(g, SWT.NONE, n, lastNode).setDirected(true);
 			}
 			for (int j = 0; j < 1; j++) {
-				GraphNode n2 = new GraphNode(g, SWT.NONE, "2 - " + j);
+				GraphNode n2 = new GraphNode(g, SWT.NONE);
+				n2.setText("2 - " + j);
 				GraphConnection c = new GraphConnection(g, SWT.NONE, n, n2);
 				c.setWeight(-1);
 				c.setDirected(true);
@@ -136,7 +139,7 @@ public class TreeLayoutExample {
 		Action expandAction = new Action() {
 			@Override
 			public void run() {
-				List selection = g.getSelection();
+				List<? extends GraphItem> selection = g.getSelection();
 				if (!selection.isEmpty()) {
 					GraphNode selected = (GraphNode) selection.get(0);
 					g.setExpanded(selected, true);
@@ -149,10 +152,10 @@ public class TreeLayoutExample {
 		Action collapseAction = new Action() {
 			@Override
 			public void run() {
-				List selection = g.getSelection();
+				List<? extends GraphItem> selection = g.getSelection();
 				if (!selection.isEmpty()) {
-					GraphItem selected = (GraphItem) selection.get(0);
-					g.setExpanded((GraphNode) selected, false);
+					GraphNode selected = (GraphNode) selection.get(0);
+					g.setExpanded(selected, false);
 				}
 			}
 		};

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/AnimationSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/AnimationSnippet.java
@@ -1,8 +1,8 @@
 package org.eclipse.zest.examples.swt;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Display;
@@ -39,14 +39,12 @@ public class AnimationSnippet {
 
 		g = new Graph(shell, SWT.NONE);
 
-		final GraphNode n = new GraphNode(g, SWT.NONE, Messages.Paper);
-		final GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Rock);
+		final GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText(Messages.Paper);
+		final GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Rock);
 
-		b.addSelectionListener(new SelectionListener() {
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) {
-			}
-
+		b.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				Animation.markBegin();

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/CustomLayout.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/CustomLayout.java
@@ -32,9 +32,12 @@ public class CustomLayout {
 
 		g = new Graph(shell, SWT.NONE);
 
-		GraphNode n = new GraphNode(g, SWT.NONE, Messages.Paper);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Rock);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.Scissors);
+		GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText(Messages.Paper);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Rock);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Scissors);
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet1.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet1.java
@@ -49,9 +49,12 @@ public class GraphSnippet1 {
 
 		g = new Graph(shell, SWT.NONE);
 
-		GraphNode n = new GraphNode(g, SWT.NONE, Messages.Paper);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Rock);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.Scissors);
+		GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText(Messages.Paper);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Rock);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Scissors);
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet10.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet10.java
@@ -46,11 +46,14 @@ public class GraphSnippet10 {
 
 		g = new Graph(shell, SWT.NONE);
 
-		GraphNode n = new GraphNode(g, SWT.NONE, Messages.Paper);
+		GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText(Messages.Paper);
 		n.setBorderColor(org.eclipse.draw2d.ColorConstants.yellow);
 		n.setBorderWidth(3);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Rock);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.Scissors);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Rock);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Scissors);
 		final GraphConnection connection = new GraphConnection(g, SWT.NONE, n, n2);
 		connection.setLineWidth(3);
 		new GraphConnection(g, SWT.NONE, n2, n3);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet11.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet11.java
@@ -51,8 +51,10 @@ public class GraphSnippet11 {
 		shell.setSize(400, 400);
 
 		g = new Graph(shell, SWT.NONE);
-		GraphNode n = new GraphNode(g, SWT.NONE, Messages.GraphSnippet11_Node1);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.GraphSnippet11_Node2);
+		GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText(Messages.GraphSnippet11_Node1);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.GraphSnippet11_Node2);
 		createConnection(g, n, n2, ColorConstants.darkGreen, 20);
 		createConnection(g, n, n2, ColorConstants.darkGreen, -20);
 		createConnection(g, n, n2, ColorConstants.darkBlue, 40);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet12.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet12.java
@@ -12,11 +12,9 @@
  ******************************************************************************/
 package org.eclipse.zest.examples.swt;
 
-import java.util.Iterator;
-
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
@@ -25,6 +23,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.zest.core.widgets.CGraphNode;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
+import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.examples.Messages;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
@@ -109,35 +108,26 @@ public class GraphSnippet12 {
 		shell.setSize(400, 400);
 
 		g = new Graph(shell, SWT.NONE);
-		g.addSelectionListener(new SelectionListener() {
+		g.addSelectionListener(new SelectionAdapter() {
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				Iterator iter = g.getSelection().iterator();
-				while (iter.hasNext()) {
-					Object o = iter.next();
-					if (o instanceof CGraphNode) {
-						IFigure figure = ((CGraphNode) o).getFigure();
+				for (GraphItem graphItem : g.getSelection()) {
+					if (graphItem instanceof CGraphNode graphNode) {
+						IFigure figure = graphNode.getFigure();
 						figure.setBackgroundColor(ColorConstants.blue);
 						figure.setForegroundColor(ColorConstants.blue);
 					}
 				}
-				iter = g.getNodes().iterator();
-				while (iter.hasNext()) {
-					Object o = iter.next();
-					if (o instanceof CGraphNode) {
-						if (!g.getSelection().contains(o)) {
-							((CGraphNode) o).getFigure().setBackgroundColor(ColorConstants.black);
-							((CGraphNode) o).getFigure().setForegroundColor(ColorConstants.black);
+				for (GraphNode graphItem : g.getNodes()) {
+					if (graphItem instanceof CGraphNode graphNode) {
+						if (!g.getSelection().contains(graphNode)) {
+							IFigure figure = graphNode.getFigure();
+							figure.setBackgroundColor(ColorConstants.black);
+							figure.setForegroundColor(ColorConstants.black);
 						}
 					}
 				}
-			}
-
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) {
-				// TODO Auto-generated method stub
-
 			}
 		});
 
@@ -145,9 +135,12 @@ public class GraphSnippet12 {
 		Image ibull = new Image(d, GraphSnippet12.class.getResourceAsStream("/ibull.jpg")); //$NON-NLS-1$
 		CGraphNode n = new CGraphNode(g, SWT.NONE, createPersonFigure(zx));
 		CGraphNode n2 = new CGraphNode(g, SWT.NONE, createPersonFigure(ibull));
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.GraphSnippet12_PDE);
-		GraphNode n4 = new GraphNode(g, SWT.NONE, Messages.GraphSnippet12_Zest);
-		GraphNode n5 = new GraphNode(g, SWT.NONE, Messages.GraphSnippet12_PDEVizTool);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.GraphSnippet12_PDE);
+		GraphNode n4 = new GraphNode(g, SWT.NONE);
+		n4.setText(Messages.GraphSnippet12_Zest);
+		GraphNode n5 = new GraphNode(g, SWT.NONE);
+		n5.setText(Messages.GraphSnippet12_PDEVizTool);
 
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n, n3);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet13.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet13.java
@@ -12,11 +12,9 @@
  ******************************************************************************/
 package org.eclipse.zest.examples.swt;
 
-import java.util.Iterator;
-
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
@@ -26,6 +24,7 @@ import org.eclipse.zest.core.widgets.CGraphNode;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphContainer;
+import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
 import org.eclipse.zest.examples.Messages;
@@ -114,35 +113,26 @@ public class GraphSnippet13 {
 		shell.setSize(400, 400);
 
 		g = new Graph(shell, SWT.NONE);
-		g.addSelectionListener(new SelectionListener() {
+		g.addSelectionListener(new SelectionAdapter() {
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				Iterator iter = g.getSelection().iterator();
-				while (iter.hasNext()) {
-					Object o = iter.next();
-					if (o instanceof CGraphNode) {
-						IFigure figure = ((CGraphNode) o).getFigure();
+				for (GraphItem graphItem : g.getSelection()) {
+					if (graphItem instanceof CGraphNode graphNode) {
+						IFigure figure = graphNode.getFigure();
 						figure.setBackgroundColor(ColorConstants.blue);
 						figure.setForegroundColor(ColorConstants.blue);
 					}
 				}
-				iter = g.getNodes().iterator();
-				while (iter.hasNext()) {
-					Object o = iter.next();
-					if (o instanceof CGraphNode) {
-						if (!g.getSelection().contains(o)) {
-							((CGraphNode) o).getFigure().setBackgroundColor(ColorConstants.black);
-							((CGraphNode) o).getFigure().setForegroundColor(ColorConstants.black);
+				for (GraphNode graphItem : g.getNodes()) {
+					if (graphItem instanceof CGraphNode graphNode) {
+						if (!g.getSelection().contains(graphNode)) {
+							IFigure figure = graphNode.getFigure();
+							figure.setBackgroundColor(ColorConstants.black);
+							figure.setForegroundColor(ColorConstants.black);
 						}
 					}
 				}
-			}
-
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) {
-				// TODO Auto-generated method stub
-
 			}
 		});
 
@@ -163,9 +153,11 @@ public class GraphSnippet13 {
 		GraphContainer c2 = new GraphContainer(g, SWT.NONE);
 		c2.setText(Messages.GraphSnippet13_USA);
 
-		GraphNode n1 = new GraphNode(c1, SWT.NONE, Messages.GraphSnippet13_Node1);
+		GraphNode n1 = new GraphNode(c1, SWT.NONE);
+		n1.setText(Messages.GraphSnippet13_Node1);
 		n1.setSize(200, 100);
-		GraphNode n2 = new GraphNode(c2, SWT.NONE, Messages.GraphSnippet13_Node2);
+		GraphNode n2 = new GraphNode(c2, SWT.NONE);
+		n2.setText(Messages.GraphSnippet13_Node2);
 		n2.setTooltip(tooltip);
 
 		GraphConnection connection = new GraphConnection(g, ZestStyles.CONNECTIONS_DIRECTED, n1, n2);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet14.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet14.java
@@ -47,9 +47,12 @@ public class GraphSnippet14 {
 
 		g = new Graph(shell, SWT.NONE, true); // enable hide nodes
 
-		GraphNode n = new GraphNode(g, SWT.NONE, Messages.Paper);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Rock);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.Scissors);
+		GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText(Messages.Paper);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Rock);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Scissors);
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet2.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet2.java
@@ -49,9 +49,15 @@ public class GraphSnippet2 {
 
 		g = new Graph(shell, SWT.NONE);
 		g.setConnectionStyle(ZestStyles.CONNECTIONS_DIRECTED);
-		GraphNode n1 = new GraphNode(g, SWT.NONE, Messages.Information, image1);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Warning, image2);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.Error, image3);
+		GraphNode n1 = new GraphNode(g, SWT.NONE);
+		n1.setText(Messages.Information);
+		n1.setImage(image1);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Warning);
+		n2.setImage(image2);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Error);
+		n3.setImage(image3);
 
 		new GraphConnection(g, SWT.NONE, n1, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet3.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet3.java
@@ -57,9 +57,15 @@ public class GraphSnippet3 {
 		});
 
 		g.setConnectionStyle(ZestStyles.CONNECTIONS_DIRECTED);
-		GraphNode n1 = new GraphNode(g, SWT.NONE, Messages.Information, image1);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Warning, image2);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.Error, image3);
+		GraphNode n1 = new GraphNode(g, SWT.NONE);
+		n1.setText(Messages.Information);
+		n1.setImage(image1);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Warning);
+		n2.setImage(image2);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Error);
+		n3.setImage(image3);
 
 		new GraphConnection(g, SWT.NONE, n1, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet4.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet4.java
@@ -46,8 +46,6 @@ public class GraphSnippet4 {
 	 *
 	 * @param image1
 	 * @param image2
-	 * @param result
-	 * @return
 	 */
 	public static Image mergeImages(Image image1, Image image2) {
 		Image mergedImage = new Image(Display.getDefault(), image1.getBounds().width + image2.getBounds().width,
@@ -74,9 +72,15 @@ public class GraphSnippet4 {
 
 		g = new Graph(shell, SWT.NONE);
 		g.setConnectionStyle(ZestStyles.CONNECTIONS_DIRECTED);
-		GraphNode n1 = new GraphNode(g, SWT.NONE, Messages.Information, image1);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Warning, image2);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.Error, image3);
+		GraphNode n1 = new GraphNode(g, SWT.NONE);
+		n1.setText(Messages.Information);
+		n1.setImage(image1);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Warning);
+		n2.setImage(image2);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Error);
+		n3.setImage(image3);
 
 		GraphConnection connection1 = new GraphConnection(g, SWT.NONE, n1, n2);
 		GraphConnection connection2 = new GraphConnection(g, SWT.NONE, n2, n3);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet5.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet5.java
@@ -14,7 +14,6 @@ package org.eclipse.zest.examples.swt;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -57,12 +56,12 @@ public class GraphSnippet5 {
 	 * @param args
 	 */
 	public static void main(String[] args) {
-		final Map figureListing = new HashMap();
+		final Map<String, GraphNode> figureListing = new HashMap<>();
 		final StringBuffer stringBuffer = new StringBuffer();
 		final Shell shell = new Shell();
 		final Display d = shell.getDisplay();
 		FontData fontData = d.getSystemFont().getFontData()[0];
-		fontData.height = 42;
+		fontData.setHeight(42);
 
 		final Font font = new Font(d, fontData);
 
@@ -75,9 +74,15 @@ public class GraphSnippet5 {
 
 		g = new Graph(shell, SWT.NONE);
 		g.setConnectionStyle(ZestStyles.CONNECTIONS_DIRECTED);
-		GraphNode n1 = new GraphNode(g, SWT.NONE, Messages.GraphSnippet5_Information, image1);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.GraphSnippet5_Warning, image2);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.GraphSnippet5_Error, image3);
+		GraphNode n1 = new GraphNode(g, SWT.NONE);
+		n1.setText(Messages.GraphSnippet5_Information);
+		n1.setImage(image1);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.GraphSnippet5_Warning);
+		n2.setImage(image2);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.GraphSnippet5_Error);
+		n3.setImage(image3);
 		figureListing.put(n1.getText().toLowerCase(), n1);
 		figureListing.put(n2.getText().toLowerCase(), n2);
 		figureListing.put(n3.getText().toLowerCase(), n3);
@@ -103,17 +108,15 @@ public class GraphSnippet5 {
 						|| (e.character == '.') || (e.character >= '0' && e.character <= '9')) {
 					stringBuffer.append(e.character);
 				}
-				Iterator iterator = figureListing.keySet().iterator();
-				List list = new ArrayList();
+				List<GraphItem> list = new ArrayList<>();
 				if (stringBuffer.length() > 0) {
-					while (iterator.hasNext()) {
-						String string = (String) iterator.next();
+					for (String string : figureListing.keySet()) {
 						if (string.indexOf(stringBuffer.toString().toLowerCase()) >= 0) {
 							list.add(figureListing.get(string));
 						}
 					}
 				}
-				g.setSelection((GraphItem[]) list.toArray(new GraphItem[list.size()]));
+				g.setSelection(list.toArray(new GraphItem[list.size()]));
 				if (complete && stringBuffer.length() > 0) {
 					stringBuffer.delete(0, stringBuffer.length());
 				}

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet6.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet6.java
@@ -52,12 +52,15 @@ public class GraphSnippet6 {
 		g = new Graph(shell, SWT.NONE);
 		g.setConnectionStyle(ZestStyles.CONNECTIONS_DIRECTED);
 		for (int i = 0; i < 80; i++) {
-			GraphNode n1 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE, Messages.Information,
-					image1);
-			GraphNode n2 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE, Messages.Warning,
-					image2);
-			GraphNode n3 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE, Messages.Error,
-					image3);
+			GraphNode n1 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			n1.setText(Messages.Information);
+			n1.setImage(image1);
+			GraphNode n2 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			n2.setText(Messages.Warning);
+			n2.setImage(image2);
+			GraphNode n3 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			n3.setText(Messages.Error);
+			n3.setImage(image3);
 			new GraphConnection(g, SWT.NONE, n1, n2);
 			new GraphConnection(g, SWT.NONE, n2, n3);
 			new GraphConnection(g, SWT.NONE, n3, n3);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet7.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet7.java
@@ -47,9 +47,12 @@ public class GraphSnippet7 {
 
 		g = new Graph(shell, SWT.NONE);
 
-		GraphNode n = new GraphNode(g, SWT.NONE, Messages.Paper);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Rock);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.Scissors);
+		GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText(Messages.Paper);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Rock);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Scissors);
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet8.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet8.java
@@ -49,14 +49,22 @@ public class GraphSnippet8 {
 
 		graph = new Graph(shell, SWT.NONE);
 
-		GraphNode a = new GraphNode(graph, SWT.NONE, Messages.Root);
-		GraphNode b = new GraphNode(graph, SWT.NONE, Messages.GraphSnippet8_Node1);
-		GraphNode c = new GraphNode(graph, SWT.NONE, Messages.GraphSnippet8_Node2);
-		GraphNode d = new GraphNode(graph, SWT.NONE, Messages.GraphSnippet8_Node3);
-		GraphNode e = new GraphNode(graph, SWT.NONE, Messages.GraphSnippet8_Node4);
-		GraphNode f = new GraphNode(graph, SWT.NONE, Messages.GraphSnippet8_Node5);
-		GraphNode g = new GraphNode(graph, SWT.NONE, Messages.GraphSnippet8_Node6);
-		GraphNode h = new GraphNode(graph, SWT.NONE, Messages.GraphSnippet8_Node7);
+		GraphNode a = new GraphNode(graph, SWT.NONE);
+		a.setText(Messages.Root);
+		GraphNode b = new GraphNode(graph, SWT.NONE);
+		b.setText(Messages.GraphSnippet8_Node1);
+		GraphNode c = new GraphNode(graph, SWT.NONE);
+		c.setText(Messages.GraphSnippet8_Node2);
+		GraphNode d = new GraphNode(graph, SWT.NONE);
+		d.setText(Messages.GraphSnippet8_Node3);
+		GraphNode e = new GraphNode(graph, SWT.NONE);
+		e.setText(Messages.GraphSnippet8_Node4);
+		GraphNode f = new GraphNode(graph, SWT.NONE);
+		f.setText(Messages.GraphSnippet8_Node5);
+		GraphNode g = new GraphNode(graph, SWT.NONE);
+		g.setText(Messages.GraphSnippet8_Node6);
+		GraphNode h = new GraphNode(graph, SWT.NONE);
+		h.setText(Messages.GraphSnippet8_Node7);
 		GraphConnection connection = new GraphConnection(graph, SWT.NONE, a, b);
 		connection.setData(Boolean.FALSE);
 		connection = new GraphConnection(graph, SWT.NONE, a, c);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet9.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet9.java
@@ -44,7 +44,8 @@ public class GraphSnippet9 {
 
 		graph = new Graph(shell, SWT.NONE);
 
-		GraphNode a = new GraphNode(graph, ZestStyles.CONNECTIONS_DIRECTED, Messages.Root);
+		GraphNode a = new GraphNode(graph, ZestStyles.CONNECTIONS_DIRECTED);
+		a.setText(Messages.Root);
 		GraphConnection connection = new GraphConnection(graph, SWT.NONE, a, a);
 		connection.setText(Messages.GraphSnippet9_Connection);
 		a.setLocation(100, 100);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/HelloWorld.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/HelloWorld.java
@@ -43,8 +43,10 @@ public class HelloWorld {
 		shell.setSize(400, 400);
 
 		g = new Graph(shell, SWT.NONE);
-		GraphNode hello = new GraphNode(g, SWT.NONE, Messages.HelloWorld_Node1);
-		GraphNode world = new GraphNode(g, SWT.NONE, Messages.HelloWorld_Node2);
+		GraphNode hello = new GraphNode(g, SWT.NONE);
+		hello.setText(Messages.HelloWorld_Node1);
+		GraphNode world = new GraphNode(g, SWT.NONE);
+		world.setText(Messages.HelloWorld_Node2);
 		new GraphConnection(g, SWT.NONE, hello, world);
 		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/LayoutExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/LayoutExample.java
@@ -46,11 +46,14 @@ public class LayoutExample {
 		shell.setSize(400, 400);
 
 		g = new Graph(shell, SWT.NONE);
-		GraphNode root = new GraphNode(g, SWT.NONE, Messages.Root);
+		GraphNode root = new GraphNode(g, SWT.NONE);
+		root.setText(Messages.Root);
 		for (int i = 0; i < 3; i++) {
-			GraphNode n = new GraphNode(g, SWT.NONE, Messages.bind(Messages.LayoutExample_Node1, i));
+			GraphNode n = new GraphNode(g, SWT.NONE);
+			n.setText(Messages.bind(Messages.LayoutExample_Node1, i));
 			for (int j = 0; j < 3; j++) {
-				GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.bind(Messages.LayoutExample_Node2, j));
+				GraphNode n2 = new GraphNode(g, SWT.NONE);
+				n2.setText(Messages.bind(Messages.LayoutExample_Node2, j));
 				new GraphConnection(g, SWT.NONE, n, n2);
 			}
 			new GraphConnection(g, SWT.NONE, root, n);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/ManhattanLayoutGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/ManhattanLayoutGraphSnippet.java
@@ -57,9 +57,12 @@ public class ManhattanLayoutGraphSnippet {
 
 		final Graph g = new Graph(shell, SWT.NONE);
 
-		GraphNode n = new GraphNode(g, SWT.NONE, Messages.Paper);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Rock);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.Scissors);
+		GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText(Messages.Paper);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Rock);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Scissors);
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet.java
@@ -37,18 +37,24 @@ public class NestedGraphSnippet {
 	private static Image classImage;
 
 	public static void createContainer(Graph g) {
-		GraphContainer a = new GraphContainer(g, SWT.NONE, Messages.NestedGraphSnippet_Container1, classImage);
+		GraphContainer a = new GraphContainer(g, SWT.NONE);
+		a.setText(Messages.NestedGraphSnippet_Container1);
+		a.setImage(classImage);
 		int r = (int) ((Math.random() * 3) + 1);
 		r = 2;
 		populateContainer(a, g, r, true);
 		for (int i = 0; i < 4; i++) {
-			GraphContainer b = new GraphContainer(g, SWT.NONE, Messages.NestedGraphSnippet_Container2, classImage);
+			GraphContainer b = new GraphContainer(g, SWT.NONE);
+			b.setText(Messages.NestedGraphSnippet_Container2);
+			b.setImage(classImage);
 			r = (int) ((Math.random() * 3) + 1);
 			r = 2;
 			populateContainer(b, g, r, false);
 			new GraphConnection(g, SWT.NONE, a, b);
 			for (int j = 0; j < 4; j++) {
-				GraphContainer c = new GraphContainer(g, SWT.NONE, Messages.NestedGraphSnippet_Container3, classImage);
+				GraphContainer c = new GraphContainer(g, SWT.NONE);
+				c.setText(Messages.NestedGraphSnippet_Container3);
+				c.setImage(classImage);
 				r = (int) ((Math.random() * 3) + 1);
 				r = 2;
 				populateContainer(c, g, r, true);
@@ -58,25 +64,30 @@ public class NestedGraphSnippet {
 	}
 
 	public static void populateContainer(GraphContainer c, Graph g, int number, boolean radial) {
-		GraphNode a = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT,
-				Messages.NestedGraphSnippet_Node1, classImage);
+		GraphNode a = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+		a.setText(Messages.NestedGraphSnippet_Node1);
+		a.setImage(classImage);
 		for (int i = 0; i < 4; i++) {
-			GraphNode b = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT,
-					Messages.NestedGraphSnippet_Node2, classImage);
+			GraphNode b = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+			b.setText(Messages.NestedGraphSnippet_Node2);
+			b.setImage(classImage);
 			new GraphConnection(g, SWT.NONE, a, b);
 			for (int j = 0; j < 4; j++) {
-				GraphNode d = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT,
-						Messages.NestedGraphSnippet_Node3, classImage);
+				GraphNode d = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+				d.setText(Messages.NestedGraphSnippet_Node3);
+				d.setImage(classImage);
 				new GraphConnection(g, SWT.NONE, b, d);
 				if (number > 2) {
 					for (int k = 0; k < 4; k++) {
-						GraphNode e = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT,
-								Messages.NestedGraphSnippet_Node4, classImage);
+						GraphNode e = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+						e.setText(Messages.NestedGraphSnippet_Node4);
+						e.setImage(classImage);
 						new GraphConnection(g, SWT.NONE, d, e);
 						if (number > 3) {
 							for (int l = 0; l < 4; l++) {
-								GraphNode f = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT,
-										Messages.NestedGraphSnippet_Node5, classImage);
+								GraphNode f = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+								f.setText(Messages.NestedGraphSnippet_Node5);
+								f.setImage(classImage);
 								new GraphConnection(g, SWT.NONE, e, f);
 							}
 						}

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet2.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet2.java
@@ -64,11 +64,16 @@ public class NestedGraphSnippet2 {
 		container4.setText(Messages.NestedGraphSnippet2_Container7);
 
 		/* Objects */
-		GraphNode object1 = new GraphNode(container1, ZestStyles.NODES_FISHEYE, Messages.NestedGraphSnippet2_Node1);
-		GraphNode object2 = new GraphNode(container1, ZestStyles.NODES_FISHEYE, Messages.NestedGraphSnippet2_Node2);
-		GraphNode object3 = new GraphNode(container2, ZestStyles.NODES_FISHEYE, Messages.NestedGraphSnippet2_Node3);
-		GraphNode object4 = new GraphNode(container3, ZestStyles.NODES_FISHEYE, Messages.NestedGraphSnippet2_Node4);
-		GraphNode object5 = new GraphNode(container4, ZestStyles.NODES_FISHEYE, Messages.NestedGraphSnippet2_Node5);
+		GraphNode object1 = new GraphNode(container1, ZestStyles.NODES_FISHEYE);
+		object1.setText(Messages.NestedGraphSnippet2_Node1);
+		GraphNode object2 = new GraphNode(container1, ZestStyles.NODES_FISHEYE);
+		object2.setText(Messages.NestedGraphSnippet2_Node2);
+		GraphNode object3 = new GraphNode(container2, ZestStyles.NODES_FISHEYE);
+		object3.setText(Messages.NestedGraphSnippet2_Node3);
+		GraphNode object4 = new GraphNode(container3, ZestStyles.NODES_FISHEYE);
+		object4.setText(Messages.NestedGraphSnippet2_Node4);
+		GraphNode object5 = new GraphNode(container4, ZestStyles.NODES_FISHEYE);
+		object5.setText(Messages.NestedGraphSnippet2_Node5);
 
 		/* Connections */
 		new GraphConnection(g, ZestStyles.CONNECTIONS_DIRECTED, object1, object2);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/PaintSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/PaintSnippet.java
@@ -62,9 +62,12 @@ public class PaintSnippet {
 
 		g = new Graph(shell, SWT.NONE);
 
-		GraphNode n = new GraphNode(g, SWT.NONE, Messages.Paper);
-		GraphNode n2 = new GraphNode(g, SWT.NONE, Messages.Rock);
-		GraphNode n3 = new GraphNode(g, SWT.NONE, Messages.Scissors);
+		GraphNode n = new GraphNode(g, SWT.NONE);
+		n.setText(Messages.Paper);
+		GraphNode n2 = new GraphNode(g, SWT.NONE);
+		n2.setText(Messages.Rock);
+		GraphNode n3 = new GraphNode(g, SWT.NONE);
+		n3.setText(Messages.Scissors);
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/ZoomSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/ZoomSnippet.java
@@ -13,8 +13,8 @@
 package org.eclipse.zest.examples.swt;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
-import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
@@ -40,18 +40,24 @@ public class ZoomSnippet {
 	private static Image classImage;
 
 	public static void createContainer(Graph g) {
-		GraphContainer a = new GraphContainer(g, SWT.NONE, Messages.ZoomSnippet_Container1, classImage);
+		GraphContainer a = new GraphContainer(g, SWT.NONE);
+		a.setText(Messages.ZoomSnippet_Container1);
+		a.setImage(classImage);
 		int r = (int) ((Math.random() * 3) + 1);
 		r = 2;
 		populateContainer(a, g, r, true);
 		for (int i = 0; i < 4; i++) {
-			GraphContainer b = new GraphContainer(g, SWT.NONE, Messages.ZoomSnippet_Container2, classImage);
+			GraphContainer b = new GraphContainer(g, SWT.NONE);
+			b.setText(Messages.ZoomSnippet_Container2);
+			b.setImage(classImage);
 			r = (int) ((Math.random() * 3) + 1);
 			r = 2;
 			populateContainer(b, g, r, false);
 			new GraphConnection(g, SWT.NONE, a, b);
 			for (int j = 0; j < 4; j++) {
-				GraphContainer c = new GraphContainer(g, SWT.NONE, Messages.ZoomSnippet_Container3, classImage);
+				GraphContainer c = new GraphContainer(g, SWT.NONE);
+				c.setText(Messages.ZoomSnippet_Container3);
+				c.setImage(classImage);
 				r = (int) ((Math.random() * 3) + 1);
 				r = 2;
 				populateContainer(c, g, r, true);
@@ -61,25 +67,30 @@ public class ZoomSnippet {
 	}
 
 	public static void populateContainer(GraphContainer c, Graph g, int number, boolean radial) {
-		GraphNode a = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT,
-				Messages.ZoomSnippet_Node1, classImage);
+		GraphNode a = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+		a.setText(Messages.ZoomSnippet_Node1);
+		a.setImage(classImage);
 		for (int i = 0; i < 4; i++) {
-			GraphNode b = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT,
-					Messages.ZoomSnippet_Node2, classImage);
+			GraphNode b = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+			b.setText(Messages.ZoomSnippet_Node2);
+			b.setImage(classImage);
 			new GraphConnection(g, SWT.NONE, a, b);
 			for (int j = 0; j < 4; j++) {
-				GraphNode d = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT,
-						Messages.ZoomSnippet_Node3, classImage);
+				GraphNode d = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+				d.setText(Messages.ZoomSnippet_Node3);
+				d.setImage(classImage);
 				new GraphConnection(g, SWT.NONE, b, d);
 				if (number > 2) {
 					for (int k = 0; k < 4; k++) {
-						GraphNode e = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT,
-								Messages.ZoomSnippet_Node4, classImage);
+						GraphNode e = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+						e.setText(Messages.ZoomSnippet_Node4);
+						e.setImage(classImage);
 						new GraphConnection(g, SWT.NONE, d, e);
 						if (number > 3) {
 							for (int l = 0; l < 4; l++) {
-								GraphNode f = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT,
-										Messages.ZoomSnippet_Node5, classImage);
+								GraphNode f = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+								f.setText(Messages.ZoomSnippet_Node5);
+								f.setImage(classImage);
 								new GraphConnection(g, SWT.NONE, e, f);
 							}
 						}
@@ -124,7 +135,7 @@ public class ZoomSnippet {
 		// GridLayoutAlgorithm(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
 		g.setLayoutAlgorithm(compositeLayoutAlgorithm, true);
 
-		g.addKeyListener(new KeyListener() {
+		g.addKeyListener(new KeyAdapter() {
 			boolean flip = true;
 
 			@Override
@@ -143,13 +154,6 @@ public class ZoomSnippet {
 				}
 
 			}
-
-			@Override
-			public void keyReleased(KeyEvent e) {
-				// TODO Auto-generated method stub
-
-			}
-
 		});
 
 		shell.open();


### PR DESCRIPTION
This primarily solves the warnings caused by the deprecated GraphNode constructor, but also does a general cleanup and modernization of the snippets.