### PR TITLE
Enlarging connection line width again

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/WireEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/WireEditPart.java
@@ -61,7 +61,7 @@ public class WireEditPart extends AbstractConnectionEditPart implements Property
 		 * its router to change.
 		 */
 		getFigure().addPropertyChangeListener(Connection.PROPERTY_CONNECTION_ROUTER, this);
-		((PolylineConnection) getFigure()).setLineWidth(2);
+		((PolylineConnection) getFigure()).setLineWidth(3);
 	}
 
 	/**

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/WireEndpointEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/WireEndpointEditPolicy.java
@@ -19,7 +19,7 @@ public class WireEndpointEditPolicy extends org.eclipse.gef.editpolicies.Connect
 	@Override
 	protected void addSelectionHandles() {
 		super.addSelectionHandles();
-		getConnectionFigure().setLineWidth(3);
+		getConnectionFigure().setLineWidth(4);
 	}
 
 	protected PolylineConnection getConnectionFigure() {
@@ -29,7 +29,7 @@ public class WireEndpointEditPolicy extends org.eclipse.gef.editpolicies.Connect
 	@Override
 	protected void removeSelectionHandles() {
 		super.removeSelectionHandles();
-		getConnectionFigure().setLineWidth(1);
+		getConnectionFigure().setLineWidth(2);
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/FigureFactory.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/FigureFactory.java
@@ -25,7 +25,7 @@ public class FigureFactory {
 	public static PolylineConnection createNewBendableWire(Wire wire) {
 		PolylineConnection conn = new PolylineConnection();
 		conn.addRoutingListener(RoutingAnimator.getDefault());
-		conn.setLineWidth(2);
+		conn.setLineWidth(3);
 		// conn.setSourceDecoration(new PolygonDecoration());
 		// conn.setTargetDecoration(new PolylineDecoration());
 		return conn;
@@ -35,7 +35,7 @@ public class FigureFactory {
 
 		PolylineConnection conn = new PolylineConnection();
 		conn.addRoutingListener(RoutingAnimator.getDefault());
-		conn.setLineWidth(2);
+		conn.setLineWidth(3);
 		PolygonDecoration arrow;
 
 		if (wire == null || wire.getSource() instanceof SimpleOutput) {
@@ -43,7 +43,7 @@ public class FigureFactory {
 		} else {
 			arrow = new PolygonDecoration();
 			arrow.setTemplate(PolygonDecoration.INVERTED_TRIANGLE_TIP);
-			arrow.setScale(10, 5);
+			arrow.setScale(20, 10);
 		}
 		conn.setSourceDecoration(arrow);
 
@@ -52,7 +52,7 @@ public class FigureFactory {
 		} else {
 			arrow = new PolygonDecoration();
 			arrow.setTemplate(PolygonDecoration.INVERTED_TRIANGLE_TIP);
-			arrow.setScale(10, 5);
+			arrow.setScale(20, 10);
 		}
 		conn.setTargetDecoration(arrow);
 		return conn;


### PR DESCRIPTION
Similar to https://github.com/eclipse-gef/gef-classic/pull/661, this PR enlarge the connection width again since it turned out it was proportionally still too small before (especially with comparting it to the connectors of the gates)


BEFORE:
![2025-02-21 11_48_00-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/0b3a31e7-7dc0-468b-8fd1-41800e501098)

![2025-02-21 11_48_25-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/2da83872-e2b9-4fa1-b94d-d1ebbcb41fbd)

AFTER:
![2025-02-21 11_52_13-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/1f9df9a3-4aa8-4774-99af-c21903fc469d)

![2025-02-21 11_52_52-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/dac44df6-f414-4df2-aaf3-073b6045dd68)



