### PR TITLE
Center LED text in display and adjust font size

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFigure.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
+import static org.eclipse.draw2d.FigureUtilities.getTextExtents;
+
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 
@@ -43,13 +45,15 @@ public class LEDFigure extends NodeFigure implements HandleBounds {
 	 */
 	public static final Color DISPLAY_TEXT = new Color(null, 255, 199, 16);
 
-	protected static final Font DISPLAY_FONT = new Font(null, "", 38, 0); //$NON-NLS-1$
+	protected static final Font DISPLAY_FONT = new Font(null, "", 23, 0); //$NON-NLS-1$
 	protected static PointList connector = new PointList();
 	protected static PointList bottomConnector = new PointList();
 	protected static Rectangle displayRectangle = new Rectangle(30, 22, 62, 50);
 	protected static Rectangle displayShadow = new Rectangle(28, 20, 64, 52);
 	protected static Rectangle displayHighlight = new Rectangle(30, 22, 64, 52);
 	protected static Point valuePoint = new Point(32, 20);
+	private static final int HORIZONTAL_PADDING = 3;
+	private static final int VERTICAL_OFFSET = -1;
 
 	static {
 		connector.addPoint(-4, 0);
@@ -181,10 +185,16 @@ public class LEDFigure extends NodeFigure implements HandleBounds {
 		g.setBackgroundColor(ColorConstants.black);
 		g.fillRectangle(displayRectangle);
 
+		// Calculate centered position within display inlcuding padding
+		Dimension textExtents = getTextExtents(value, DISPLAY_FONT);
+		int x = displayRectangle.x + HORIZONTAL_PADDING
+				+ ((displayRectangle.width - 2 * HORIZONTAL_PADDING) - textExtents.width) / 2;
+		int y = displayRectangle.y + (displayRectangle.height - textExtents.height) / 2 + VERTICAL_OFFSET;
+
 		// Draw the value
 		g.setFont(DISPLAY_FONT);
 		g.setForegroundColor(DISPLAY_TEXT);
-		g.drawText(value, valuePoint);
+		g.drawText(value, new Point(x, y));
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses two issues with the LED text display:

- **Misaligned text**: Introduced dynamic positioning (including  padding and offset constants) to ensure the text is centered within the display rectangle. 
- **Oversized font**: Reduced the font size from 38 to 23 to ensure the displayed number does not appear too large.

Before: (on 3840x2160 resolution, 150%scaling, Windows)
![2025-01-19 13_29_39-runtime-EclipseApplication(1) - test_fourBitAdder21 logic - Eclipse IDE](https://github.com/user-attachments/assets/4e0c9710-ce17-499c-966e-4994b5a517a0)


After:
![2025-01-19 14_41_26-runtime-EclipseApplication(1) - test_fourBitAdder21 logic - Eclipse IDE](https://github.com/user-attachments/assets/89ee13c7-869f-4313-b848-325bab70e4ab)
