### PR TITLE
Update all lists of listeners to use CopyOnWriteArrayList

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractImageFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractImageFigure.java
@@ -13,8 +13,8 @@
 
 package org.eclipse.draw2d;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Abstract implementation of the image figure. Implements attaching/detaching
@@ -25,7 +25,7 @@ import java.util.List;
  */
 public abstract class AbstractImageFigure extends Figure implements IImageFigure {
 
-	private final List<ImageChangedListener> imageListeners = new ArrayList<>();
+	private final List<ImageChangedListener> imageListeners = new CopyOnWriteArrayList<>();
 
 	@Override
 	public final void addImageChangedListener(ImageChangedListener listener) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ButtonGroup.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ButtonGroup.java
@@ -16,6 +16,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * A ButtonGroup holds a group of {@link Clickable Clickable's} models and
@@ -32,7 +33,7 @@ public class ButtonGroup {
 	private ButtonModel selectedModel;
 	private ButtonModel defaultModel;
 	private final List<ButtonModel> members = new ArrayList<>();
-	private final List<PropertyChangeListener> listeners = new ArrayList<>();
+	private final List<PropertyChangeListener> listeners = new CopyOnWriteArrayList<>();
 
 	/**
 	 * Constructs a ButtonGroup with no default selection.

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionAnchorBase.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionAnchorBase.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Provides support for a ConnectionAnchor. A ConnectionAnchor is one of the end
@@ -25,7 +25,7 @@ public abstract class ConnectionAnchorBase implements ConnectionAnchor {
 	/**
 	 * The list of listeners
 	 */
-	protected List<AnchorListener> listeners = new ArrayList<>(1);
+	protected List<AnchorListener> listeners = new CopyOnWriteArrayList<>();
 
 	/**
 	 * @see org.eclipse.draw2d.ConnectionAnchor#addAnchorListener(AnchorListener)

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PolylineConnection.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PolylineConnection.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -362,7 +362,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	final class RoutingNotifier implements ConnectionRouter {
 
 		ConnectionRouter realRouter;
-		List<RoutingListener> listeners = new ArrayList<>(1);
+		List<RoutingListener> listeners = new CopyOnWriteArrayList<>();
 
 		RoutingNotifier(ConnectionRouter router, RoutingListener listener) {
 			realRouter = router;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/UpdateManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/UpdateManager.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.draw2d;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.swt.graphics.GC;
 
@@ -45,7 +45,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  */
 public abstract class UpdateManager {
 
-	private final List<UpdateListener> listeners = new ArrayList<>();
+	private final List<UpdateListener> listeners = new CopyOnWriteArrayList<>();
 	private boolean disposed;
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
@@ -14,9 +14,9 @@ package org.eclipse.draw2d.zoom;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.swt.widgets.Display;
 
@@ -54,7 +54,7 @@ public abstract class AbstractZoomManager {
 	/** Style bit meaning animate during {@link #zoomIn()} and {@link #zoomOut()} */
 	public static final int ANIMATE_ZOOM_IN_OUT = 1;
 
-	private final List<ZoomListener> listeners = new ArrayList<>();
+	private final List<ZoomListener> listeners = new CopyOnWriteArrayList<>();
 
 	private double multiplier = 1.0;
 	private final ScalableFigure pane;

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/actions/StyleService.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/actions/StyleService.java
@@ -15,6 +15,7 @@ package org.eclipse.gef.examples.text.actions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * @since 3.1
@@ -25,7 +26,7 @@ public class StyleService {
 	public static final Object STATE_READ_ONLY = new Object();
 	public static final Object UNDEFINED = new Object();
 
-	private List<StyleListener> listeners = new ArrayList<>();
+	private List<StyleListener> listeners = new CopyOnWriteArrayList<>();
 	private StyleProvider provider;
 	private StyleListener providerListener = StyleService.this::propogateChange;
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
@@ -14,8 +14,8 @@ package org.eclipse.gef.ui.palette;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.FocusEvent;
@@ -91,7 +91,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	private PaletteCustomizer customizer = null;
 	private PaletteCustomizerDialog customizerDialog = null;
 	private boolean globalScrollbar = false;
-	private final List<PaletteListener> paletteListeners = new ArrayList<>();
+	private final List<PaletteListener> paletteListeners = new CopyOnWriteArrayList<>();
 	private PaletteRoot paletteRoot = null;
 	private final PreferenceListener prefListener = new PreferenceListener();
 	private PaletteViewerPreferences prefs = PREFERENCE_STORE;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DragSource;
@@ -31,7 +32,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
@@ -83,7 +83,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * @deprecated
 	 */
 	@Deprecated
-	protected ListenerList<ISelectionChangedListener> selectionListeners = new ListenerList<>();
+	protected List<ISelectionChangedListener> selectionListeners = new CopyOnWriteArrayList<>();
 
 	/**
 	 * The editpart specifically set to have focus. Note that if this value is

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
@@ -12,8 +12,8 @@
  ******************************************************************************/
 package org.eclipse.zest.core.viewers;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
@@ -92,7 +92,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	protected void hookControl(Control control) {
 		super.hookControl(control);
 
-		selectionChangedListeners = new ArrayList<>();
+		selectionChangedListeners = new CopyOnWriteArrayList<>();
 		getGraphControl().addSelectionListener(new SelectionAdapter() {
 
 			@Override

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ControlAdapter;
@@ -113,7 +114,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	Set<IFigure> subgraphFigures;
 	private HideNodeHelper hoverNode = null;
 	IFigure fisheyedFigure = null;
-	private final List<FisheyeListener> fisheyeListeners = new ArrayList<>();
+	private final List<FisheyeListener> fisheyeListeners = new CopyOnWriteArrayList<>();
 	private List<SelectionListener> selectionListeners = null;
 
 	/** This maps all visible nodes to their model element. */
@@ -231,7 +232,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 		this.connections = new ArrayList<>();
 		this.constraintAdapters = new ArrayList<>();
 		this.selectedItems = new ArrayList<>();
-		this.selectionListeners = new ArrayList<>();
+		this.selectionListeners = new CopyOnWriteArrayList<>();
 		this.figure2ItemMap = new HashMap<>();
 		this.enableHideNodes = enableHideNodes;
 		this.subgraphFigures = new HashSet<>();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/HideNodeHelper.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/HideNodeHelper.java
@@ -10,8 +10,8 @@
 
 package org.eclipse.zest.core.widgets;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.zest.core.widgets.internal.ContainerFigure;
 import org.eclipse.zest.core.widgets.internal.GraphLabel;
@@ -39,7 +39,7 @@ public class HideNodeHelper extends ContainerFigure {
 	private final GraphLabel hiddenNodesLabel = new GraphLabel("0", false); //$NON-NLS-1$
 
 	private final HideNodeListener thisHideNodeListener;
-	private final List<HideNodeListener> hideNodeListeners = new ArrayList<>();
+	private final List<HideNodeListener> hideNodeListeners = new CopyOnWriteArrayList<>();
 
 	/**
 	 * Create a HideNodeHelper and add it to the node's nodeFigure

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalLayoutContext.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalLayoutContext.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.zest.layouts.LayoutAlgorithm;
 import org.eclipse.zest.layouts.dataStructures.DisplayIndependentRectangle;
@@ -37,10 +38,10 @@ class InternalLayoutContext implements LayoutContext {
 
 	final IContainer2 container;
 	private final List<LayoutFilter> filters = new ArrayList<>();
-	private final List<ContextListener> contextListeners = new ArrayList<>();
-	private final List<GraphStructureListener> graphStructureListeners = new ArrayList<>();
-	private final List<LayoutListener> layoutListeners = new ArrayList<>();
-	private final List<PruningListener> pruningListeners = new ArrayList<>();
+	private final List<ContextListener> contextListeners = new CopyOnWriteArrayList<>();
+	private final List<GraphStructureListener> graphStructureListeners = new CopyOnWriteArrayList<>();
+	private final List<LayoutListener> layoutListeners = new CopyOnWriteArrayList<>();
+	private final List<PruningListener> pruningListeners = new CopyOnWriteArrayList<>();
 	private LayoutAlgorithm mainAlgorithm;
 	private LayoutAlgorithm layoutAlgorithm;
 	private ExpandCollapseManager expandCollapseManager;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
@@ -19,6 +19,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.zest.layouts.Filter;
 import org.eclipse.zest.layouts.InvalidLayoutConfiguration;
@@ -74,7 +75,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		private Thread creationThread = null;
 		protected Comparator comparator;
 		protected Filter filter;
-		private final List<ProgressListener> progressListeners = new ArrayList<>();
+		private final List<ProgressListener> progressListeners = new CopyOnWriteArrayList<>();
 		private Calendar lastProgressEventFired;
 		private double widthToHeightRatio;
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/TreeLayoutObserver.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/TreeLayoutObserver.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.zest.layouts.interfaces.ConnectionLayout;
 import org.eclipse.zest.layouts.interfaces.GraphStructureListener;
@@ -409,7 +410,7 @@ public class TreeLayoutObserver {
 	private final TreeNodeFactory factory;
 	private final LayoutContext context;
 	private TreeNode superRoot;
-	private final List<TreeListener> treeListeners = new ArrayList<>();
+	private final List<TreeListener> treeListeners = new CopyOnWriteArrayList<>();
 
 	/**
 	 * Creates a


### PR DESCRIPTION
This changes the list of listeners to a thread-safe implementation to avoid the ConcurrentModificationException when modifying this list while in the middle of handling an event.

Note that this also adapts 71f0c56301033bcf5ff5ba1261cdc2719d9bb391, in which the List of ISelectionChangedListeners was changed to a ListenerList, thus breaking API on the protected field.