### PR TITLE
Revert "Make some fields in the FlyoutPaletteComposite protected rather than private, in order to allow for the possibility of a sub-class overriding the layout method(s) and accessing the various controls and states required."

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -110,15 +110,8 @@ public class FlyoutPaletteComposite extends Composite {
 	private static final int MIN_PALETTE_SIZE = 20;
 	private static final int MAX_PALETTE_SIZE = 500;
 
-	/**
-	 * @since 3.21
-	 */
-	protected static final int STATE_HIDDEN = 8;
-
-	/**
-	 * @since 3.21
-	 */
-	protected static final int STATE_EXPANDED = 1;
+	private static final int STATE_HIDDEN = 8;
+	private static final int STATE_EXPANDED = 1;
 
 	private static final Dimension ARROW_SIZE = new Dimension(6, 11);
 	private static final int SASH_BUTTON_WIDTH = 11;
@@ -136,22 +129,12 @@ public class FlyoutPaletteComposite extends Composite {
 	public static final int STATE_PINNED_OPEN = 4;
 
 	private final PropertyChangeSupport listeners = new PropertyChangeSupport(this);
-
-	/**
-	 * @since 3.21
-	 */
-	protected final Composite paletteContainer;
+	private final Composite paletteContainer;
 	private PaletteViewer pViewer;
 	private PaletteViewer externalViewer;
 	private IMemento capturedPaletteState;
-	/**
-	 * @since 3.21
-	 */
-	protected Control graphicalControl;
-	/**
-	 * @since 3.21
-	 */
-	protected final Composite sash;
+	private Control graphicalControl;
+	private final Composite sash;
 	private final PaletteViewerProvider provider;
 	private final FlyoutPreferences prefs;
 	private Point cachedBounds = new Point(0, 0);
@@ -164,26 +147,10 @@ public class FlyoutPaletteComposite extends Composite {
 	 * button is visible.
 	 */
 	private boolean transferFocus = false;
-
-	/**
-	 * @since 3.21
-	 */
-	protected int dock = PositionConstants.EAST;
-
-	/**
-	 * @since 3.21
-	 */
-	protected int paletteState = STATE_HIDDEN;
-
-	/**
-	 * @since 3.21
-	 */
-	protected int paletteWidth = DEFAULT_PALETTE_SIZE;
-
-	/**
-	 * @since 3.21
-	 */
-	protected int minWidth = MIN_PALETTE_SIZE;
+	private int dock = PositionConstants.EAST;
+	private int paletteState = STATE_HIDDEN;
+	private int paletteWidth = DEFAULT_PALETTE_SIZE;
+	private int minWidth = MIN_PALETTE_SIZE;
 	private int cachedSize = -1;
 	private int cachedState = -1;
 	private int cachedLocation = -1;
@@ -342,10 +309,7 @@ public class FlyoutPaletteComposite extends Composite {
 		return false;
 	}
 
-	/**
-	 * @since 3.21
-	 */
-	protected boolean isInState(int state) {
+	private boolean isInState(int state) {
 		return (paletteState & state) != 0;
 	}
 


### PR DESCRIPTION
This reverts commit 9761db060995388c38585d382dd487770c789c36.