### PR TITLE
Deprecate transfer listeners for removal

### DIFF
--- a/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/ui/FlowEditor.java
+++ b/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/ui/FlowEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2024 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,6 +31,8 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
+import org.eclipse.jface.util.TransferDragSourceListener;
+import org.eclipse.jface.util.TransferDropTargetListener;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
@@ -136,7 +138,8 @@ public class FlowEditor extends GraphicalEditorWithPalette {
 	@Override
 	protected void initializeGraphicalViewer() {
 		getGraphicalViewer().setContents(diagram);
-		getGraphicalViewer().addDropTargetListener(new TemplateTransferDropTargetListener(getGraphicalViewer()));
+		getGraphicalViewer().addDropTargetListener(
+				(TransferDropTargetListener) new TemplateTransferDropTargetListener(getGraphicalViewer()));
 
 	}
 
@@ -146,7 +149,8 @@ public class FlowEditor extends GraphicalEditorWithPalette {
 	@Override
 	protected void initializePaletteViewer() {
 		super.initializePaletteViewer();
-		getPaletteViewer().addDragSourceListener(new TemplateTransferDragSourceListener(getPaletteViewer()));
+		getPaletteViewer().addDragSourceListener(
+				(TransferDragSourceListener) new TemplateTransferDragSourceListener(getPaletteViewer()));
 	}
 
 	/**

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/LogicEditor.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/LogicEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -55,6 +55,7 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.util.SafeRunnable;
+import org.eclipse.jface.util.TransferDragSourceListener;
 import org.eclipse.jface.util.TransferDropTargetListener;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IEditorInput;
@@ -512,7 +513,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 			protected void configurePaletteViewer(PaletteViewer viewer) {
 				super.configurePaletteViewer(viewer);
 				viewer.setCustomizer(new LogicPaletteCustomizer());
-				viewer.addDragSourceListener(new TemplateTransferDragSourceListener(viewer));
+				viewer.addDragSourceListener(
+						(TransferDragSourceListener) new TemplateTransferDragSourceListener(viewer));
 			}
 
 			@Override

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditor.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2024 Elias Volanakis and others.
+ * Copyright (c) 2004, 2025 Elias Volanakis and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,6 +31,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
+import org.eclipse.jface.util.TransferDragSourceListener;
 import org.eclipse.jface.util.TransferDropTargetListener;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IEditorInput;
@@ -147,7 +148,8 @@ public class ShapesEditor extends GraphicalEditorWithFlyoutPalette {
 				// CombinatedTemplateCreationEntries
 				// from the palette into the editor
 				// @see ShapesEditor#createTransferDropTargetListener()
-				viewer.addDragSourceListener(new TemplateTransferDragSourceListener(viewer));
+				viewer.addDragSourceListener(
+						(TransferDragSourceListener) new TemplateTransferDragSourceListener(viewer));
 			}
 		};
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -100,7 +100,10 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 *
 	 * @param listener a drag source listener
 	 * @see #addDragSourceListener(TransferDragSourceListener)
+	 * @deprecated Use {@link #addDragSourceListener(TransferDragSourceListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@Deprecated(since = "3.21", forRemoval = true)
 	void addDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener listener);
 
 	/**
@@ -118,7 +121,10 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 *
 	 * @param listener the listener
 	 * @see #addDropTargetListener(TransferDropTargetListener)
+	 * @deprecated Use {@link #addDragSourceListener(TransferDragSourceListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@Deprecated(since = "3.21", forRemoval = true)
 	void addDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener listener);
 
 	/**
@@ -428,9 +434,10 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 *
 	 * @see #addDragSourceListener(TransferDragSourceListener)
 	 * @param listener the listener
-	 * @deprecated
+	 * @deprecated Use {@link #removeDragSourceListener(TransferDragSourceListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.0", forRemoval = true)
 	void removeDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener listener);
 
 	/**
@@ -448,9 +455,10 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 *
 	 * @see #addDropTargetListener(TransferDropTargetListener)
 	 * @param listener
-	 * @deprecated
+	 * @deprecated Use {@link #removeDropTargetListener(TransferDropTargetListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.0", forRemoval = true)
 	void removeDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener listener);
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/AbstractTransferDragSourceListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/AbstractTransferDragSourceListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,13 +15,17 @@ package org.eclipse.gef.dnd;
 import org.eclipse.swt.dnd.DragSourceEvent;
 import org.eclipse.swt.dnd.Transfer;
 
+import org.eclipse.jface.util.TransferDragSourceListener;
+
 import org.eclipse.gef.EditPartViewer;
 
 /**
  * An abstract implementation of <code>TransferDragSourceListener</code>
  * associated with an {@link EditPartViewer}
  */
-public abstract class AbstractTransferDragSourceListener implements TransferDragSourceListener {
+@SuppressWarnings("removal")
+public abstract class AbstractTransferDragSourceListener
+		implements TransferDragSourceListener, org.eclipse.gef.dnd.TransferDragSourceListener {
 
 	private EditPartViewer viewer;
 	private Transfer transfer;

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/AbstractTransferDropTargetListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/AbstractTransferDropTargetListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,6 +24,8 @@ import org.eclipse.swt.dnd.DropTargetListener;
 import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.dnd.TransferData;
 
+import org.eclipse.jface.util.TransferDropTargetListener;
+
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
@@ -45,7 +47,9 @@ import org.eclipse.gef.commands.Command;
  * behavior, such as interacting with the target EditPart or its ancestors to
  * achieve things like auto-scroll/auto-expose.
  */
-public abstract class AbstractTransferDropTargetListener implements TransferDropTargetListener {
+@SuppressWarnings("removal")
+public abstract class AbstractTransferDropTargetListener
+		implements TransferDropTargetListener, org.eclipse.gef.dnd.TransferDropTargetListener {
 
 	private DropTargetEvent currentEvent;
 	private AutoexposeHelper exposeHelper;

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/DelegatingDragAdapter.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/DelegatingDragAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -46,8 +46,11 @@ public class DelegatingDragAdapter extends org.eclipse.jface.util.DelegatingDrag
 	 * updated to reflect the change.
 	 *
 	 * @param listener the new listener
-	 * @deprecated
+	 * @deprecated Use
+	 *             {@link #addDragSourceListener(org.eclipse.jface.util.TransferDragSourceListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@Deprecated(since = "3.0", forRemoval = true)
 	public void addDragSourceListener(TransferDragSourceListener listener) {
 		super.addDragSourceListener(listener);
 	}
@@ -56,8 +59,10 @@ public class DelegatingDragAdapter extends org.eclipse.jface.util.DelegatingDrag
 	 * Combines the <code>Transfer</code>s from every TransferDragSourceListener.
 	 *
 	 * @return the combined <code>Transfer</code>s
-	 * @deprecated call getTransfers() instead.
+	 * @deprecated call getTransfers() instead. This method will be removed after
+	 *             the 2027-03 release.
 	 */
+	@Deprecated(since = "3.0", forRemoval = true)
 	public Transfer[] getTransferTypes() {
 		return super.getTransfers();
 	}
@@ -67,8 +72,11 @@ public class DelegatingDragAdapter extends org.eclipse.jface.util.DelegatingDrag
 	 * updated to reflect the change.
 	 *
 	 * @param listener the listener being removed
-	 * @deprecated
+	 * @deprecated Use
+	 *             {@link #removeDragSourceListener(org.eclipse.jface.util.TransferDragSourceListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@Deprecated(since = "3.0", forRemoval = true)
 	public void removeDragSourceListener(TransferDragSourceListener listener) {
 		super.removeDragSourceListener(listener);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/DelegatingDropAdapter.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/DelegatingDropAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,8 +39,11 @@ public class DelegatingDropAdapter extends org.eclipse.jface.util.DelegatingDrop
 	 * Adds the given TransferDropTargetListener.
 	 *
 	 * @param listener the listener
-	 * @deprecated
+	 * @deprecated Use
+	 *             {@link #addDropTargetListener(org.eclipse.jface.util.TransferDropTargetListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@Deprecated(since = "3.0", forRemoval = true)
 	public void addDropTargetListener(TransferDropTargetListener listener) {
 		super.addDropTargetListener(listener);
 	}
@@ -51,6 +54,7 @@ public class DelegatingDropAdapter extends org.eclipse.jface.util.DelegatingDrop
 	 * @return the merged Transfers from all listeners
 	 * @deprecated use getTransfers() instead
 	 */
+	@Deprecated(since = "3.0", forRemoval = true)
 	public Transfer[] getTransferTypes() {
 		return super.getTransfers();
 	}
@@ -59,7 +63,11 @@ public class DelegatingDropAdapter extends org.eclipse.jface.util.DelegatingDrop
 	 * Removes the given <code>TransferDropTargetListener</code>.
 	 *
 	 * @param listener the listener
+	 * @deprecated Use
+	 *             {@link #removeDropTargetListener(org.eclipse.jface.util.TransferDropTargetListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@Deprecated(since = "3.21", forRemoval = true)
 	public void removeDropTargetListener(TransferDropTargetListener listener) {
 		super.removeDropTargetListener(listener);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransferDragSourceListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransferDragSourceListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -33,11 +33,12 @@ import org.eclipse.gef.palette.PaletteTemplateEntry;
 public class TemplateTransferDragSourceListener extends AbstractTransferDragSourceListener {
 
 	/**
-	 * @deprecated Use the constructor without the transfer specified.
+	 * @deprecated Use the constructor without the transfer specified. This
+	 *             constructor will be removed after the 2027-03 release.
 	 * @param viewer viewer
 	 * @param xfer   xfer
 	 */
-	@Deprecated
+	@Deprecated(since = "3.0", forRemoval = true)
 	public TemplateTransferDragSourceListener(EditPartViewer viewer, Transfer xfer) {
 		super(viewer, xfer);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/TransferDragSourceListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/TransferDragSourceListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -29,6 +29,7 @@ import org.eclipse.swt.dnd.Transfer;
  *
  * @deprecated use org.eclipse.jface.util.TransferDragSourceListener instead
  */
+@Deprecated(since = "3.21", forRemoval = true)
 public interface TransferDragSourceListener extends org.eclipse.jface.util.TransferDragSourceListener {
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/TransferDropTargetListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/TransferDropTargetListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,6 +30,7 @@ import org.eclipse.swt.dnd.Transfer;
  *
  * @deprecated use org.eclipse.jface.util.TransferDropTargetListener instead
  */
+@Deprecated(since = "3.21", forRemoval = true)
 public interface TransferDropTargetListener extends org.eclipse.jface.util.TransferDropTargetListener {
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -141,8 +141,11 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 
 	/**
 	 * @see EditPartViewer#addDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener)
+	 * @deprecated Use {@link #addDragSourceListener(TransferDragSourceListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
 	@Override
+	@Deprecated(since = "3.21", forRemoval = true)
 	public void addDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener listener) {
 		addDragSourceListener((TransferDragSourceListener) listener);
 	}
@@ -158,8 +161,11 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 
 	/**
 	 * @see EditPartViewer#addDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener)
+	 * @deprecated Use {@link #addDropTargetListener(TransferDropTargetListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
 	@Override
+	@Deprecated(since = "3.21", forRemoval = true)
 	public void addDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener listener) {
 		addDropTargetListener((TransferDropTargetListener) listener);
 	}
@@ -562,9 +568,10 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 
 	/**
 	 * @see EditPartViewer#removeDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener)
-	 * @deprecated
+	 * @deprecated Use {@link #removeDragSourceListener(TransferDragSourceListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.0", forRemoval = true)
 	@Override
 	public void removeDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener listener) {
 		removeDragSourceListener((TransferDragSourceListener) listener);
@@ -583,9 +590,10 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 
 	/**
 	 * @see EditPartViewer#removeDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener)
-	 * @deprecated
+	 * @deprecated Use {@link #removeDropTargetListener(TransferDropTargetListener)}
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.0", forRemoval = true)
 	@Override
 	public void removeDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener listener) {
 		removeDropTargetListener((TransferDropTargetListener) listener);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,6 +31,8 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 
+import org.eclipse.jface.util.TransferDragSourceListener;
+import org.eclipse.jface.util.TransferDropTargetListener;
 import org.eclipse.jface.viewers.StructuredSelection;
 
 import org.eclipse.draw2d.geometry.Point;
@@ -122,8 +124,8 @@ public class TreeViewer extends AbstractEditPartViewer {
 		dispatcher = new EventDispatcher();
 		RootTreeEditPart rep = new RootTreeEditPart();
 		setRootEditPart(rep);
-		addDragSourceListener(new TreeViewerTransferDragListener(this));
-		addDropTargetListener(new TreeViewerTransferDropListener(this));
+		addDragSourceListener((TransferDragSourceListener) new TreeViewerTransferDragListener(this));
+		addDropTargetListener((TransferDropTargetListener) new TreeViewerTransferDropListener(this));
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDragListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDragListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -32,9 +32,10 @@ class TreeViewerTransferDragListener extends AbstractTransferDragSourceListener 
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated Use the constructor without the transfer specified. This
+	 *             constructor will be removed after the 2027-03 release.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.0", forRemoval = true)
 	public TreeViewerTransferDragListener(EditPartViewer viewer, Transfer xfer) {
 		super(viewer, xfer);
 	}


### PR DESCRIPTION
The TransferDragSourceListener and TransferDropTargetListener are effecitively equivalent to their JFace counterpart and should be used instead.