### PR TITLE
Add missing license header to NodeSearchDialog

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/HideNodeHelper.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/HideNodeHelper.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright 2023, Sebastian Hollersbacher, Johannes Kepler Universität Linz
+ *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which
  * accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors: Sebastian Hollersbacher
  ******************************************************************************/

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/NodeSearchDialog.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/NodeSearchDialog.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright 2023, Sebastian Hollersbacher, Johannes Kepler Universität Linz
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: Sebastian Hollersbacher
+ ******************************************************************************/
 package org.eclipse.zest.core.widgets.internal;
 
 import java.util.ArrayList;

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet14.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet14.java
@@ -6,6 +6,8 @@
  * accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-v20.html
  *
+ * SPDX-License-Identifier: EPL-2.0
+ *
  * Contributors: Sebastian Hollersbacher
  ******************************************************************************/
 package org.eclipse.zest.examples.swt;


### PR DESCRIPTION
The NodeSearchDialog class was created by Sebastian Hollersbacher with e890b56b744fc68dbb3ac6efaf66e9bff2590e90 as part of the "Hide Node" feature.

Furthermore, the related HideNodeHelper and GraphSnippet14 have been updated to also contain the SPDX license identifier.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/674