### PR TITLE
Modernize Gate Figures (AND, OR, XOR)

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
@@ -28,6 +28,8 @@ public class AndGateFigure extends GateFigure {
 	 */
 	public AndGateFigure() {
 		setBackgroundColor(LogicColorConstants.andGate);
+
+		setForegroundColor(LogicColorConstants.outlineColor);
 	}
 
 	/**
@@ -47,17 +49,19 @@ public class AndGateFigure extends GateFigure {
 		r.translate(4, 4);
 		r.setSize(22, 18);
 
+		g.setLineWidth(2);
+
 		// Draw terminals, 2 at top
 		g.drawLine(r.x + 4, r.y, r.x + 4, r.y - 4);
 		g.drawLine(r.right() - 6, r.y, r.right() - 6, r.y - 4);
 
 		// draw main area
-		g.fillRectangle(r);
+		g.fillRoundRectangle(r, 5, 5);
 
 		// outline main area
-		g.drawLine(r.x, r.y, r.right() - 1, r.y);
-		g.drawLine(r.right() - 1, r.y, r.right() - 1, r.bottom() - 1);
-		g.drawLine(r.x, r.y, r.x, r.bottom() - 1);
+		Rectangle outlineRect = r.getCopy();
+		outlineRect.width--;
+		g.drawRoundRectangle(outlineRect, 5, 5);
 
 		// draw and outline the arc
 		r.height = 18;
@@ -65,7 +69,7 @@ public class AndGateFigure extends GateFigure {
 		g.fillArc(r, 180, 180);
 		r.width--;
 		r.height--;
-		g.drawArc(r, 180, 190);
+		g.drawArc(r, 180, 180);
 		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicColorConstants.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicColorConstants.java
@@ -16,9 +16,10 @@ import org.eclipse.swt.graphics.Color;
 
 public interface LogicColorConstants {
 
-	public final static Color andGate = new Color(null, 220, 70, 80);
-	public final static Color orGate = new Color(null, 0, 134, 255);
-	public final static Color xorGate = new Color(null, 240, 240, 40);
+	public final static Color andGate = new Color(null, 204, 61, 61);
+	public final static Color orGate = new Color(null, 41, 121, 255);
+	public final static Color xorGate = new Color(null, 255, 204, 0);
+	public static final Color outlineColor = new Color(null, 64, 64, 64);
 	public final static Color logicGreen = new Color(null, 123, 174, 148);
 	public final static Color logicHighlight = new Color(null, 66, 166, 115);
 	public final static Color connectorGreen = new Color(null, 0, 69, 40);

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicColorConstants.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicColorConstants.java
@@ -16,14 +16,14 @@ import org.eclipse.swt.graphics.Color;
 
 public interface LogicColorConstants {
 
-	public final static Color andGate = new Color(null, 204, 61, 61);
-	public final static Color orGate = new Color(null, 41, 121, 255);
-	public final static Color xorGate = new Color(null, 255, 204, 0);
-	public static final Color outlineColor = new Color(null, 64, 64, 64);
-	public final static Color logicGreen = new Color(null, 123, 174, 148);
-	public final static Color logicHighlight = new Color(null, 66, 166, 115);
-	public final static Color connectorGreen = new Color(null, 0, 69, 40);
-	public final static Color logicBackgroundBlue = new Color(null, 200, 200, 240);
-	public final static Color ghostFillColor = new Color(null, 31, 31, 31);
+	public final static Color andGate = new Color(204, 61, 61);
+	public final static Color orGate = new Color(41, 121, 255);
+	public final static Color xorGate = new Color(255, 204, 0);
+	public static final Color outlineColor = new Color(64, 64, 64);
+	public final static Color logicGreen = new Color(123, 174, 148);
+	public final static Color logicHighlight = new Color(66, 166, 115);
+	public final static Color connectorGreen = new Color(0, 69, 40);
+	public final static Color logicBackgroundBlue = new Color(200, 200, 240);
+	public final static Color ghostFillColor = new Color(31, 31, 31);
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
@@ -41,6 +41,7 @@ public class OrGateFigure extends GateFigure {
 	 */
 	public OrGateFigure() {
 		setBackgroundColor(LogicColorConstants.orGate);
+		setForegroundColor(LogicColorConstants.outlineColor);
 	}
 
 	/**
@@ -60,6 +61,8 @@ public class OrGateFigure extends GateFigure {
 		r.translate(4, 4);
 		r.setSize(22, 18);
 
+		g.setLineWidth(2);
+
 		// Draw terminals, 2 at top
 		g.drawLine(r.x + 4, r.y + 4, r.x + 4, r.y - 4);
 		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
@@ -67,11 +70,11 @@ public class OrGateFigure extends GateFigure {
 		// Draw the bottom arc of the gate
 		r.y += 8;
 
-		r.width--;
-		r.height--;
+		r.x -= 1;
 		g.fillOval(r);
-		r.width--;
+		r.width -= 2;
 		r.height--;
+		r.x++;
 
 		g.drawOval(r);
 		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
@@ -53,6 +53,7 @@ public class XOrGateFigure extends GateFigure {
 	 */
 	public XOrGateFigure() {
 		setBackgroundColor(LogicColorConstants.xorGate);
+		setForegroundColor(LogicColorConstants.outlineColor);
 	}
 
 	/**
@@ -72,6 +73,8 @@ public class XOrGateFigure extends GateFigure {
 		r.translate(4, 4);
 		r.setSize(22, 18);
 
+		g.setLineWidth(2);
+
 		// Draw terminals, 2 at top
 		g.drawLine(r.x + 4, r.y + 4, r.x + 4, r.y - 4);
 		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
@@ -84,13 +87,13 @@ public class XOrGateFigure extends GateFigure {
 		 * top arc of the gate, so this region is clipped.
 		 */
 		g.pushState();
-		r.y += 2;
-		g.clipRect(r);
-		r.y--;
-		r.width--;
-		r.height--;
+		Rectangle clipRect = r.getCopy();
+		clipRect.x -= 2;
+		clipRect.width += 2;
+		clipRect.y = r.y + 6;
+		g.clipRect(clipRect);
 		g.fillOval(r);
-		r.width--;
+		r.width -= 2;
 		r.height--;
 		g.drawOval(r);
 		g.popState();


### PR DESCRIPTION
This PR proposes a more modern design for the gates of the logic designer:
- Introduced thicker outlines for improved clarity.
- Added a new shared outline color (dark gray) to replace the monotone black color.
- Rounded edges in the AND gate for a softer and modernized appearance.
- Updated colors: The AND gate uses a soft red, the OR gate azure blue and the XOR gate a more vibrant yellow.
- Adjusted offsets, and clipping logic due to the new line width.

Follow-up PRs will be: 
- modern design of the reamining components 
- adjustment of the corresponding feedback figures 

Before:
![gates - before](https://github.com/user-attachments/assets/1f43e85b-ba0e-46eb-bac3-480debe99cf0)

After:
![gates -after](https://github.com/user-attachments/assets/956479fc-d9df-4261-b68d-5e990af4c775)
