### PR TITLE
Provide concrete Request Types for getTargetRequest

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/dnd/TextTransferDropTargetListener.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/dnd/TextTransferDropTargetListener.java
@@ -31,13 +31,14 @@ public class TextTransferDropTargetListener extends AbstractTransferDropTargetLi
 		return new NativeDropRequest();
 	}
 
-	protected NativeDropRequest getNativeDropRequest() {
-		return (NativeDropRequest) getTargetRequest();
+	@Override
+	protected NativeDropRequest getTargetRequest() {
+		return (NativeDropRequest) super.getTargetRequest();
 	}
 
 	@Override
 	protected void updateTargetRequest() {
-		getNativeDropRequest().setData(getCurrentEvent().data);
+		getTargetRequest().setData(getCurrentEvent().data);
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/AbstractConnectionCreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/AbstractConnectionCreationTool.java
@@ -189,6 +189,14 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	}
 
 	/**
+	 * @since 3.21
+	 */
+	@Override
+	protected CreateConnectionRequest getTargetRequest() {
+		return (CreateConnectionRequest) super.getTargetRequest();
+	}
+
+	/**
 	 * When the button is first pressed, the source node and its command
 	 * contribution are determined and locked in. After that time, the tool will be
 	 * looking for the target node to complete the connection
@@ -204,7 +212,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 			updateTargetUnderMouse();
 			setConnectionSource(getTargetEditPart());
 			Command command = getCommand();
-			((CreateConnectionRequest) getTargetRequest()).setSourceEditPart(getTargetEditPart());
+			getTargetRequest().setSourceEditPart(getTargetEditPart());
 			if (command != null) {
 				setState(STATE_CONNECTION_STARTED);
 				setCurrentCommand(command);
@@ -402,7 +410,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	 */
 	@Override
 	protected void updateTargetRequest() {
-		CreateConnectionRequest request = (CreateConnectionRequest) getTargetRequest();
+		CreateConnectionRequest request = getTargetRequest();
 		request.setType(getCommandName());
 		request.setLocation(getLocation());
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionCreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionCreationTool.java
@@ -24,7 +24,6 @@ import org.eclipse.gef.AccessibleAnchorProvider;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.requests.CreateConnectionRequest;
 import org.eclipse.gef.requests.CreationFactory;
 
 /**
@@ -205,7 +204,7 @@ public class ConnectionCreationTool extends AbstractConnectionCreationTool {
 		if (command != null && command.canExecute()) {
 			updateTargetUnderMouse();
 			setConnectionSource(getTargetEditPart());
-			((CreateConnectionRequest) getTargetRequest()).setSourceEditPart(getTargetEditPart());
+			getTargetRequest().setSourceEditPart(getTargetEditPart());
 			setState(STATE_ACCESSIBLE_DRAG_IN_PROGRESS);
 			placeMouseInViewer(getLocation().getTranslated(6, 6));
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionEndpointTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionEndpointTracker.java
@@ -168,6 +168,14 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	}
 
 	/**
+	 * @since 3.21
+	 */
+	@Override
+	protected ReconnectRequest getTargetRequest() {
+		return (ReconnectRequest) super.getTargetRequest();
+	}
+
+	/**
 	 * If currently in the drag-in-progress state, it goes into the terminal state
 	 * erases feedback and executes the current command.
 	 *
@@ -338,7 +346,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	 */
 	@Override
 	protected void updateTargetRequest() {
-		ReconnectRequest request = (ReconnectRequest) getTargetRequest();
+		ReconnectRequest request = getTargetRequest();
 		Point p = getLocation();
 		request.setLocation(p);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/CreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/CreationTool.java
@@ -133,9 +133,11 @@ public class CreationTool extends TargetingTool {
 	 *
 	 * @return the target request as a CreateRequest
 	 * @see TargetingTool#getTargetRequest()
+	 * @deprecated use TargetingTool#getTargetRequest()
 	 */
+	@Deprecated(since = "3.21", forRemoval = true)
 	protected CreateRequest getCreateRequest() {
-		return (CreateRequest) getTargetRequest();
+		return getTargetRequest();
 	}
 
 	/**
@@ -349,7 +351,7 @@ public class CreationTool extends TargetingTool {
 	 * @since 3.7
 	 */
 	protected void enforceConstraintsForSizeOnDropCreate(CreateRequest request) {
-		CreateRequest createRequest = (CreateRequest) getTargetRequest();
+		CreateRequest createRequest = getTargetRequest();
 		if (createRequest.getSize() != null) {
 			// ensure create request respects minimum and maximum size
 			// constraints
@@ -391,4 +393,11 @@ public class CreationTool extends TargetingTool {
 		return IFigure.MIN_DIMENSION;
 	}
 
+	/**
+	 * @since 3.21
+	 */
+	@Override
+	protected CreateRequest getTargetRequest() {
+		return (CreateRequest) super.getTargetRequest();
+	}
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
@@ -141,6 +141,14 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	}
 
 	/**
+	 * @since 3.21
+	 */
+	@Override
+	protected ChangeBoundsRequest getTargetRequest() {
+		return (ChangeBoundsRequest) super.getTargetRequest();
+	}
+
+	/**
 	 * Returns the unioned bounds of the {@link #getOperationSet() operation set
 	 * edit parts'} figures in absolute coordinates. In case the figures implement
 	 * {@link HandleBounds} their {@link HandleBounds#getHandleBounds() handle
@@ -663,7 +671,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	@Override
 	protected void updateTargetRequest() {
 		repairStartLocation();
-		ChangeBoundsRequest request = (ChangeBoundsRequest) getTargetRequest();
+		ChangeBoundsRequest request = getTargetRequest();
 		request.setEditParts(getOperationSet());
 		Dimension delta = getDragMoveDelta();
 

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/SelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/SelectionTool.java
@@ -158,6 +158,14 @@ public class SelectionTool extends TargetingTool {
 	}
 
 	/**
+	 * @since 3.21
+	 */
+	@Override
+	protected SelectionRequest getTargetRequest() {
+		return (SelectionRequest) super.getTargetRequest();
+	}
+
+	/**
 	 * Returns the target hover request. If <code>null</code>, it will be created
 	 * via {@link #createHoverRequest()}.
 	 *
@@ -199,7 +207,7 @@ public class SelectionTool extends TargetingTool {
 			}
 		}
 		updateTargetRequest();
-		((SelectionRequest) getTargetRequest()).setLastButtonPressed(button);
+		getTargetRequest().setLastButtonPressed(button);
 		updateTargetUnderMouse();
 		EditPart editpart = getTargetEditPart();
 		if (editpart != null) {
@@ -220,7 +228,7 @@ public class SelectionTool extends TargetingTool {
 		if (getCurrentInput().isAnyButtonDown()) {
 			return false;
 		}
-		((SelectionRequest) getTargetRequest()).setLastButtonPressed(0);
+		getTargetRequest().setLastButtonPressed(0);
 		setDragTracker(null);
 		setState(STATE_INITIAL);
 		unlockTargetEditPart();
@@ -695,7 +703,7 @@ public class SelectionTool extends TargetingTool {
 	 */
 	@Override
 	protected void updateTargetRequest() {
-		SelectionRequest request = (SelectionRequest) getTargetRequest();
+		SelectionRequest request = getTargetRequest();
 		request.setModifiers(getCurrentInput().getModifiers());
 		request.setType(getCommandName());
 		request.setLocation(getLocation());

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDropListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDropListener.java
@@ -103,6 +103,11 @@ class TreeViewerTransferDropListener extends AbstractTransferDropTargetListener 
 		return selection.get(0);
 	}
 
+	@Override
+	protected ChangeBoundsRequest getTargetRequest() {
+		return (ChangeBoundsRequest) super.getTargetRequest();
+	}
+
 	protected List<EditPart> includeChildren(List<? extends EditPart> list) {
 		List<EditPart> result = new ArrayList<>();
 		for (EditPart element : list) {
@@ -133,7 +138,7 @@ class TreeViewerTransferDropListener extends AbstractTransferDropTargetListener 
 
 	@Override
 	protected void updateTargetRequest() {
-		ChangeBoundsRequest request = (ChangeBoundsRequest) getTargetRequest();
+		ChangeBoundsRequest request = getTargetRequest();
 		request.setLocation(getDropLocation());
 		request.setType(getCommandName());
 	}


### PR DESCRIPTION
In order to reduce the required casts and to make the code's intention clearer tools which create and expect certain target request types are explicitly casted.