### PR TITLE
Enhance selection feedback in Logic Designer with thicker borders and OS native colors

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicElementMoveHandle.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicElementMoveHandle.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Wolfgang Schedl.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Wolfgang Schedl - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.examples.logicdesigner.edit;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
+
+import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.geometry.Rectangle;
+
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.editparts.ZoomManager;
+import org.eclipse.gef.handles.MoveHandle;
+import org.eclipse.gef.handles.MoveHandleLocator;
+
+/**
+ * A move handle that provides enhanced visual feedback with a thicker, rounded
+ * border in the OS native selection color.
+ *
+ * Inspired by Eclipse 4DIAC's implementation:
+ * https://github.com/eclipse-4diac/4diac-ide/blob/9e3d159e7004be2cb4b7875a605162a847b743ca/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/policies/ModifiedMoveHandle.java
+ */
+public class LogicElementMoveHandle extends MoveHandle {
+	private static final int BASE_BORDER_WIDTH = 3;
+	private static final int CORNER_RADIUS = 4;
+
+	public LogicElementMoveHandle(GraphicalEditPart owner) {
+		super(owner, new MoveHandleLocator(owner.getFigure()));
+		setBorder(null);
+		setCursor(Cursors.SIZEALL);
+		initialize();
+	}
+
+	/**
+	 * Initializes handle by setting the color to the OS native selection color.
+	 */
+	@Override
+	protected void initialize() {
+		setForegroundColor(Display.getCurrent().getSystemColor(org.eclipse.swt.SWT.COLOR_LIST_SELECTION));
+	}
+
+	/**
+	 * Paints selection feedback with a rounded rectangle at the current zoom level.
+	 */
+	@Override
+	protected void paintFigure(Graphics graphics) {
+		int origWidth = graphics.getLineWidth();
+		int origAntialias = graphics.getAntialias();
+
+		graphics.setAntialias(SWT.ON);
+
+		int scaledWidth = getScaledBorderWidth();
+		graphics.setLineWidth(scaledWidth);
+
+		Rectangle bounds = getBounds().getCopy();
+		bounds.shrink(scaledWidth / 2, scaledWidth / 2);
+
+		graphics.drawRoundRectangle(bounds, CORNER_RADIUS, CORNER_RADIUS);
+
+		graphics.setLineWidth(origWidth);
+		graphics.setAntialias(origAntialias);
+	}
+
+	/**
+	 * Calculates the border width which is based on the current zoom level.
+	 *
+	 * @return the border width, minimum of 1 pixel
+	 */
+	protected int getScaledBorderWidth() {
+		ZoomManager zoomManager = (ZoomManager) getOwner().getViewer().getProperty(ZoomManager.class.toString());
+		if (zoomManager != null) {
+			double zoom = zoomManager.getZoom();
+			return (int) Math.max(1, Math.round(BASE_BORDER_WIDTH * zoom));
+
+		}
+		return BASE_BORDER_WIDTH;
+	}
+
+}

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicResizableEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicResizableEditPolicy.java
@@ -12,14 +12,20 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.edit;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.RectangleFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.Handle;
 import org.eclipse.gef.LayerConstants;
 import org.eclipse.gef.editpolicies.ResizableEditPolicy;
+import org.eclipse.gef.handles.ResizeHandle;
 import org.eclipse.gef.tools.ResizeTracker;
 
 import org.eclipse.gef.examples.logicdesigner.figures.AndGateFeedbackFigure;
@@ -40,6 +46,7 @@ import org.eclipse.gef.examples.logicdesigner.model.LiveOutput;
 import org.eclipse.gef.examples.logicdesigner.model.LogicFlowContainer;
 import org.eclipse.gef.examples.logicdesigner.model.LogicLabel;
 import org.eclipse.gef.examples.logicdesigner.model.OrGate;
+import org.eclipse.gef.examples.logicdesigner.model.SimpleOutput;
 import org.eclipse.gef.examples.logicdesigner.model.XORGate;
 import org.eclipse.gef.examples.logicdesigner.tools.LogicResizeTracker;
 
@@ -114,6 +121,61 @@ public class LogicResizableEditPolicy extends ResizableEditPolicy {
 		}
 
 		return figure;
+	}
+
+	@Override
+	public int getResizeDirections() {
+		if (getHost().getModel() instanceof LED || getHost().getModel() instanceof SimpleOutput) {
+			return PositionConstants.NONE;
+		}
+		if (getHost().getModel() instanceof LogicLabel) {
+			return PositionConstants.EAST | PositionConstants.WEST;
+		}
+		return PositionConstants.NORTH | PositionConstants.SOUTH | PositionConstants.EAST | PositionConstants.WEST;
+	}
+
+	@Override
+	protected List<Handle> createSelectionHandles() {
+		List<Handle> list = new ArrayList<>();
+
+		// Use the modified move handle
+		list.add(new LogicElementMoveHandle(getHost()));
+
+		if (getResizeDirections() != 0) {
+			addResizeHandles(list);
+		}
+
+		return list;
+	}
+
+	private void addResizeHandles(List<Handle> handles) {
+		GraphicalEditPart part = getHost();
+
+		if ((getResizeDirections() & PositionConstants.NORTH) != 0) {
+			handles.add(new ResizeHandle(part, PositionConstants.NORTH));
+		}
+		if ((getResizeDirections() & PositionConstants.SOUTH) != 0) {
+			handles.add(new ResizeHandle(part, PositionConstants.SOUTH));
+		}
+		if ((getResizeDirections() & PositionConstants.EAST) != 0) {
+			handles.add(new ResizeHandle(part, PositionConstants.EAST));
+		}
+		if ((getResizeDirections() & PositionConstants.WEST) != 0) {
+			handles.add(new ResizeHandle(part, PositionConstants.WEST));
+		}
+
+		if ((getResizeDirections() & PositionConstants.NORTH_EAST) != 0) {
+			handles.add(new ResizeHandle(part, PositionConstants.NORTH_EAST));
+		}
+		if ((getResizeDirections() & PositionConstants.NORTH_WEST) != 0) {
+			handles.add(new ResizeHandle(part, PositionConstants.NORTH_WEST));
+		}
+		if ((getResizeDirections() & PositionConstants.SOUTH_EAST) != 0) {
+			handles.add(new ResizeHandle(part, PositionConstants.SOUTH_EAST));
+		}
+		if ((getResizeDirections() & PositionConstants.SOUTH_WEST) != 0) {
+			handles.add(new ResizeHandle(part, PositionConstants.SOUTH_WEST));
+		}
 	}
 
 	/**


### PR DESCRIPTION
This change improves the visual feedback when selecting components in the Logic Designer by:
- Making selection borders thicker and rounded
- Using the OS native selection color for better platform integration

The implementation is inspired by Eclipse 4DIAC's enhanced selection feedback
(see: plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/policies/ModifiedMoveHandle.java)


Examples in Windows:
![border2](https://github.com/user-attachments/assets/59f59df7-d31a-4888-80eb-4d50b43ef75d)
![border1](https://github.com/user-attachments/assets/f2a2b5f3-5230-4523-9f0c-00f4a2af1178)
