### PR TITLE
Disable testAntialias() test when running on Linux

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AdvancedGraphicsTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AdvancedGraphicsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2023 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,8 @@
  *******************************************************************************/
 
 package org.eclipse.draw2d.test;
+
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -138,6 +140,9 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 
 	@Test
 	public void testAntialias() {
+		assumeFalse("gtk".equals(SWT.getPlatform()), //$NON-NLS-1$
+				"Requires https://github.com/eclipse-platform/eclipse.platform.swt/pull/1839"); //$NON-NLS-1$
+
 		class AntialiasSettings implements Runnable {
 			private final Color color;
 			private final int normal;


### PR DESCRIPTION
Due to changes in SWT, the underlying Cairo surface of an SWT image is no longer initialized with the system font options.

If a string is drawn without ever calling setTextAntialias(), the Cairo default is used. If this method is called with SWT.DEFAULT, the system default is used. Because those values are not guaranteed to be equal, this may lead to visual artifacts.

See https://github.com/eclipse-gef/gef-classic/issues/696