### PR TITLE
Don't use instanceof for null checks

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransferDropTargetListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransferDropTargetListener.java
@@ -127,10 +127,11 @@ public class TemplateTransferDropTargetListener extends AbstractTransferDropTarg
 		}
 		EditPartViewer viewer = getViewer();
 		viewer.getControl().forceFocus();
-		if (viewer.getEditPartForModel(model) instanceof EditPart ep) {
+		EditPart editPartForModel = viewer.getEditPartForModel(model);
+		if (editPartForModel != null) {
 			// Force a layout first.
 			getViewer().flush();
-			viewer.select(ep);
+			viewer.select(editPartForModel);
 		}
 	}
 


### PR DESCRIPTION
It was a bug in older ecj compiler that allowed to use instanceof patterns in Java 17 code.

Fixes https://github.com/eclipse-gef/gef-classic/issues/664