### PR TITLE
Add missing license header for AnimationSnippet and CustomLayout

### DIFF
--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/AnimationSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/AnimationSnippet.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright 2008, CHISEL Group, University of Victoria, Victoria,
+ *                 BC, Canada and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: The Chisel Group, University of Victoria
+ ******************************************************************************/
 package org.eclipse.zest.examples.swt;
 
 import org.eclipse.swt.SWT;

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/CustomLayout.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/CustomLayout.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright 2008, CHISEL Group, University of Victoria, Victoria,
+ *                 BC, Canada and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: The Chisel Group, University of Victoria
+ ******************************************************************************/
 package org.eclipse.zest.examples.swt;
 
 import org.eclipse.swt.SWT;


### PR DESCRIPTION
Both examples were created with ccfe91da08029fb5f05f4a89a7cda27f611b72c1 by Ian Bull. Given that he also created the other examples within a close time frame, it is likely that they should have the same license header.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/674