### PR TITLE
Refresh Zest GraphNode figures if node style has been changed

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024, CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ * Copyright 2005, 2025, CHISEL Group, University of Victoria, Victoria, BC, Canada.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -660,6 +660,7 @@ public class GraphNode extends GraphItem {
 	public void setNodeStyle(int nodeStyle) {
 		this.nodeStyle = nodeStyle;
 		this.cacheLabel = ((this.nodeStyle & ZestStyles.NODES_CACHE_LABEL) > 0) ? true : false;
+		updateFigureForModel(modelFigure);
 	}
 
 	/*

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/ContainerResizeGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/ContainerResizeGraphSnippet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2007, 2024, CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2007, 2025, CHISEL Group, University of Victoria, Victoria,
  *                            BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -66,28 +66,33 @@ public class ContainerResizeGraphSnippet {
 	}
 
 	public static void populateContainer(GraphContainer c, Graph g, int number, boolean radial) {
-		GraphNode a = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+		GraphNode a = new GraphNode(c, SWT.NONE);
+		a.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 		a.setText("SomeClass.java");
 		a.setImage(classImage);
 		for (int i = 0; i < 4; i++) {
-			GraphNode b = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+			GraphNode b = new GraphNode(c, SWT.NONE);
+			b.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 			b.setText("SomeNestedClass.java");
 			b.setImage(classImage);
 			new GraphConnection(g, SWT.NONE, a, b);
 			for (int j = 0; j < 4; j++) {
-				GraphNode d = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+				GraphNode d = new GraphNode(c, SWT.NONE);
+				d.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 				d.setText("DefaultAction.java");
 				d.setImage(classImage);
 				new GraphConnection(g, SWT.NONE, b, d);
 				if (number > 2) {
 					for (int k = 0; k < 4; k++) {
-						GraphNode e = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+						GraphNode e = new GraphNode(c, SWT.NONE);
+						e.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 						e.setText("LastAction(Hero).java");
 						e.setImage(classImage);
 						new GraphConnection(g, SWT.NONE, d, e);
 						if (number > 3) {
 							for (int l = 0; l < 4; l++) {
-								GraphNode f = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+								GraphNode f = new GraphNode(c, SWT.NONE);
+								f.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 								f.setText("LastAction(Hero).java");
 								f.setImage(classImage);
 								new GraphConnection(g, SWT.NONE, e, f);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/FisheyeGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/FisheyeGraphSnippet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2007, 2024, CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2007, 2025, CHISEL Group, University of Victoria, Victoria,
  *                            BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -50,13 +50,16 @@ public class FisheyeGraphSnippet {
 		Graph g = new Graph(shell, SWT.NONE);
 		g.setConnectionStyle(ZestStyles.CONNECTIONS_DIRECTED);
 		for (int i = 0; i < 80; i++) {
-			GraphNode n1 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			GraphNode n1 = new GraphNode(g, SWT.NONE);
+			n1.setNodeStyle(ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
 			n1.setText(Messages.Information);
 			n1.setImage(image1);
-			GraphNode n2 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			GraphNode n2 = new GraphNode(g, SWT.NONE);
+			n2.setNodeStyle(ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
 			n2.setText(Messages.Warning);
 			n2.setImage(image2);
-			GraphNode n3 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			GraphNode n3 = new GraphNode(g, SWT.NONE);
+			n3.setNodeStyle(ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
 			n3.setText(Messages.Error);
 			n3.setImage(image3);
 			new GraphConnection(g, SWT.NONE, n1, n2);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet6.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet6.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2007, 2024, CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2007, 2025, CHISEL Group, University of Victoria, Victoria,
  *                            BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -52,13 +52,16 @@ public class GraphSnippet6 {
 		g = new Graph(shell, SWT.NONE);
 		g.setConnectionStyle(ZestStyles.CONNECTIONS_DIRECTED);
 		for (int i = 0; i < 80; i++) {
-			GraphNode n1 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			GraphNode n1 = new GraphNode(g, SWT.NONE);
+			n1.setNodeStyle(ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
 			n1.setText(Messages.Information);
 			n1.setImage(image1);
-			GraphNode n2 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			GraphNode n2 = new GraphNode(g, SWT.NONE);
+			n2.setNodeStyle(ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
 			n2.setText(Messages.Warning);
 			n2.setImage(image2);
-			GraphNode n3 = new GraphNode(g, ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
+			GraphNode n3 = new GraphNode(g, SWT.NONE);
+			n3.setNodeStyle(ZestStyles.NODES_HIDE_TEXT | ZestStyles.NODES_FISHEYE);
 			n3.setText(Messages.Error);
 			n3.setImage(image3);
 			new GraphConnection(g, SWT.NONE, n1, n2);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet9.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet9.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2007, 2024, CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2007, 2025, CHISEL Group, University of Victoria, Victoria,
  *                            BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -44,9 +44,10 @@ public class GraphSnippet9 {
 
 		graph = new Graph(shell, SWT.NONE);
 
-		GraphNode a = new GraphNode(graph, ZestStyles.CONNECTIONS_DIRECTED);
+		GraphNode a = new GraphNode(graph, SWT.NONE);
 		a.setText(Messages.Root);
 		GraphConnection connection = new GraphConnection(graph, SWT.NONE, a, a);
+		connection.setConnectionStyle(ZestStyles.CONNECTIONS_DIRECTED);
 		connection.setText(Messages.GraphSnippet9_Connection);
 		a.setLocation(100, 100);
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2007, 2024, CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2007, 2025, CHISEL Group, University of Victoria, Victoria,
  *                            BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -64,28 +64,33 @@ public class NestedGraphSnippet {
 	}
 
 	public static void populateContainer(GraphContainer c, Graph g, int number, boolean radial) {
-		GraphNode a = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+		GraphNode a = new GraphNode(c, SWT.NONE);
+		a.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 		a.setText(Messages.NestedGraphSnippet_Node1);
 		a.setImage(classImage);
 		for (int i = 0; i < 4; i++) {
-			GraphNode b = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+			GraphNode b = new GraphNode(c, SWT.NONE);
+			b.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 			b.setText(Messages.NestedGraphSnippet_Node2);
 			b.setImage(classImage);
 			new GraphConnection(g, SWT.NONE, a, b);
 			for (int j = 0; j < 4; j++) {
-				GraphNode d = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+				GraphNode d = new GraphNode(c, SWT.NONE);
+				d.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 				d.setText(Messages.NestedGraphSnippet_Node3);
 				d.setImage(classImage);
 				new GraphConnection(g, SWT.NONE, b, d);
 				if (number > 2) {
 					for (int k = 0; k < 4; k++) {
-						GraphNode e = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+						GraphNode e = new GraphNode(c, SWT.NONE);
+						e.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 						e.setText(Messages.NestedGraphSnippet_Node4);
 						e.setImage(classImage);
 						new GraphConnection(g, SWT.NONE, d, e);
 						if (number > 3) {
 							for (int l = 0; l < 4; l++) {
-								GraphNode f = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+								GraphNode f = new GraphNode(c, SWT.NONE);
+								f.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 								f.setText(Messages.NestedGraphSnippet_Node5);
 								f.setImage(classImage);
 								new GraphConnection(g, SWT.NONE, e, f);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet2.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2007, 2024, CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2007, 2025, CHISEL Group, University of Victoria, Victoria,
  *                            BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -64,15 +64,20 @@ public class NestedGraphSnippet2 {
 		container4.setText(Messages.NestedGraphSnippet2_Container7);
 
 		/* Objects */
-		GraphNode object1 = new GraphNode(container1, ZestStyles.NODES_FISHEYE);
+		GraphNode object1 = new GraphNode(container1, SWT.NONE);
+		object1.setNodeStyle(ZestStyles.NODES_FISHEYE);
 		object1.setText(Messages.NestedGraphSnippet2_Node1);
-		GraphNode object2 = new GraphNode(container1, ZestStyles.NODES_FISHEYE);
+		GraphNode object2 = new GraphNode(container1, SWT.NONE);
+		object2.setNodeStyle(ZestStyles.NODES_FISHEYE);
 		object2.setText(Messages.NestedGraphSnippet2_Node2);
-		GraphNode object3 = new GraphNode(container2, ZestStyles.NODES_FISHEYE);
+		GraphNode object3 = new GraphNode(container2, SWT.NONE);
+		object3.setNodeStyle(ZestStyles.NODES_FISHEYE);
 		object3.setText(Messages.NestedGraphSnippet2_Node3);
-		GraphNode object4 = new GraphNode(container3, ZestStyles.NODES_FISHEYE);
+		GraphNode object4 = new GraphNode(container3, SWT.NONE);
+		object4.setNodeStyle(ZestStyles.NODES_FISHEYE);
 		object4.setText(Messages.NestedGraphSnippet2_Node4);
-		GraphNode object5 = new GraphNode(container4, ZestStyles.NODES_FISHEYE);
+		GraphNode object5 = new GraphNode(container4, SWT.NONE);
+		object5.setNodeStyle(ZestStyles.NODES_FISHEYE);
 		object5.setText(Messages.NestedGraphSnippet2_Node5);
 
 		/* Connections */

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/ZoomSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/ZoomSnippet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2007, 2024, CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2007, 2025, CHISEL Group, University of Victoria, Victoria,
  *                            BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -67,28 +67,33 @@ public class ZoomSnippet {
 	}
 
 	public static void populateContainer(GraphContainer c, Graph g, int number, boolean radial) {
-		GraphNode a = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+		GraphNode a = new GraphNode(c, SWT.NONE);
+		a.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 		a.setText(Messages.ZoomSnippet_Node1);
 		a.setImage(classImage);
 		for (int i = 0; i < 4; i++) {
-			GraphNode b = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+			GraphNode b = new GraphNode(c, SWT.NONE);
+			b.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 			b.setText(Messages.ZoomSnippet_Node2);
 			b.setImage(classImage);
 			new GraphConnection(g, SWT.NONE, a, b);
 			for (int j = 0; j < 4; j++) {
-				GraphNode d = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+				GraphNode d = new GraphNode(c, SWT.NONE);
+				d.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 				d.setText(Messages.ZoomSnippet_Node3);
 				d.setImage(classImage);
 				new GraphConnection(g, SWT.NONE, b, d);
 				if (number > 2) {
 					for (int k = 0; k < 4; k++) {
-						GraphNode e = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+						GraphNode e = new GraphNode(c, SWT.NONE);
+						e.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 						e.setText(Messages.ZoomSnippet_Node4);
 						e.setImage(classImage);
 						new GraphConnection(g, SWT.NONE, d, e);
 						if (number > 3) {
 							for (int l = 0; l < 4; l++) {
-								GraphNode f = new GraphNode(c, ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
+								GraphNode f = new GraphNode(c, SWT.NONE);
+								f.setNodeStyle(ZestStyles.NODES_FISHEYE | ZestStyles.NODES_HIDE_TEXT);
 								f.setText(Messages.ZoomSnippet_Node5);
 								f.setImage(classImage);
 								new GraphConnection(g, SWT.NONE, e, f);


### PR DESCRIPTION
There are currently two ways the Zest styles for a graph node can be set: Either via the constructor or by calling the setNodeStyle() method.

Certain styles affect how the nodes are visualized and therefore, the underlying figure needs to be updated together with the node style. This currently only happens when the node is created. As a result, certain styles such as the NODES_HIDE_TEXT and NODES_FISHEYE are effectively ignored if retroactively added to a node.

With this change, the model figure is explicitly updated (which is also done when e.g. updating the font). Note that mixing SWT and Zest styles is usually not a good idea, as it introduces the risk in case they share one or more bits. Which is why the test snippets have been updated as well, to emphasize the use of setNodeStyle() as the indented workflow.

Fixes https://github.com/eclipse-gef/gef-classic/issues/647