### PR TITLE
Double size for AND,OR,XOR gates for better visibility

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFeedbackFigure.java
@@ -28,14 +28,14 @@ public class AndGateFeedbackFigure extends AndGateFigure {
 		g.setBackgroundColor(LogicColorConstants.ghostFillColor);
 
 		Rectangle r = getBounds().getCopy();
-		r.translate(2, 2);
-		r.setSize(11, 9);
+		r.translate(4, 4);
+		r.setSize(22, 18);
 
 		// Draw terminals, 2 at top
-		g.drawLine(r.x + 2, r.y, r.x + 2, r.y - 2);
-		g.drawLine(r.right() - 3, r.y, r.right() - 3, r.y - 2);
-		g.drawPoint(r.x + 2, r.y);
-		g.drawPoint(r.right() - 3, r.y);
+		g.drawLine(r.x + 4, r.y, r.x + 4, r.y - 4);
+		g.drawLine(r.right() - 6, r.y, r.right() - 6, r.y - 4);
+		g.drawPoint(r.x + 4, r.y);
+		g.drawPoint(r.right() - 6, r.y);
 
 		// outline main area
 		g.drawLine(r.x, r.y, r.right() - 1, r.y);
@@ -48,20 +48,21 @@ public class AndGateFeedbackFigure extends AndGateFigure {
 		g.fillRectangle(r);
 
 		// draw and outline the arc
-		r.height = 9;
-		r.y += 4;
+		r.height = 18;
+		r.y += 8;
 		g.setForegroundColor(LogicColorConstants.ghostFillColor);
-		g.drawLine(r.x, r.y + 4, r.x + 10, r.y + 4);
+		g.drawLine(r.x, r.y + 8, r.x + 20, r.y + 8);
 		g.setForegroundColor(ColorConstants.white);
 
-		g.drawPoint(r.x, r.y + 4);
+		g.drawPoint(r.x, r.y + 8);
+
 		g.fillArc(r, 180, 180);
 
 		r.width--;
 		r.height--;
 
 		g.drawArc(r, 180, 180);
-		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 2);
+		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
 
 		g.drawPoint(r.x + r.width / 2, r.bottom());
 	}

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
@@ -21,7 +21,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  */
 public class AndGateFigure extends GateFigure {
 
-	public static final Dimension SIZE = new Dimension(15, 17);
+	public static final Dimension SIZE = new Dimension(30, 34);
 
 	/**
 	 * Constructor for AndGateFigure.
@@ -44,12 +44,12 @@ public class AndGateFigure extends GateFigure {
 	@Override
 	protected void paintFigure(Graphics g) {
 		Rectangle r = getBounds().getCopy();
-		r.translate(2, 2);
-		r.setSize(11, 9);
+		r.translate(4, 4);
+		r.setSize(22, 18);
 
 		// Draw terminals, 2 at top
-		g.drawLine(r.x + 2, r.y, r.x + 2, r.y - 2);
-		g.drawLine(r.right() - 3, r.y, r.right() - 3, r.y - 2);
+		g.drawLine(r.x + 4, r.y, r.x + 4, r.y - 4);
+		g.drawLine(r.right() - 6, r.y, r.right() - 6, r.y - 4);
 
 		// draw main area
 		g.fillRectangle(r);
@@ -60,13 +60,13 @@ public class AndGateFigure extends GateFigure {
 		g.drawLine(r.x, r.y, r.x, r.bottom() - 1);
 
 		// draw and outline the arc
-		r.height = 9;
-		r.y += 4;
+		r.height = 18;
+		r.y += 8;
 		g.fillArc(r, 180, 180);
 		r.width--;
 		r.height--;
 		g.drawArc(r, 180, 190);
-		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 2);
+		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/GateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/GateFigure.java
@@ -18,9 +18,9 @@ public class GateFigure extends OutputFigure {
 
 	public GateFigure() {
 		FixedConnectionAnchor inputConnectionAnchorA = new FixedConnectionAnchor(this);
-		inputConnectionAnchorA.offsetH = 4;
+		inputConnectionAnchorA.offsetH = 8;
 		FixedConnectionAnchor inputConnectionAnchorB = new FixedConnectionAnchor(this);
-		inputConnectionAnchorB.offsetH = 10;
+		inputConnectionAnchorB.offsetH = 20;
 		inputConnectionAnchors.add(inputConnectionAnchorA);
 		inputConnectionAnchors.add(inputConnectionAnchorB);
 		connectionAnchors.put(Gate.TERMINAL_A, inputConnectionAnchorA);

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFeedbackFigure.java
@@ -28,27 +28,29 @@ public class OrGateFeedbackFigure extends OrGateFigure {
 		g.setBackgroundColor(LogicColorConstants.ghostFillColor);
 
 		Rectangle r = getBounds().getCopy();
-		r.translate(2, 2);
-		r.setSize(11, 9);
+		r.translate(4, 4);
+		r.setSize(22, 18);
 
 		// Draw terminals, 2 at top
-		g.drawLine(r.x + 2, r.y + 2, r.x + 2, r.y - 2);
-		g.drawLine(r.right() - 3, r.y + 2, r.right() - 3, r.y - 2);
+		g.drawLine(r.x + 4, r.y + 4, r.x + 4, r.y - 4);
+		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
 
 		// fix it
-		g.drawPoint(r.x + 2, r.y + 2);
-		g.drawPoint(r.right() - 3, r.y + 2);
+		g.drawPoint(r.x + 4, r.y + 4);
+		g.drawPoint(r.right() - 6, r.y + 4);
 
 		// Draw the bottom arc of the gate
-		r.y += 4;
+		r.y += 8;
 
+		r.width--;
+		r.height--;
 		g.fillArc(r, 180, 180);
 		r.width--;
 		r.height--;
-		g.drawPoint(r.x, r.y + 4);
+		g.drawPoint(r.x, r.y + 8);
 
 		g.drawArc(r, 180, 180);
-		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 2);
+		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
 		g.drawPoint(r.x + r.width / 2, r.bottom());
 
 		// draw gate

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
@@ -21,19 +21,19 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * @author danlee
  */
 public class OrGateFigure extends GateFigure {
-	public static final Dimension SIZE = new Dimension(15, 17);
+	public static final Dimension SIZE = new Dimension(30, 34);
 	protected static final PointList GATE_OUTLINE = new PointList();
 
 	static {
-		GATE_OUTLINE.addPoint(2, 10);
-		GATE_OUTLINE.addPoint(2, 2);
+		GATE_OUTLINE.addPoint(4, 20);
 		GATE_OUTLINE.addPoint(4, 4);
-		GATE_OUTLINE.addPoint(6, 5);
-		GATE_OUTLINE.addPoint(7, 5);
-		GATE_OUTLINE.addPoint(8, 5);
-		GATE_OUTLINE.addPoint(10, 4);
-		GATE_OUTLINE.addPoint(12, 2);
+		GATE_OUTLINE.addPoint(8, 8);
 		GATE_OUTLINE.addPoint(12, 10);
+		GATE_OUTLINE.addPoint(14, 10);
+		GATE_OUTLINE.addPoint(16, 10);
+		GATE_OUTLINE.addPoint(20, 8);
+		GATE_OUTLINE.addPoint(24, 4);
+		GATE_OUTLINE.addPoint(24, 20);
 	}
 
 	/**
@@ -57,20 +57,24 @@ public class OrGateFigure extends GateFigure {
 	@Override
 	protected void paintFigure(Graphics g) {
 		Rectangle r = getBounds().getCopy();
-		r.translate(2, 2);
-		r.setSize(11, 9);
+		r.translate(4, 4);
+		r.setSize(22, 18);
 
 		// Draw terminals, 2 at top
-		g.drawLine(r.x + 2, r.y + 2, r.x + 2, r.y - 2);
-		g.drawLine(r.right() - 3, r.y + 2, r.right() - 3, r.y - 2);
+		g.drawLine(r.x + 4, r.y + 4, r.x + 4, r.y - 4);
+		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
 
 		// Draw the bottom arc of the gate
-		r.y += 4;
+		r.y += 8;
+
+		r.width--;
+		r.height--;
 		g.fillOval(r);
 		r.width--;
 		r.height--;
+
 		g.drawOval(r);
-		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 2);
+		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
 
 		// draw gate
 		g.translate(getLocation());

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OutputFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OutputFigure.java
@@ -21,7 +21,7 @@ public class OutputFigure extends NodeFigure {
 	public OutputFigure() {
 		FixedConnectionAnchor outputConnectionAnchor = new FixedConnectionAnchor(this);
 		outputConnectionAnchor.topDown = false;
-		outputConnectionAnchor.offsetH = 7;
+		outputConnectionAnchor.offsetH = 14;
 		outputConnectionAnchors.add(outputConnectionAnchor);
 		connectionAnchors.put(SimpleOutput.TERMINAL_OUT, outputConnectionAnchor);
 		setLayoutManager(new StackLayout());

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFeedbackFigure.java
@@ -27,19 +27,19 @@ public class XOrGateFeedbackFigure extends XOrGateFigure {
 		g.setForegroundColor(ColorConstants.white);
 		g.setBackgroundColor(LogicColorConstants.ghostFillColor);
 		Rectangle r = getBounds().getCopy();
-		r.translate(2, 2);
-		r.setSize(11, 9);
+		r.translate(4, 4);
+		r.setSize(22, 18);
 
 		// Draw terminals, 2 at top
-		g.drawLine(r.x + 2, r.y + 2, r.x + 2, r.y - 2);
-		g.drawLine(r.right() - 3, r.y + 2, r.right() - 3, r.y - 2);
+		g.drawLine(r.x + 4, r.y + 4, r.x + 4, r.y - 4);
+		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
 
 		// fix it
-		g.drawPoint(r.x + 2, r.y + 2);
-		g.drawPoint(r.right() - 3, r.y + 2);
+		g.drawPoint(r.x + 4, r.y + 4);
+		g.drawPoint(r.right() - 6, r.y + 4);
 
 		// Draw an oval that represents the bottom arc
-		r.y += 4;
+		r.y += 8;
 
 		/*
 		 * Draw the bottom gate arc. This is done with an oval. The oval overlaps the
@@ -50,13 +50,15 @@ public class XOrGateFeedbackFigure extends XOrGateFigure {
 		g.clipRect(r);
 		r.y--;
 
+		r.width--;
+		r.height--;
 		g.fillArc(r, 180, 180);
 		r.width--;
 		r.height--;
 		g.drawArc(r, 180, 180);
-		g.drawPoint(r.x, r.y + 4);
+		g.drawPoint(r.x, r.y + 8);
 		g.popState();
-		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 2);
+		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
 		g.drawPoint(r.x + r.width / 2, r.bottom());
 
 		// Draw the gate outline and top curve

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
@@ -22,30 +22,30 @@ import org.eclipse.draw2d.geometry.Rectangle;
  */
 public class XOrGateFigure extends GateFigure {
 
-	public static final Dimension SIZE = new Dimension(15, 17);
+	public static final Dimension SIZE = new Dimension(30, 34);
 	protected static final PointList GATE_OUTLINE = new PointList();
 	protected static final PointList GATE_TOP = new PointList();
 
 	static {
 		// setup gate outline
-		GATE_OUTLINE.addPoint(2, 10);
-		GATE_OUTLINE.addPoint(2, 4);
-		GATE_OUTLINE.addPoint(4, 6);
-		GATE_OUTLINE.addPoint(6, 7);
-		GATE_OUTLINE.addPoint(7, 7);
-		GATE_OUTLINE.addPoint(8, 7);
-		GATE_OUTLINE.addPoint(10, 6);
-		GATE_OUTLINE.addPoint(12, 4);
-		GATE_OUTLINE.addPoint(12, 10);
+		GATE_OUTLINE.addPoint(4, 20);
+		GATE_OUTLINE.addPoint(4, 8);
+		GATE_OUTLINE.addPoint(8, 12);
+		GATE_OUTLINE.addPoint(12, 14);
+		GATE_OUTLINE.addPoint(14, 14);
+		GATE_OUTLINE.addPoint(16, 14);
+		GATE_OUTLINE.addPoint(20, 12);
+		GATE_OUTLINE.addPoint(24, 8);
+		GATE_OUTLINE.addPoint(24, 20);
 
 		// setup top curve of gate
-		GATE_TOP.addPoint(2, 2);
 		GATE_TOP.addPoint(4, 4);
-		GATE_TOP.addPoint(6, 5);
-		GATE_TOP.addPoint(7, 5);
-		GATE_TOP.addPoint(8, 5);
-		GATE_TOP.addPoint(10, 4);
-		GATE_TOP.addPoint(12, 2);
+		GATE_TOP.addPoint(8, 8);
+		GATE_TOP.addPoint(12, 10);
+		GATE_TOP.addPoint(14, 10);
+		GATE_TOP.addPoint(16, 10);
+		GATE_TOP.addPoint(20, 8);
+		GATE_TOP.addPoint(24, 4);
 	}
 
 	/**
@@ -69,30 +69,32 @@ public class XOrGateFigure extends GateFigure {
 	@Override
 	protected void paintFigure(Graphics g) {
 		Rectangle r = getBounds().getCopy();
-		r.translate(2, 2);
-		r.setSize(11, 9);
+		r.translate(4, 4);
+		r.setSize(22, 18);
 
 		// Draw terminals, 2 at top
-		g.drawLine(r.x + 2, r.y + 2, r.x + 2, r.y - 2);
-		g.drawLine(r.right() - 3, r.y + 2, r.right() - 3, r.y - 2);
+		g.drawLine(r.x + 4, r.y + 4, r.x + 4, r.y - 4);
+		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
 
 		// Draw an oval that represents the bottom arc
-		r.y += 4;
+		r.y += 8;
 
 		/*
 		 * Draw the bottom gate arc. This is done with an oval. The oval overlaps the
 		 * top arc of the gate, so this region is clipped.
 		 */
 		g.pushState();
-		r.y++;
+		r.y += 2;
 		g.clipRect(r);
 		r.y--;
+		r.width--;
+		r.height--;
 		g.fillOval(r);
 		r.width--;
 		r.height--;
 		g.drawOval(r);
 		g.popState();
-		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 2);
+		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
 
 		// Draw the gate outline and top curve
 		g.translate(getLocation());

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/LogicDiagramTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/LogicDiagramTests.java
@@ -266,7 +266,7 @@ public class LogicDiagramTests extends AbstractSWTBotEditorTests {
 
 		assertNotEquals(first.getBounds().getCenter().y, second.getBounds().getCenter().y);
 		bot.toolbarButtonWithTooltip("Align Middle").click();
-		assertEquals(first.getBounds().getCenter().y, second.getBounds().getCenter().y);
+		assertEquals(first.getBounds().getCenter().y, second.getBounds().getCenter().y, 1.0);
 	}
 
 	/**


### PR DESCRIPTION
Changes:
- Increased size of AND, OR, and XOR gates to double their original size
- Maintained original aspect ratios and proportions
- Note: Connection and anchor point alignments will be addressed in a follow-up PR


BEFORE:
![before](https://github.com/user-attachments/assets/8cdae02b-f697-46b7-a2dd-3cbc5c5d4d76)

AFTER: 
![after](https://github.com/user-attachments/assets/84505fee-cecf-42ca-8e38-8d8c69667fec)
