### PR TITLE
Deprecate CommandStackListener for removal

### DIFF
--- a/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/ui/FlowEditor.java
+++ b/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/ui/FlowEditor.java
@@ -19,7 +19,6 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-import java.util.EventObject;
 
 import org.eclipse.swt.SWT;
 
@@ -46,6 +45,8 @@ import org.eclipse.gef.ContextMenuProvider;
 import org.eclipse.gef.DefaultEditDomain;
 import org.eclipse.gef.KeyHandler;
 import org.eclipse.gef.KeyStroke;
+import org.eclipse.gef.commands.CommandStackEvent;
+import org.eclipse.gef.commands.CommandStackEventListener;
 import org.eclipse.gef.dnd.TemplateTransferDragSourceListener;
 import org.eclipse.gef.dnd.TemplateTransferDropTargetListener;
 import org.eclipse.gef.editparts.ScalableRootEditPart;
@@ -77,12 +78,14 @@ public class FlowEditor extends GraphicalEditorWithPalette {
 	}
 
 	/**
-	 * @see org.eclipse.gef.commands.CommandStackListener#commandStackChanged(java.util.EventObject)
+	 * @see CommandStackEventListener#stackChanged(CommandStackEvent event)
 	 */
 	@Override
-	public void commandStackChanged(EventObject event) {
-		firePropertyChange(IEditorPart.PROP_DIRTY);
-		super.commandStackChanged(event);
+	public void stackChanged(CommandStackEvent event) {
+		if (event.isPostChangeEvent()) {
+			firePropertyChange(IEditorPart.PROP_DIRTY);
+		}
+		super.stackChanged(event);
 	}
 
 	/**

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
@@ -159,7 +159,7 @@ public class CommandStackTest {
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
+	@SuppressWarnings({ "static-method", "removal" })
 	public void testConcurrentModification2() {
 		CommandStack stack = new CommandStack();
 		CommandStackListener listener = new CommandStackListener() {

--- a/org.eclipse.gef/src/org/eclipse/gef/commands/CommandStack.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/commands/CommandStack.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -132,9 +132,10 @@ public class CommandStack {
 	 * The list of {@link CommandStackListener}s.
 	 *
 	 * @deprecated This field should not be referenced, use
-	 *             {@link #notifyListeners()}
+	 *             {@link #notifyListeners()}. This field will be removed after the
+	 *             2027-03 release.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.11", forRemoval = true)
 	protected List<CommandStackListener> listeners = new CopyOnWriteArrayList<>();
 
 	private final Stack<Command> redoable = new Stack<>();
@@ -170,9 +171,9 @@ public class CommandStack {
 	 * @param listener the listener
 	 * @deprecated Use
 	 *             {@link #addCommandStackEventListener(CommandStackEventListener)}
-	 *             instead.
+	 *             instead. This method will be removed after the 2027-03 release.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.11", forRemoval = true)
 	public void addCommandStackListener(CommandStackListener listener) {
 		listeners.add(listener);
 	}
@@ -342,9 +343,10 @@ public class CommandStack {
 	/**
 	 * Sends notification to all {@link CommandStackListener}s.
 	 *
-	 * @deprecated Use {@link #notifyListeners(Command, int)} instead.
+	 * @deprecated Use {@link #notifyListeners(Command, int)} instead. This method
+	 *             will be removed after the 2027-03 release.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.11", forRemoval = true)
 	protected void notifyListeners() {
 		EventObject event = new EventObject(this);
 		listeners.forEach(listener -> listener.commandStackChanged(event));
@@ -397,9 +399,10 @@ public class CommandStack {
 	 * Removes the first occurrence of the specified listener.
 	 *
 	 * @param listener the listener
-	 * @deprecated Use {@link CommandStackEventListener} instead.
+	 * @deprecated Use {@link CommandStackEventListener} instead. This method will
+	 *             be removed after the 2027-03 release.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.11", forRemoval = true)
 	public void removeCommandStackListener(CommandStackListener listener) {
 		listeners.remove(listener);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/commands/CommandStackListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/commands/CommandStackListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,8 +19,10 @@ import java.util.EventObject;
  * has changed.
  *
  * @deprecated Use {@link CommandStackEventListener} instead and filter for
- *             post-events using {@link CommandStack#POST_MASK}.
+ *             post-events using {@link CommandStack#POST_MASK}. This interface
+ *             will be removed after the 2027-03 release.
  */
+@Deprecated(since = "3.11", forRemoval = true)
 public interface CommandStackListener {
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditor.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -38,6 +38,8 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.commands.CommandStack;
+import org.eclipse.gef.commands.CommandStackEvent;
+import org.eclipse.gef.commands.CommandStackEventListener;
 import org.eclipse.gef.commands.CommandStackListener;
 import org.eclipse.gef.ui.actions.ActionBarContributor;
 import org.eclipse.gef.ui.actions.ActionRegistry;
@@ -60,7 +62,9 @@ import org.eclipse.gef.ui.properties.UndoablePropertySheetPage;
  *
  * @author hudsonr
  */
-public abstract class GraphicalEditor extends EditorPart implements CommandStackListener, ISelectionListener {
+@SuppressWarnings("removal")
+public abstract class GraphicalEditor extends EditorPart
+		implements CommandStackListener, CommandStackEventListener, ISelectionListener {
 
 	private DefaultEditDomain editDomain;
 	private GraphicalViewer graphicalViewer;
@@ -81,10 +85,26 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	 * are updated.
 	 *
 	 * @param event the change event
+	 * @deprecated Use {@link #stackChanged(CommandStackEvent)} instead. This method
+	 *             will be removed after the 2027-03 release.
 	 */
 	@Override
+	@Deprecated(since = "3.21", forRemoval = true)
 	public void commandStackChanged(EventObject event) {
 		updateActions(stackActions);
+	}
+
+	/**
+	 * When the command stack changes, the actions interested in the command stack
+	 * are updated.
+	 *
+	 * @param event the change event
+	 */
+	@Override
+	public void stackChanged(CommandStackEvent event) {
+		if (event.isPostChangeEvent()) {
+			commandStackChanged(event);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This interface has been deprecated a long time ago in favor of the CommandStackEventListener.