### PR TITLE
Prepared Eclipse GEF Classic for 324 Devlopements #705

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# GEF Classic 3.24.0
+
+## Draw2D
+
+## GEF
+
+## Zest
+
 # GEF Classic 3.23.0
 
 ## Draw2D

--- a/org.eclipse.draw2d-feature/feature.xml
+++ b/org.eclipse.draw2d-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.draw2d"
       label="%featureName"
-      version="3.23.0.qualifier"
+      version="3.24.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.draw2d.doc.isv/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.doc.isv; singleton:=true
-Bundle-Version: 3.13.400.qualifier
+Bundle-Version: 3.13.500.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.draw2d.doc.isv/pom.xml
+++ b/org.eclipse.draw2d.doc.isv/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.draw2d.plugins</groupId>
 	<artifactId>org.eclipse.draw2d.doc.isv</artifactId>
-	<version>3.13.400-SNAPSHOT</version>
+	<version>3.13.500-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<name>[bundle] GEF Classic Draw2d Developer Documentation</name>
 	<build>

--- a/org.eclipse.draw2d.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.examples
-Bundle-Version: 3.16.200.qualifier
+Bundle-Version: 3.16.300.qualifier
 Export-Package: gef.bugs;x-friends:="org.eclipse.draw2d.tests"
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.draw2d;bundle-version="[3.16.0,4.0.0)"

--- a/org.eclipse.draw2d.sdk-feature/feature.xml
+++ b/org.eclipse.draw2d.sdk-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.draw2d.sdk"
       label="%featureName"
-      version="3.23.0.qualifier"
+      version="3.24.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.draw2d"
       license-feature="org.eclipse.license"

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d;singleton:=true
-Bundle-Version: 3.19.0.qualifier
+Bundle-Version: 3.19.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.draw2d,

--- a/org.eclipse.gef-feature/feature.xml
+++ b/org.eclipse.gef-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.gef"
       label="%featureName"
-      version="3.23.0.qualifier"
+      version="3.24.0.qualifier"
       provider-name="%providerName"
       image="eclipse_update_120.jpg"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.baseline/gef-classic-3.23.0.target
+++ b/org.eclipse.gef.baseline/gef-classic-3.23.0.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="GEF Classic 3.23.0 Base Line Target" sequenceNumber="1">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
+			<repository location="http://download.eclipse.org/cbi/updates/license"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2025-03"/>
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="0.0.0"/>
+		</location>
+	</locations>
+</target>

--- a/org.eclipse.gef.doc.isv/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.doc.isv; singleton:=true
-Bundle-Version: 3.13.800.qualifier
+Bundle-Version: 3.13.900.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)";resolution:=optional,

--- a/org.eclipse.gef.doc.isv/pom.xml
+++ b/org.eclipse.gef.doc.isv/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.doc.isv</artifactId>
-	<version>3.13.800-SNAPSHOT</version>
+	<version>3.13.900-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<name>[bundle] GEF Classic GEF Developer Documentation</name>
 	<build>

--- a/org.eclipse.gef.examples-feature/feature.xml
+++ b/org.eclipse.gef.examples-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.gef.examples"
       label="%featureName"
-      version="3.23.0.qualifier"
+      version="3.24.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gef.examples.logic"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.examples.digraph1/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.digraph1/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.gef.examples.digraph1;singleton:=true
-Bundle-Version: 1.2.400
+Bundle-Version: 1.2.500.qualifier
 Require-Bundle: org.eclipse.gef;bundle-version="[3.18.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="[3.3.0,4.0.0)";visibility:=reexport,
  org.eclipse.ui;bundle-version="[3.3.0,4.0.0)";visibility:=reexport,

--- a/org.eclipse.gef.examples.digraph2/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.digraph2/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.gef.examples.digraph2;singleton:=true
-Bundle-Version: 1.2.400
+Bundle-Version: 1.2.500.qualifier
 Require-Bundle: org.eclipse.gef.examples.digraph1;bundle-version="[1.0.0,2.0.0)";visibility:=reexport
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.gef.examples.flow/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.flow/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.gef.examples.flow; singleton:=true
-Bundle-Version: 3.16.300.qualifier
+Bundle-Version: 3.16.400.qualifier
 Bundle-Activator: org.eclipse.gef.examples.flow.FlowPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples.logic/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.logic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.logic; singleton:=true
-Bundle-Version: 3.14.700.qualifier
+Bundle-Version: 3.14.800.qualifier
 Bundle-Activator: org.eclipse.gef.examples.logicdesigner.LogicPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples.shapes/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.shapes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.shapes; singleton:=true
-Bundle-Version: 3.15.300.qualifier
+Bundle-Version: 3.15.400.qualifier
 Export-Package: org.eclipse.gef.examples.shapes.palette;x-friends:="org.eclipse.gef.tests"
 Bundle-Activator: org.eclipse.gef.examples.shapes.ShapesPlugin
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.gef.examples.text/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.text; singleton:=true
-Bundle-Version: 3.15.400.qualifier
+Bundle-Version: 3.15.500.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.gef.examples.text,

