### PR TITLE
Restore original intersect() logic in case two rectangles touch

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RectangleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2010 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -427,6 +427,18 @@ public class RectangleTest extends BaseTestCase {
 		rectangle1 = new Rectangle(10, 15, 70, 30);
 		assertSame(rectangle1, rectangle1.intersect(new Rectangle(0, 0, 5, 10)));
 		assertTrue(rectangle1.isEmpty());
+		//
+		rectangle1 = new Rectangle(100, 100, 300, 300);
+		rectangle2 = new Rectangle(200, 200, 100, 0);
+		assertEquals(200, 200, 100, 0, rectangle1.intersect(rectangle2));
+		//
+		rectangle1 = new Rectangle(100, 100, 300, 300);
+		rectangle2 = new Rectangle(200, 200, 0, 100);
+		assertEquals(200, 200, 0, 100, rectangle1.intersect(rectangle2));
+		//
+		rectangle1 = new Rectangle(100, 100, 300, 300);
+		rectangle2 = new Rectangle(200, 200, 0, 0);
+		assertEquals(200, 200, 0, 0, rectangle1.intersect(rectangle2));
 	}
 
 	@SuppressWarnings("static-method")

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
@@ -727,7 +727,7 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 		int x2 = Math.min(x + width, rect.x() + rect.width());
 		int y1 = Math.max(y, rect.y());
 		int y2 = Math.min(y + height, rect.y() + rect.height());
-		if (((x2 - x1) <= 0) || ((y2 - y1) <= 0)) {
+		if (((x2 - x1) < 0) || ((y2 - y1) < 0)) {
 			return setBounds(0, 0, 0, 0); // no intersection
 		}
 		return setBounds(x1, y1, x2 - x1, y2 - y1);


### PR DESCRIPTION
In case two rectangles touch horizontally or vertically, the x and y coordinates should be preserved.

Closes https://github.com/eclipse-gef/gef-classic/issues/689