### PR TITLE
Reduce LED figure size and optimize display proportions

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFigure.java
@@ -34,37 +34,37 @@ import org.eclipse.gef.examples.logicdesigner.model.LED;
  */
 public class LEDFigure extends NodeFigure implements HandleBounds {
 
-	public static final Dimension SIZE = new Dimension(122, 94);
-	protected static final Font DISPLAY_FONT = new Font(null, "DialogInput", 23, SWT.NORMAL); //$NON-NLS-1$
+	public static final Dimension SIZE = new Dimension(92, 71);
+	protected static final Font DISPLAY_FONT = new Font(null, "DialogInput", 24, SWT.NORMAL); //$NON-NLS-1$
 	protected static PointList connector = new PointList();
 	protected static PointList bottomConnector = new PointList();
-	protected static Rectangle displayRectangle = new Rectangle(30, 22, 62, 50);
-	protected static Rectangle displayShadow = new Rectangle(28, 20, 64, 52);
-	protected static Rectangle displayHighlight = new Rectangle(30, 22, 64, 52);
-	protected static Point valuePoint = new Point(32, 20);
+	protected static Rectangle displayRectangle = new Rectangle(14, 17, 65, 38);
+	protected static Rectangle displayShadow = new Rectangle(12, 15, 66, 39);
+	protected static Rectangle displayHighlight = new Rectangle(14, 17, 66, 39);
+	protected static Point valuePoint = new Point(24, 15);
 	private static final int HORIZONTAL_PADDING = 3;
 	private static final int VERTICAL_OFFSET = -1;
 	private static final int CORNER_RADIUS = 6;
 
 	static {
-		connector.addPoint(-4, 0);
+		connector.addPoint(-3, 0);
 		connector.addPoint(2, 0);
-		connector.addPoint(4, 2);
-		connector.addPoint(4, 10);
-		connector.addPoint(-2, 10);
-		connector.addPoint(-2, 2);
+		connector.addPoint(3, 2);
+		connector.addPoint(3, 8);
+		connector.addPoint(-1, 8);
+		connector.addPoint(-1, 2);
 
-		bottomConnector.addPoint(-4, 0);
+		bottomConnector.addPoint(-3, 0);
 		bottomConnector.addPoint(2, 0);
-		bottomConnector.addPoint(4, -2);
-		bottomConnector.addPoint(4, -10);
-		bottomConnector.addPoint(-2, -10);
-		bottomConnector.addPoint(-2, -2);
+		bottomConnector.addPoint(3, -1);
+		bottomConnector.addPoint(3, -7);
+		bottomConnector.addPoint(-1, -7);
+		bottomConnector.addPoint(-1, -1);
 	}
 
-	protected static final int[] GAP_CENTERS_X = { 16, 46, 76, 106 };
-	protected static final int Y1 = 4;
-	protected static final int Y2 = 88;
+	protected static final int[] GAP_CENTERS_X = { 12, 35, 57, 80 };
+	protected static final int Y1 = 3;
+	protected static final int Y2 = 66;
 
 	protected String value;
 
@@ -74,38 +74,38 @@ public class LEDFigure extends NodeFigure implements HandleBounds {
 	public LEDFigure() {
 		FixedConnectionAnchor c;
 		c = new FixedConnectionAnchor(this);
-		c.offsetH = 102;
+		c.offsetH = 77;
 		connectionAnchors.put(LED.TERMINAL_1_IN, c);
 		inputConnectionAnchors.add(c);
 		c = new FixedConnectionAnchor(this);
-		c.offsetH = 72;
+		c.offsetH = 54;
 		connectionAnchors.put(LED.TERMINAL_2_IN, c);
 		inputConnectionAnchors.add(c);
 		c = new FixedConnectionAnchor(this);
-		c.offsetH = 42;
+		c.offsetH = 32;
 		connectionAnchors.put(LED.TERMINAL_3_IN, c);
 		inputConnectionAnchors.add(c);
 		c = new FixedConnectionAnchor(this);
-		c.offsetH = 12;
+		c.offsetH = 9;
 		connectionAnchors.put(LED.TERMINAL_4_IN, c);
 		inputConnectionAnchors.add(c);
 		c = new FixedConnectionAnchor(this);
-		c.offsetH = 102;
+		c.offsetH = 77;
 		c.topDown = false;
 		connectionAnchors.put(LED.TERMINAL_1_OUT, c);
 		outputConnectionAnchors.add(c);
 		c = new FixedConnectionAnchor(this);
-		c.offsetH = 72;
+		c.offsetH = 54;
 		c.topDown = false;
 		connectionAnchors.put(LED.TERMINAL_2_OUT, c);
 		outputConnectionAnchors.add(c);
 		c = new FixedConnectionAnchor(this);
-		c.offsetH = 42;
+		c.offsetH = 32;
 		c.topDown = false;
 		connectionAnchors.put(LED.TERMINAL_3_OUT, c);
 		outputConnectionAnchors.add(c);
 		c = new FixedConnectionAnchor(this);
-		c.offsetH = 12;
+		c.offsetH = 9;
 		c.topDown = false;
 		connectionAnchors.put(LED.TERMINAL_4_OUT, c);
 		outputConnectionAnchors.add(c);
@@ -117,7 +117,7 @@ public class LEDFigure extends NodeFigure implements HandleBounds {
 	 */
 	@Override
 	public Rectangle getHandleBounds() {
-		return getBounds().getShrinked(new Insets(4, 0, 4, 0));
+		return getBounds().getShrinked(new Insets(3, 0, 3, 0));
 	}
 
 	/**
@@ -156,8 +156,6 @@ public class LEDFigure extends NodeFigure implements HandleBounds {
 		for (int i = 0; i < 4; i++) {
 			// Draw the gaps for the connectors
 			g.setForegroundColor(ColorConstants.listBackground);
-			g.drawLine(GAP_CENTERS_X[i] - 2, Y1, GAP_CENTERS_X[i] + 3, Y1);
-			g.drawLine(GAP_CENTERS_X[i] - 2, Y2, GAP_CENTERS_X[i] + 3, Y2);
 
 			// Draw the connectors
 			g.setForegroundColor(LogicColorConstants.connectorGreen);

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/model/LED.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/model/LED.java
@@ -28,7 +28,7 @@ public class LED extends LogicSubpart {
 
 	static final long serialVersionUID = 1;
 
-	private static final Dimension DEFAULT_SIZE = new Dimension(122, 94);
+	private static final Dimension DEFAULT_SIZE = new Dimension(92, 71);
 
 	private static final Image LED_ICON = createImage(LED.class, "icons/ledicon16.gif"); //$NON-NLS-1$
 	private static int count;

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/LogicDiagramTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/LogicDiagramTests.java
@@ -111,7 +111,7 @@ public class LogicDiagramTests extends AbstractSWTBotEditorTests {
 			forceUpdate(editor.getSWTBotGefViewer());
 		});
 
-		assertEquals(figure.getLocation(), new Point(12, 20), "Part is not on grid line");
+		assertEquals(figure.getLocation(), new Point(12, 21), "Part is not on grid line");
 	}
 
 	/**
@@ -124,7 +124,7 @@ public class LogicDiagramTests extends AbstractSWTBotEditorTests {
 
 		SWTBotGefEditor editor = bot.gefEditor("emptyModel1.logic");
 		editor.activateTool("LED");
-		editor.click(50, 48);
+		editor.click(50, 49);
 
 		editor.activateTool("Label");
 		editor.click(200, 200);


### PR DESCRIPTION
This PR reduces the LED figure size and optimizes display proportions. 
The reason for this is that the LED appeared proportionally just too large when comparing it with the gates. 
To ensure good visibility of the displayed numbers the font size was not changed

- Reduce overall LED size by 25% (122x94 -> 92x71)
- Adjust all components proportionally (connectors, gaps, handles)
- Enlarge display rectangle for better readability
- Maintain font size for clear number display
- Update model's DEFAULT_SIZE to match figure dimensions

BEFORE:
![2025-02-21 10_48_13-runtime-EclipseApplication(1) - test_emptyMoasdfdel1 logic - Eclipse IDE](https://github.com/user-attachments/assets/76326fc8-f5d3-41fc-9b0e-dc3bc3dd48d3)

AFTER:
![2025-02-21 10_57_54-runtime-EclipseApplication(1) - test_emptyMoasdfdel1 logic - Eclipse IDE](https://github.com/user-attachments/assets/18fc8026-4b8c-4f19-b7a1-cd245b9a8b94)