--- a/org.eclipse.gef.examples.ui.capabilities/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.ui.capabilities/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.ui.capabilities;singleton:=true
-Bundle-Version: 3.13.400.qualifier
+Bundle-Version: 3.13.500.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples.ui.pde/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.ui.pde/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.ui.pde; singleton:=true
-Bundle-Version: 3.13.400.qualifier
+Bundle-Version: 3.13.500.qualifier
 Bundle-Activator: org.eclipse.gef.examples.ui.pde.internal.GefExamplesPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Plugin.name
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.gef.examples;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.100.qualifier
 Require-Bundle: org.eclipse.gef;bundle-version="[3.21.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.33.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.207.100,4.0.0)"

--- a/org.eclipse.gef.sdk-feature/feature.xml
+++ b/org.eclipse.gef.sdk-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.gef.sdk"
       label="%featureName"
-      version="3.23.0.qualifier"
+      version="3.24.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gef"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef; singleton:=true
-Bundle-Version: 3.21.0.qualifier
+Bundle-Version: 3.21.100.qualifier
 Bundle-Activator: org.eclipse.gef.internal.InternalGEFPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.zest-feature/feature.xml
+++ b/org.eclipse.zest-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.zest"
       label="%featureName"
-      version="3.23.0.qualifier"
+      version="3.24.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.zest.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.zest.cloudio/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.cloudio/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.cloudio;singleton:=true
 Bundle-Localization: plugin
 Bundle-Vendor: %Plugin.providerName
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.100.qualifier
 Bundle-Activator: org.eclipse.zest.cloudio.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.core;singleton:=true
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.15.0.qualifier
+Bundle-Version: 1.15.100.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.draw2d;visibility:=reexport

--- a/org.eclipse.zest.doc.isv/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.doc.isv; singleton:=true
-Bundle-Version: 1.8.1000.qualifier
+Bundle-Version: 1.8.1100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.zest.doc.isv/pom.xml
+++ b/org.eclipse.zest.doc.isv/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.zest.plugins</groupId>
 	<artifactId>org.eclipse.zest.doc.isv</artifactId>
-	<version>1.8.1000-SNAPSHOT</version>
+	<version>1.8.1100-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<name>[bundle] GEF Classic Zest Developer Documentation</name>
 	<build>

--- a/org.eclipse.zest.examples.cloudio/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.examples.cloudio/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.examples.cloudio;singleton:=true
 Bundle-Localization: plugin
 Bundle-Vendor: %Plugin.providerName
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.100.qualifier
 Bundle-Activator: org.eclipse.zest.examples.cloudio.application.ui.CloudioApplicationPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.views,

--- a/org.eclipse.zest.examples.layouts/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.examples.layouts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.examples.layouts
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Automatic-Module-Name: org.eclipse.zest.examples.layouts

--- a/org.eclipse.zest.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.examples
-Bundle-Version: 3.18.200.qualifier
+Bundle-Version: 3.18.300.qualifier
 Export-Package: org.eclipse.zest.examples.jface;x-friends:="org.eclipse.zest.tests",
  org.eclipse.zest.examples.swt;x-friends:="org.eclipse.zest.tests",
  org.eclipse.zest.examples.uml;x-friends:="org.eclipse.zest.tests"

--- a/org.eclipse.zest.layouts/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.layouts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.layouts;singleton:=true
-Bundle-Version: 2.0.100.qualifier
+Bundle-Version: 2.0.200.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.zest.layouts,

--- a/org.eclipse.zest.sdk-feature/feature.xml
+++ b/org.eclipse.zest.sdk-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.zest.sdk"
       label="%featureName"
-      version="3.23.0.qualifier"
+      version="3.24.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.zest.core"
       license-feature="org.eclipse.license"

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<cbi-plugins.version>1.5.2</cbi-plugins.version>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse-gef/gef-classic.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<comparator.repo>https://download.eclipse.org/tools/gef/classic/release/3.22.0</comparator.repo>
+		<comparator.repo>https://download.eclipse.org/tools/gef/classic/release/3.23.0</comparator.repo>
 		<surefire.timeout>300</surefire.timeout>
 		<asciidoctor-maven-plugin.version>3.1.1</asciidoctor-maven-plugin.version>
 		<jruby.version>9.4.5.0</jruby.version>
@@ -58,6 +58,9 @@
 					<sourceReferences>
 						<generate>true</generate>
 					</sourceReferences>
+					<archive>
+						<addMavenDescriptor>false</addMavenDescriptor>
+					</archive>
 				</configuration>
 				<dependencies>
 					<dependency>

--- a/target-platform/GEF_classic.target
+++ b/target-platform/GEF_classic.target
@@ -7,7 +7,7 @@
 <repository location="http://download.eclipse.org/cbi/updates/license"/>
 </location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/staging/2025-03"/>
+		<repository location="https://download.eclipse.org/staging/2025-06"/>
 	    <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="0.0.0"/>
 	</location>


### PR DESCRIPTION
 - Update the version number of all features to 3.24.0
 - Bump maintenance version number of all plugins
 - Update the target platform for the API baseline to GEF Classic 3.24.0
 - Update the pom file target platform checking to GEF Classic 3.24.0
 - Update the development target platform to Eclipse 2025-06
 - Added changelog entry