### PR TITLE
Updated Feedback shadow for remaining figures

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/CircuitBorder.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/CircuitBorder.java
@@ -25,7 +25,7 @@ public class CircuitBorder extends AbstractBorder {
 	protected static Insets insets = new Insets(16, 12, 16, 12);
 	protected static PointList connector = new PointList();
 	protected static PointList bottomConnector = new PointList();
-	private static final int CORNER_RADIUS = 6;
+	protected static final int CORNER_RADIUS = 6;
 
 	static {
 		connector.addPoint(-4, 0);

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/CircuitFeedbackBorder.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/CircuitFeedbackBorder.java
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
-import org.eclipse.draw2d.ColorConstants;
+import static org.eclipse.gef.examples.logicdesigner.figures.CircuitBorder.CORNER_RADIUS;
+
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Insets;
@@ -29,10 +30,12 @@ public class CircuitFeedbackBorder extends CircuitBorder {
 
 			// Draw the connectors
 			connector.translate(x1, rec.y);
+			g.fillPolygon(connector);
 			g.drawPolygon(connector);
 			connector.translate(-x1, -rec.y);
 			g.drawLine(x1 - 2, rec.bottom() - 3, x1 + 3, rec.bottom() - 3);
 			bottomConnector.translate(x1, rec.bottom());
+			g.fillPolygon(bottomConnector);
 			g.drawPolygon(bottomConnector);
 			bottomConnector.translate(-x1, -rec.bottom());
 		}
@@ -40,36 +43,21 @@ public class CircuitFeedbackBorder extends CircuitBorder {
 
 	@Override
 	public void paint(IFigure figure, Graphics g, Insets in) {
-		g.setXORMode(true);
-		g.setForegroundColor(ColorConstants.white);
-		g.setBackgroundColor(LogicColorConstants.ghostFillColor);
+		g.setForegroundColor(LogicColorConstants.feedbackFill);
+		g.setBackgroundColor(LogicColorConstants.feedbackFill);
 
 		Rectangle r = figure.getBounds().getShrinked(in);
 
-		// Draw the sides of the border
-		g.fillRectangle(r.x, r.y + 2, r.width, 6);
-		g.fillRectangle(r.x, r.bottom() - 8, r.width, 6);
-		g.fillRectangle(r.x, r.y + 2, 6, r.height - 4);
-		g.fillRectangle(r.right() - 6, r.y + 2, 6, r.height - 4);
+		// Draw top and bottom
+		Rectangle topBorder = new Rectangle(r.x, r.y + 4, r.width, 12);
+		g.fillRoundRectangle(topBorder, CORNER_RADIUS * 2, CORNER_RADIUS * 2);
+		Rectangle bottomBorder = new Rectangle(r.x, r.bottom() - 16, r.width, 12);
+		g.fillRoundRectangle(bottomBorder, CORNER_RADIUS * 2, CORNER_RADIUS * 2);
 
-		g.fillRectangle(r.x, r.y + 2, 6, 6);
-		g.fillRectangle(r.x, r.bottom() - 8, 6, 6);
-		g.fillRectangle(r.right() - 6, r.y + 2, 6, 6);
-		g.fillRectangle(r.right() - 6, r.bottom() - 8, 6, 6);
+		// Draw left and right side
+		g.fillRectangle(r.x, r.y + 4 + CORNER_RADIUS, 8, r.height - 8 - CORNER_RADIUS * 2);
+		g.fillRectangle(r.right() - 8, r.y + 4 + CORNER_RADIUS, 8, r.height - 8 - CORNER_RADIUS * 2);
 
-		// Outline the border
-		g.drawPoint(r.x, r.y + 2);
-		g.drawPoint(r.x, r.bottom() - 3);
-		g.drawPoint(r.right() - 1, r.y + 2);
-		g.drawPoint(r.right() - 1, r.bottom() - 3);
-		g.drawLine(r.x, r.y + 2, r.right() - 1, r.y + 2);
-		g.drawLine(r.x, r.bottom() - 3, r.right() - 1, r.bottom() - 3);
-		g.drawLine(r.x, r.y + 2, r.x, r.bottom() - 3);
-		g.drawLine(r.right() - 1, r.bottom() - 3, r.right() - 1, r.y + 2);
-
-		r.shrink(new Insets(1, 1, 0, 0));
-		r.expand(1, 1);
-		r.shrink(getInsets(figure));
 		drawConnectors(g, figure.getBounds().getShrinked(in));
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/CircuitFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/CircuitFeedbackFigure.java
@@ -18,7 +18,6 @@ public class CircuitFeedbackFigure extends RectangleFigure {
 
 	public CircuitFeedbackFigure() {
 		this.setFill(false);
-		this.setXOR(true);
 		setBorder(new CircuitFeedbackBorder());
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/GroundFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/GroundFeedbackFigure.java
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
-import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.swt.SWT;
+
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -23,21 +24,25 @@ public class GroundFeedbackFigure extends GroundFigure {
 	 */
 	@Override
 	protected void paintFigure(Graphics g) {
-		g.setXORMode(true);
-		g.setForegroundColor(ColorConstants.white);
-		g.setBackgroundColor(LogicColorConstants.ghostFillColor);
 		Rectangle r = getBounds().getCopy();
 
+		g.setBackgroundColor(LogicColorConstants.feedbackFill);
+		g.setForegroundColor(LogicColorConstants.feedbackOutline);
+		g.setAntialias(SWT.ON);
+		g.setLineWidth(2);
+
+		r.x += 1;
+		r.y += 1;
+		r.width -= 2;
+		r.height -= 2;
+
 		g.fillOval(r);
-		r.height--;
-		r.width--;
 		g.drawOval(r);
 		g.translate(r.getLocation());
 
 		// Draw the "V"
 		g.drawLine(6, 8, 10, 18);
 		g.drawLine(10, 18, 14, 8);
-		g.drawLine(10, 16, 10, 18);
 
 		// Draw the "0"
 		g.drawOval(14, 16, 6, 6);

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFeedbackFigure.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
-import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -23,41 +22,31 @@ public class LEDFeedbackFigure extends LEDFigure {
 	 */
 	@Override
 	protected void paintFigure(Graphics g) {
-		g.setXORMode(true);
-		g.setForegroundColor(ColorConstants.white);
+		g.setBackgroundColor(LogicColorConstants.feedbackOutline);
 
 		Rectangle r = getBounds().getCopy();
 		g.translate(r.getLocation());
 
-		g.setBackgroundColor(LogicColorConstants.ghostFillColor);
-		g.fillRectangle(0, 4, r.width, r.height - 8);
+		Rectangle mainBody = new Rectangle(0, 2, r.width, r.height - 4);
+		g.fillRoundRectangle(mainBody, CORNER_RADIUS, CORNER_RADIUS);
+		drawConnectors(g, r);
 
-		int right = r.width - 1;
-		g.drawLine(0, Y1, right, Y1);
-		g.drawLine(0, Y1, 0, Y2);
-		g.drawLine(0, Y2, right, Y2);
-		g.drawLine(right, Y1, right, Y2);
+		// Draw display
+		g.setBackgroundColor(LogicColorConstants.feedbackFill);
+		g.fillRoundRectangle(displayRectangle, CORNER_RADIUS, CORNER_RADIUS);
 
-		g.drawPoint(0, Y1);
-		g.drawPoint(right, Y1);
-		g.drawPoint(0, Y2);
-		g.drawPoint(right, Y2);
+	}
 
-		// Draw the gaps for the connectors
+	private static void drawConnectors(Graphics g, Rectangle r) {
 		for (int i = 0; i < 4; i++) {
-			g.drawLine(GAP_CENTERS_X[i] - 4, Y1, GAP_CENTERS_X[i] + 6, Y1);
-			g.drawLine(GAP_CENTERS_X[i] - 4, Y2, GAP_CENTERS_X[i] + 6, Y2);
-		}
 
-		// Draw the connectors
-		for (int i = 0; i < 4; i++) {
 			connector.translate(GAP_CENTERS_X[i], 0);
-			g.drawPolygon(connector);
+			g.fillPolygon(connector);
 			connector.translate(-GAP_CENTERS_X[i], 0);
 
 			bottomConnector.translate(GAP_CENTERS_X[i], r.height - 1);
-			g.drawPolygon(bottomConnector);
-			bottomConnector.translate(-GAP_CENTERS_X[i], -r.height + 1);
+			g.fillPolygon(bottomConnector);
+			bottomConnector.translate(-GAP_CENTERS_X[i], -(r.height - 1));
 		}
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFigure.java
@@ -44,7 +44,7 @@ public class LEDFigure extends NodeFigure implements HandleBounds {
 	protected static Point valuePoint = new Point(24, 15);
 	private static final int HORIZONTAL_PADDING = 3;
 	private static final int VERTICAL_OFFSET = -1;
-	private static final int CORNER_RADIUS = 6;
+	protected static final int CORNER_RADIUS = 6;
 
 	static {
 		connector.addPoint(-3, 0);

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LabelFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LabelFeedbackFigure.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
-import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -26,9 +25,8 @@ public class LabelFeedbackFigure extends BentCornerFigure {
 	protected void paintFigure(Graphics graphics) {
 		Rectangle rect = getBounds().getCopy();
 
-		graphics.setXORMode(true);
-		graphics.setForegroundColor(ColorConstants.white);
-		graphics.setBackgroundColor(LogicColorConstants.ghostFillColor);
+		graphics.setBackgroundColor(LogicColorConstants.feedbackFill);
+		graphics.setForegroundColor(LogicColorConstants.feedbackOutline);
 
 		graphics.translate(getLocation());
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LiveOutputFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LiveOutputFeedbackFigure.java
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
-import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.swt.SWT;
+
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -23,12 +24,17 @@ public class LiveOutputFeedbackFigure extends LiveOutputFigure {
 	 */
 	@Override
 	protected void paintFigure(Graphics g) {
-		g.setXORMode(true);
-		g.setForegroundColor(ColorConstants.white);
-
-		g.setBackgroundColor(LogicColorConstants.ghostFillColor);
-
 		Rectangle r = getBounds().getCopy();
+
+		g.setBackgroundColor(LogicColorConstants.feedbackFill);
+		g.setForegroundColor(LogicColorConstants.feedbackOutline);
+		g.setAntialias(SWT.ON);
+		g.setLineWidth(2);
+
+		r.x += 1;
+		r.y += 1;
+		r.width -= 2;
+		r.height -= 2;
 
 		g.fillOval(r);
 		r.height--;
@@ -39,12 +45,10 @@ public class LiveOutputFeedbackFigure extends LiveOutputFigure {
 		// Draw the "V"
 		g.drawLine(6, 8, 10, 18);
 		g.drawLine(10, 18, 14, 8);
-		g.drawLine(10, 16, 10, 18);
 
 		// Draw the "+"
 		g.drawLine(18, 14, 18, 22);
 		g.drawLine(14, 18, 22, 18);
-		g.drawPoint(18, 18);
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicColorConstants.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicColorConstants.java
@@ -27,5 +27,7 @@ public interface LogicColorConstants {
 	public final static Color logicBackgroundBlue = new Color(200, 200, 240);
 	public final static Color ghostFillColor = new Color(31, 31, 31);
 	public static final Color displayTextLED = new Color(255, 187, 51);
+	public final static Color feedbackFill = new Color(120, 120, 120);
+	public final static Color feedbackOutline = new Color(70, 70, 70);
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicFlowFeedbackBorder.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicFlowFeedbackBorder.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
-import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Insets;
@@ -29,9 +28,8 @@ public class LogicFlowFeedbackBorder extends LogicFlowBorder {
 
 	@Override
 	public void paint(IFigure figure, Graphics graphics, Insets insets) {
-		graphics.setForegroundColor(ColorConstants.white);
-		graphics.setBackgroundColor(LogicColorConstants.ghostFillColor);
-		graphics.setXORMode(true);
+		graphics.setBackgroundColor(LogicColorConstants.feedbackFill);
+		graphics.setForegroundColor(LogicColorConstants.feedbackOutline);
 
 		Rectangle r = figure.getBounds();
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicFlowFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicFlowFeedbackFigure.java
@@ -18,7 +18,6 @@ public class LogicFlowFeedbackFigure extends RectangleFigure {
 
 	public LogicFlowFeedbackFigure() {
 		this.setFill(false);
-		this.setXOR(true);
 		setBorder(new LogicFlowFeedbackBorder());
 	}
 


### PR DESCRIPTION
This PR updates the shadow figures to be aligned with the new modernized design of the gates done in https://github.com/eclipse-gef/gef-classic/pull/679

It is the continuation of the PR https://github.com/eclipse-gef/gef-classic/pull/703 where you can find details to the implementation of the shadow.

The remaining figures look like the following:
![2025-03-02 22_47_28-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/fa884b7c-1f8e-46ce-9868-5490ebd2972c)
![2025-03-02 22_47_04-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/5dda39b8-ecea-4a29-bae0-996a3ea5716a)
![2025-03-02 22_46_36-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/649a048f-41dd-44cb-a2c9-68d0fe6e362d)
![2025-03-02 22_47_58-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/3f33f3f7-7218-4c85-8f2b-26ced42f7312)
![2025-03-02 22_47_42-runtime-EclipseApplication(1) - test_fourBitasdfAdder1 logic - Eclipse IDE](https://github.com/user-attachments/assets/e47f36ca-f18b-49c8-9c28-a645a38ae2c5)


