### PR TITLE
Fix visual artifacts in AndGateFigure between rectangle and arc

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
+import org.eclipse.swt.SWT;
+
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -48,6 +50,7 @@ public class AndGateFigure extends GateFigure {
 		r.translate(4, 4);
 		r.setSize(22, 18);
 
+		g.setAntialias(SWT.ON);
 		g.setLineWidth(2);
 
 		// Draw terminals, 2 at top
@@ -55,6 +58,7 @@ public class AndGateFigure extends GateFigure {
 		g.drawLine(r.right() - 6, r.y, r.right() - 6, r.y - 4);
 
 		// draw main area
+		r.height++;
 		g.fillRoundRectangle(r, 5, 5);
 
 		// outline main area


### PR DESCRIPTION
- Extended the fill height of the rounded rectangle by 1px to ensure proper overlap with the arc
- Additionally, antialiasing has been enabled to smooth out the border and edges

BEFORE:
<img width="266" alt="Screenshot 2025-02-03 214811 BEFORE" src="https://github.com/user-attachments/assets/f83c07b0-1dea-4d95-95cc-0b1722af2e0f" />

AFTER:
<img width="268" alt="Screenshot 2025-02-03 214705 AFTER" src="https://github.com/user-attachments/assets/fba32965-1488-486f-a679-f811c0d4408b" />
