### PR TITLE
Fix oval rendering artifacts in OR+XOR gate

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
+import org.eclipse.swt.SWT;
+
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.PointList;
@@ -61,6 +63,7 @@ public class OrGateFigure extends GateFigure {
 		r.translate(4, 4);
 		r.setSize(22, 18);
 
+		g.setAntialias(SWT.ON);
 		g.setLineWidth(2);
 
 		// Draw terminals, 2 at top
@@ -70,11 +73,10 @@ public class OrGateFigure extends GateFigure {
 		// Draw the bottom arc of the gate
 		r.y += 8;
 
-		r.x -= 1;
+		r.width--;
 		g.fillOval(r);
-		r.width -= 2;
+		r.width--;
 		r.height--;
-		r.x++;
 
 		g.drawOval(r);
 		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
+import org.eclipse.swt.SWT;
+
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.PointList;
@@ -73,6 +75,7 @@ public class XOrGateFigure extends GateFigure {
 		r.translate(4, 4);
 		r.setSize(22, 18);
 
+		g.setAntialias(SWT.ON);
 		g.setLineWidth(2);
 
 		// Draw terminals, 2 at top
@@ -92,8 +95,10 @@ public class XOrGateFigure extends GateFigure {
 		clipRect.width += 2;
 		clipRect.y = r.y + 6;
 		g.clipRect(clipRect);
+		r.width--;
+
 		g.fillOval(r);
-		r.width -= 2;
+		r.width--;
 		r.height--;
 		g.drawOval(r);
 		g.popState();


### PR DESCRIPTION
When rendering the XOR gate's bottom arc, there was a visual artifact where the filled oval would slightly overflow beyond the border. 
See https://github.com/eclipse-gef/gef-classic/pull/676 
- This PR fixes this issue (thanks a lot to @ptziegler and @azoitl for pointing this out)
- Additionally, antialiasing has been enabled to smooth out the border and edges 

BEFORE:
![image](https://github.com/user-attachments/assets/c13bb977-5be3-4448-b29d-937c2f8b561d)

AFTER: 
<img width="135" alt="image" src="https://github.com/user-attachments/assets/c06dc588-b7b9-445b-b85c-9d9dc3e7dba7" />
