### PR TITLE
Publish GEF/Zest examples and Zest CloudIO to update site

### DIFF
--- a/org.eclipse.gef.examples-feature/feature.xml
+++ b/org.eclipse.gef.examples-feature/feature.xml
@@ -69,4 +69,20 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.gef.examples.digraph1"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.gef.examples.digraph2"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.gef.examples.ui.capabilities"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.gef.examples.ui.pde"
+         version="0.0.0"/>
+
 </feature>

--- a/org.eclipse.gef.examples.digraph1/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.digraph1/META-INF/MANIFEST.MF
@@ -11,9 +11,9 @@ Require-Bundle: org.eclipse.gef;bundle-version="[3.18.0,4.0.0)";visibility:=reex
  org.eclipse.core.resources;bundle-version="[3.3.0,4.0.0)";visibility:=reexport
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Export-Package: org.eclipse.gef.examples.digraph1.editor,
- org.eclipse.gef.examples.digraph1.editpart,
- org.eclipse.gef.examples.digraph1.figure,
- org.eclipse.gef.examples.digraph1.model,
- org.eclipse.gef.examples.digraph1.policy
+Export-Package: org.eclipse.gef.examples.digraph1.editor;x-internal:=true,
+ org.eclipse.gef.examples.digraph1.editpart;x-internal:=true,
+ org.eclipse.gef.examples.digraph1.figure;x-internal:=true,
+ org.eclipse.gef.examples.digraph1.model;x-internal:=true,
+ org.eclipse.gef.examples.digraph1.policy;x-internal:=true
 Automatic-Module-Name: org.eclipse.gef.examples.digraph1

--- a/org.eclipse.gef.examples.ui.pde/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.ui.pde/META-INF/MANIFEST.MF
@@ -6,9 +6,9 @@ Bundle-Version: 3.13.400.qualifier
 Bundle-Activator: org.eclipse.gef.examples.ui.pde.internal.GefExamplesPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Export-Package: org.eclipse.gef.examples.ui.pde.internal,
- org.eclipse.gef.examples.ui.pde.internal.l10n,
- org.eclipse.gef.examples.ui.pde.internal.wizards
+Export-Package: org.eclipse.gef.examples.ui.pde.internal;x-internal:=true,
+ org.eclipse.gef.examples.ui.pde.internal.l10n;x-internal:=true,
+ org.eclipse.gef.examples.ui.pde.internal.wizards;x-internal:=true
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",

--- a/org.eclipse.gef.repository/category.xml
+++ b/org.eclipse.gef.repository/category.xml
@@ -45,6 +45,18 @@
    <bundle id="org.eclipse.draw2d.examples.source">
       <category name="draw2d"/>
    </bundle>
+   <bundle id="org.eclipse.zest.examples.cloudio">
+      <category name="zest"/>
+   </bundle>
+   <bundle id="org.eclipse.zest.examples.cloudio.source">
+      <category name="zest"/>
+   </bundle>
+   <bundle id="org.eclipse.zest.examples.layouts">
+      <category name="zest"/>
+   </bundle>
+   <bundle id="org.eclipse.zest.examples.layouts.source">
+      <category name="zest"/>
+   </bundle>
    <category-def name="GEF" label="GEF (Graphical Editing Framework) Classic">
       <description>
          Draw2d, GEF (MVC), and Zest runtime, SDK, examples, and sources

--- a/org.eclipse.zest-feature/feature.xml
+++ b/org.eclipse.zest-feature/feature.xml
@@ -62,4 +62,8 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.zest.cloudio"
+         version="0.0.0"/>
+
 </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -377,6 +377,8 @@
 		
 		<!--examples-->
 		<module>org.eclipse.draw2d.examples</module>
+		<module>org.eclipse.gef.examples.digraph1</module>
+		<module>org.eclipse.gef.examples.digraph2</module>
 		<module>org.eclipse.gef.examples.flow</module>
 		<module>org.eclipse.gef.examples.logic</module>
 		<module>org.eclipse.gef.examples.shapes</module>


### PR DESCRIPTION
Primarily done to enable the baseline-check for those bundles, but also to make them available to users. This includes:

- org.eclipse.gef.examples.digraph1
- org.eclipse.gef.examples.digraph2
- org.eclipse.gef.examples.ui.capabilities
- org.eclipse.gef.examples.ui.pde
- org.eclipse.zest.examples.cloudio
- org.eclipse.zest.examples.layouts
- org.eclipse.zest.cloudio