### PR TITLE
Enlarging connection line width to enhance visual representation

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/WireEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/WireEditPart.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.draw2d.Connection;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.ManhattanConnectionRouter;
+import org.eclipse.draw2d.PolylineConnection;
 import org.eclipse.draw2d.RelativeBendpoint;
 
 import org.eclipse.gef.AccessibleEditPart;
@@ -60,6 +61,7 @@ public class WireEditPart extends AbstractConnectionEditPart implements Property
 		 * its router to change.
 		 */
 		getFigure().addPropertyChangeListener(Connection.PROPERTY_CONNECTION_ROUTER, this);
+		((PolylineConnection) getFigure()).setLineWidth(2);
 	}
 
 	/**

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/WireEndpointEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/WireEndpointEditPolicy.java
@@ -19,7 +19,7 @@ public class WireEndpointEditPolicy extends org.eclipse.gef.editpolicies.Connect
 	@Override
 	protected void addSelectionHandles() {
 		super.addSelectionHandles();
-		getConnectionFigure().setLineWidth(2);
+		getConnectionFigure().setLineWidth(3);
 	}
 
 	protected PolylineConnection getConnectionFigure() {
@@ -29,7 +29,7 @@ public class WireEndpointEditPolicy extends org.eclipse.gef.editpolicies.Connect
 	@Override
 	protected void removeSelectionHandles() {
 		super.removeSelectionHandles();
-		getConnectionFigure().setLineWidth(0);
+		getConnectionFigure().setLineWidth(1);
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/FigureFactory.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/FigureFactory.java
@@ -25,6 +25,7 @@ public class FigureFactory {
 	public static PolylineConnection createNewBendableWire(Wire wire) {
 		PolylineConnection conn = new PolylineConnection();
 		conn.addRoutingListener(RoutingAnimator.getDefault());
+		conn.setLineWidth(2);
 		// conn.setSourceDecoration(new PolygonDecoration());
 		// conn.setTargetDecoration(new PolylineDecoration());
 		return conn;
@@ -34,6 +35,7 @@ public class FigureFactory {
 
 		PolylineConnection conn = new PolylineConnection();
 		conn.addRoutingListener(RoutingAnimator.getDefault());
+		conn.setLineWidth(2);
 		PolygonDecoration arrow;
 
 		if (wire == null || wire.getSource() instanceof SimpleOutput) {
@@ -41,7 +43,7 @@ public class FigureFactory {
 		} else {
 			arrow = new PolygonDecoration();
 			arrow.setTemplate(PolygonDecoration.INVERTED_TRIANGLE_TIP);
-			arrow.setScale(5, 2.5);
+			arrow.setScale(10, 5);
 		}
 		conn.setSourceDecoration(arrow);
 
@@ -50,7 +52,7 @@ public class FigureFactory {
 		} else {
 			arrow = new PolygonDecoration();
 			arrow.setTemplate(PolygonDecoration.INVERTED_TRIANGLE_TIP);
-			arrow.setScale(5, 2.5);
+			arrow.setScale(10, 5);
 		}
 		conn.setTargetDecoration(arrow);
 		return conn;
@@ -61,8 +63,7 @@ public class FigureFactory {
 	}
 
 	public static IFigure createNewCircuit() {
-		CircuitFigure f = new CircuitFigure();
-		return f;
+		return new CircuitFigure();
 	}
 
 }


### PR DESCRIPTION
This PR doubles the connection line width for the logic designer for better readability and aligns with the previous PRs that doubled the elements.

Before:
![connectionWidth_before](https://github.com/user-attachments/assets/fb4f9ead-0a56-417f-b187-70f293b7b50d)

After:
![connectionWidth_after](https://github.com/user-attachments/assets/94e386a8-1633-4522-a277-4e1050700184)
