### PR TITLE
Add missing header to GEF/Draw2D source files

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointTests.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2011 itemis AG and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alexander Nyßen (itemis AG) - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.draw2d.test;
 
 import org.eclipse.draw2d.geometry.Dimension;

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ShapeTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ShapeTest.java
@@ -1,6 +1,15 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2011 itemis AG and others.
  *
- */
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alexander Nyßen (itemis AG) - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.draw2d.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alexander Nyßen (itemis AG) - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.gef.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
- org.eclipse.draw2d.test.ShapeTest
  -  Created in 2011 with e8c84cd0f84e304fbb195789d5e6f3557de60dd8.
- org.eclipse.draw2d.test.PointTests
  -  Created in 2011 with c6840ee2b2a64e7fc6fad4d03fb4602b21f54bb4.
- org.eclipse.gef.test.CommandStackTest
  -  Created in 2015 with 67aae64c367abbed4e4bd37c1aafad9da5c6bd63.

All three classes were created by Alexander Nyßen. Both the email-adress used in the 2015 commit, as well as similar commits in the 2011 commits indicates that those changes were done as part of his work at Itemis.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/674