### PR TITLE
Remove deprecation from getDistanceOrthogonal #21

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointTests.java
@@ -198,7 +198,7 @@ public class PointTests extends BaseTestCase {
 		assertEquals(5, new Point(-1, -2).getDistance(new Point(-5, 1)), 0);
 	}
 
-	@SuppressWarnings({ "static-method", "removal" })
+	@SuppressWarnings("static-method")
 	@Test
 	public void testGetDistanceOrthogonal() {
 		assertEquals(53, new Point(10, 20).getDistanceOrthogonal(new Point(51, 32)));

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
@@ -230,11 +230,7 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	 *
 	 * @param p The reference Point
 	 * @return the orthogonal distance
-	 * @noreference This method is not intended to be referenced by clients.
-	 * @deprecated May not be guaranteed by precision subclasses and should thus not
-	 *             be used any more.
 	 */
-	@Deprecated(since = "3.7", forRemoval = true)
 	public int getDistanceOrthogonal(Point p) {
 		return Math.abs(y - p.y()) + Math.abs(x - p.x());
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
@@ -113,6 +113,23 @@ public class PrecisionPoint extends Point {
 	}
 
 	/**
+	 * provide a precision version of
+	 * org.eclipse.draw2d.geometry.Point#getDistanceSquared(org.eclipse.draw2d.geometry.Point)
+	 *
+	 * @since 3.19
+	 */
+	@Override
+	public int getDistanceSquared(Point p) {
+		double deltaX = p.preciseX() - this.preciseX();
+		double deltaY = p.preciseX() - this.preciseX();
+		long result = (long) (deltaX * deltaX + deltaY * deltaY);
+		if (result > Integer.MAX_VALUE) {
+			return Integer.MAX_VALUE;
+		}
+		return (int) result;
+	}
+
+	/**
 	 * Returns a precise copy of this.
 	 *
 	 * @return a precise copy

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
@@ -43,7 +43,6 @@ public class PrecisionPoint extends Point {
 	 * Constructor for PrecisionPoint.
 	 */
 	public PrecisionPoint() {
-		super();
 	}
 
 	/**
@@ -100,6 +99,17 @@ public class PrecisionPoint extends Point {
 	@Override
 	public Dimension getDifference(Point p) {
 		return new PrecisionDimension(this.preciseX() - p.preciseX(), this.preciseY() - p.preciseY());
+	}
+
+	/**
+	 * provide a precision version of
+	 * org.eclipse.draw2d.geometry.Point#getDistanceOrthogonal(org.eclipse.draw2d.geometry.Point)
+	 *
+	 * @since 3.19
+	 */
+	@Override
+	public int getDistanceOrthogonal(Point p) {
+		return (int) (Math.abs(this.preciseX() - p.preciseX()) + Math.abs(this.preciseY() - p.preciseY()));
 	}
 
 	/**


### PR DESCRIPTION
getDistanceOrthogonal is used in several places in GEF. There is no straight forward replacement. To reason for deprecation is precision of subclasses. As there is only one subclass with higher precision an improved version of that method is added there. Furthermore the impact on precision will anyhow only happen if both sides are PrecisionPoints.

https://github.com/eclipse-gef/gef-classic/issues/21