### PR TITLE
Restore license headers for Zest layout snippets

### DIFF
--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/CustomLayout.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/CustomLayout.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria, BC,
+ *                      Canada.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     The Chisel Group, University of Victoria
+ *     Mateusz Matela <mateusz.matela@gmail.com> - [tree] Add Space Tree support to Graph widget - https://bugs.eclipse.org/bugs/show_bug.cgi?id=277534
+ ******************************************************************************/
 package org.eclipse.zest.examples.layouts;
 
 import org.eclipse.swt.SWT;

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/DAGExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/DAGExample.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Ian Bull
+ *******************************************************************************/
 package org.eclipse.zest.examples.layouts;
 
 import java.util.List;

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/RadialLayoutExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/RadialLayoutExample.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     The Chisel Group, University of Victoria
+ *     Mateusz Matela <mateusz.matela@gmail.com> - [tree] Add Space Tree support to Graph widget - https://bugs.eclipse.org/bugs/show_bug.cgi?id=277534
+ *******************************************************************************/
 package org.eclipse.zest.examples.layouts;
 
 import org.eclipse.swt.SWT;

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpaceTreeBuilding.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpaceTreeBuilding.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     The Chisel Group, University of Victoria
+ *     Mateusz Matela <mateusz.matela@gmail.com> - [tree] Add Space Tree support to Graph widget - https://bugs.eclipse.org/bugs/show_bug.cgi?id=277534
+ *******************************************************************************/
 package org.eclipse.zest.examples.layouts;
 
 import java.util.List;

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpaceTreeExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/SpaceTreeExample.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     The Chisel Group, University of Victoria
+ *     Mateusz Matela <mateusz.matela@gmail.com> - [tree] Add Space Tree support to Graph widget - https://bugs.eclipse.org/bugs/show_bug.cgi?id=277534
+ *******************************************************************************/
 package org.eclipse.zest.examples.layouts;
 
 import java.util.List;

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/TreeLayoutExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/TreeLayoutExample.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     The Chisel Group, University of Victoria
+ *     Mateusz Matela <mateusz.matela@gmail.com> - [tree] Add Space Tree support to Graph widget - https://bugs.eclipse.org/bugs/show_bug.cgi?id=277534
+ *******************************************************************************/
 package org.eclipse.zest.examples.layouts;
 
 import java.util.List;


### PR DESCRIPTION
The snippets we created as part of the Google Summer of Code 2009 by Mateusz Matela and Ian Bull:
https://wiki.eclipse.org/Tree_Views_for_Zest

Copyright headers have been taken and adapted from the corresponding patch attached to https://bugs.eclipse.org/bugs/show_bug.cgi?id=277534

Contributes to https://github.com/eclipse-gef/gef-classic/issues/674