### PR TITLE
Generalize PrintOperation to handle generic Graphics implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Draw2D
 
+ - Following methods in PrintOperation have been deprecated for removal, with
+   the drop-in replacements:
+    - `PrinterGraphics getFreshPrinterGraphics()` &rarr; `Graphics getFreshGraphics()`
+    - `setupGraphicsForPage(PrinterGraphics)` &rarr; `setupGraphicsForPage(Graphics)`
+   
+   Subclasses may replace the default PrinterGraphics by overriding the
+   protected `createGraphics(SWTGraphics, Printer)` method.
+   ```java
+   PrintOperation op = new PrintFigureOperation(p, fig) {
+      @Override
+      protected Graphics createGraphics(SWTGraphics g, Printer p) {
+         ...
+      }
+   };
+   ```
 ## GEF
 
 ## Zest

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d;singleton:=true
-Bundle-Version: 3.19.100.qualifier
+Bundle-Version: 3.20.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.draw2d,

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PrintFigureOperation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PrintFigureOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -122,7 +122,7 @@ public class PrintFigureOperation extends PrintOperation {
 	 */
 	@Override
 	protected void printPages() {
-		Graphics graphics = getFreshPrinterGraphics();
+		Graphics graphics = getFreshGraphics();
 		IFigure figure = getPrintSource();
 		setupPrinterGraphicsFor(graphics, figure);
 		Rectangle bounds = figure.getBounds();


### PR DESCRIPTION
This removes the dependency from PrintOperation to PrintGraphics, allowing subclasses to inject their own drawing backend by overriding the createGraphics(SWTGraphics,Printer) method.

The following methods have been deprecated, with drop-in replacements available that work on plain Graphics objects:
- PrinterGraphics getFreshPrinterGraphics()
- setupGraphicsForPage(PrinterGraphics)