### PR TITLE
Updated Feedback shadow for Logic Gates

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFeedbackFigure.java
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
-import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.swt.SWT;
+
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -23,48 +24,37 @@ public class AndGateFeedbackFigure extends AndGateFigure {
 	 */
 	@Override
 	protected void paintFigure(Graphics g) {
-		g.setXORMode(true);
-		g.setForegroundColor(ColorConstants.white);
-		g.setBackgroundColor(LogicColorConstants.ghostFillColor);
+		g.setBackgroundColor(LogicColorConstants.feedbackFill);
+		g.setForegroundColor(LogicColorConstants.feedbackOutline);
+		g.setAntialias(SWT.ON);
+		g.setLineWidth(2);
 
 		Rectangle r = getBounds().getCopy();
-		r.translate(4, 4);
+		r.translate(4, 5);
 		r.setSize(22, 18);
 
 		// Draw terminals, 2 at top
-		g.drawLine(r.x + 4, r.y, r.x + 4, r.y - 4);
-		g.drawLine(r.right() - 6, r.y, r.right() - 6, r.y - 4);
-		g.drawPoint(r.x + 4, r.y);
-		g.drawPoint(r.right() - 6, r.y);
+		g.drawLine(r.x + 4, r.y, r.x + 4, r.y - 6);
+		g.drawLine(r.right() - 5, r.y, r.right() - 5, r.y - 5);
+
+		// draw main area
+		r.width++;
+		r.height++;
+		g.fillRoundRectangle(r, 5, 5);
 
 		// outline main area
-		g.drawLine(r.x, r.y, r.right() - 1, r.y);
-		g.drawLine(r.right() - 1, r.y, r.right() - 1, r.bottom() - 1);
-		g.drawLine(r.x, r.y, r.x, r.bottom() - 1);
-
-		g.drawPoint(r.x, r.y);
-		g.drawPoint(r.right() - 1, r.y);
-
-		g.fillRectangle(r);
+		Rectangle outlineRect = r.getCopy();
+		outlineRect.width--;
+		g.drawRoundRectangle(outlineRect, 5, 5);
 
 		// draw and outline the arc
 		r.height = 18;
-		r.y += 8;
-		g.setForegroundColor(LogicColorConstants.ghostFillColor);
-		g.drawLine(r.x, r.y + 8, r.x + 20, r.y + 8);
-		g.setForegroundColor(ColorConstants.white);
-
-		g.drawPoint(r.x, r.y + 8);
-
+		r.y += 7;
 		g.fillArc(r, 180, 180);
-
 		r.width--;
 		r.height--;
-
 		g.drawArc(r, 180, 180);
 		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
-
-		g.drawPoint(r.x + r.width / 2, r.bottom());
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicColorConstants.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicColorConstants.java
@@ -27,5 +27,7 @@ public interface LogicColorConstants {
 	public final static Color logicBackgroundBlue = new Color(200, 200, 240);
 	public final static Color ghostFillColor = new Color(31, 31, 31);
 	public static final Color displayTextLED = new Color(255, 187, 51);
+	public final static Color feedbackFill = new Color(120, 120, 120);
+	public final static Color feedbackOutline = new Color(70, 70, 70);
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFeedbackFigure.java
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
-import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.swt.SWT;
+
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -23,9 +24,10 @@ public class OrGateFeedbackFigure extends OrGateFigure {
 	 */
 	@Override
 	protected void paintFigure(Graphics g) {
-		g.setXORMode(true);
-		g.setForegroundColor(ColorConstants.white);
-		g.setBackgroundColor(LogicColorConstants.ghostFillColor);
+		g.setBackgroundColor(LogicColorConstants.feedbackFill);
+		g.setForegroundColor(LogicColorConstants.feedbackOutline);
+		g.setAntialias(SWT.ON);
+		g.setLineWidth(2);
 
 		Rectangle r = getBounds().getCopy();
 		r.translate(4, 4);
@@ -35,28 +37,21 @@ public class OrGateFeedbackFigure extends OrGateFigure {
 		g.drawLine(r.x + 4, r.y + 4, r.x + 4, r.y - 4);
 		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
 
-		// fix it
-		g.drawPoint(r.x + 4, r.y + 4);
-		g.drawPoint(r.right() - 6, r.y + 4);
-
 		// Draw the bottom arc of the gate
 		r.y += 8;
 
 		r.width--;
-		r.height--;
-		g.fillArc(r, 180, 180);
+		g.fillOval(r);
 		r.width--;
 		r.height--;
-		g.drawPoint(r.x, r.y + 8);
 
-		g.drawArc(r, 180, 180);
+		g.drawOval(r);
 		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
-		g.drawPoint(r.x + r.width / 2, r.bottom());
 
 		// draw gate
 		g.translate(getLocation());
-		g.drawPolyline(GATE_OUTLINE);
 		g.fillPolygon(GATE_OUTLINE);
+		g.drawPolyline(GATE_OUTLINE);
 		g.translate(getLocation().getNegated());
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFeedbackFigure.java
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
-import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.swt.SWT;
+
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -23,9 +24,12 @@ public class XOrGateFeedbackFigure extends XOrGateFigure {
 	 */
 	@Override
 	protected void paintFigure(Graphics g) {
-		g.setXORMode(true);
-		g.setForegroundColor(ColorConstants.white);
-		g.setBackgroundColor(LogicColorConstants.ghostFillColor);
+
+		g.setBackgroundColor(LogicColorConstants.feedbackFill);
+		g.setForegroundColor(LogicColorConstants.feedbackOutline);
+		g.setAntialias(SWT.ON);
+		g.setLineWidth(2);
+
 		Rectangle r = getBounds().getCopy();
 		r.translate(4, 4);
 		r.setSize(22, 18);
@@ -46,20 +50,19 @@ public class XOrGateFeedbackFigure extends XOrGateFigure {
 		 * top arc of the gate, so this region is clipped.
 		 */
 		g.pushState();
-		r.y++;
-		g.clipRect(r);
-		r.y--;
+		Rectangle clipRect = r.getCopy();
+		clipRect.x -= 2;
+		clipRect.width += 2;
+		clipRect.y = r.y + 6;
+		g.clipRect(clipRect);
+		r.width--;
 
+		g.fillOval(r);
 		r.width--;
 		r.height--;
-		g.fillArc(r, 180, 180);
-		r.width--;
-		r.height--;
-		g.drawArc(r, 180, 180);
-		g.drawPoint(r.x, r.y + 8);
+		g.drawOval(r);
 		g.popState();
 		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
-		g.drawPoint(r.x + r.width / 2, r.bottom());
 
 		// Draw the gate outline and top curve
 		g.translate(getLocation());


### PR DESCRIPTION
This PR replaces the XOR mode drawing in the gate feedback figures with a more consistent custom fill approach.

### Problem with XOR Mode
The previous feedback figures used XOR mode for rendering, which has several drawbacks:
- Creates white artifacts when shapes overlap with each other
- Inconsistent appearance depending on background colors
- Poor visibility against certain backgrounds

### Solution
I've replaced XOR mode with a custom fill approach in these feedback figures:

The changes done were:
1. Remove XOR mode completely
2. Use dedicated feedback colors (defined in LogicColorConstants)
3. Maintain the exact shape dimensions and proportions of original figures

new shadow figures for the gates: 

![2025-03-02 22_28_24-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/00455c0d-acf3-4115-a1a1-535a05cc2731)
![2025-03-02 22_28_37-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/e9cfed3d-f4e5-4e2a-bee8-06ef75d723da)
![2025-03-02 22_27_49-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/e35725ef-0914-430d-b5b7-df3205854909)

