### PR TITLE
Update license header for remaining examples from CPL to EPL-2

### DIFF
--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/text/BidiBlockExample.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/text/BidiBlockExample.java
@@ -1,12 +1,15 @@
-/*****************************************************************************************
- * Copyright (c) 2004, 2023 IBM Corporation and others. All rights reserved. This program and
- * the accompanying materials are made available under the terms of the Common Public
- * License v1.0 which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/cpl-v10.html
+/*******************************************************************************
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
- * Contributors: IBM Corporation - initial API and implementation
- ****************************************************************************************/
-
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.draw2d.examples.text;
 
 import org.eclipse.swt.SWT;

--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/text/CaretExample.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/text/CaretExample.java
@@ -1,14 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2023 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Common Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/cpl-v10.html
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
 package org.eclipse.draw2d.examples.text;
 
 import org.eclipse.swt.events.KeyAdapter;

--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/text/TestBorder.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/text/TestBorder.java
@@ -1,14 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2023 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Common Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/cpl-v10.html
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
 package org.eclipse.draw2d.examples.text;
 
 import org.eclipse.swt.SWT;

--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/text/TextSurroundingFigureExample.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/text/TextSurroundingFigureExample.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
  * Copyright (c) 2005, 2023 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Common Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/cpl-v10.html
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation


### PR DESCRIPTION
The other examples were migrated to EPL-1 with
c98396ff6e009fd91d4c817ab18ea28d008c0fe9 and later migrated to EPL-2 with 0b1a1058d93c981633af7c1cead6b4d579ab2898. Those files being missed is very likely simply an oversight.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/674