### PR TITLE
Fixes ruler issues on HiDPI displays #710

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.gef.internal.ui.rulers;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.ColorConstants;
@@ -142,6 +143,8 @@ public class RulerFigure extends Figure {
 	 */
 	@Override
 	protected void paintFigure(Graphics graphics) {
+		graphics.setTextAntialias(SWT.ON);
+
 		double dotsPerUnit = getDPU();
 		Rectangle clip = transposer.t(graphics.getClip(Rectangle.SINGLETON));
 		Rectangle figClientArea = transposer.t(getClientArea());


### PR DESCRIPTION
The fix for  #710.

The main fix removes the use of temporary rotated Image for vertical marks. The result before and after on 200% display on a Windows machine is the following:

![ruler-hidpi-before](https://github.com/user-attachments/assets/96a2ac3d-75e1-4b15-a154-1d7f80b8ae99)

![ruler-hidpi-after](https://github.com/user-attachments/assets/9f4e98dd-5e1e-4b77-92cd-dcdc3f5a246d)

I've also removed the background fill under text marks performed using graphics.fillRectangle(forbiddenZone). I believe that this is unnecessary and also draws over the bottom/right border as can be also seen in before and after images. To observe this better click on each image and check the border under the digits for horizontal ruler, and to the right for vertical ruler.

The final tweak is that I've enabled text aliasing for RulerFigure. Text aliasing works by default on Linux and macOS, but is needed to be enabled explicitly on Windows. These are before and after results:

![ruler-hidpi-no-antialias](https://github.com/user-attachments/assets/1aaa70c0-5627-42b3-9507-1a56142e4f2e)

![ruler-hidpi-text-antialias png](https://github.com/user-attachments/assets/a9f25389-8d73-4a87-a1f7-83aa3f2e9a16)

The difference can only be clearly seen when text marks are multi-digit, which happens when ruler unit is set to pixels. Without text antialias vertical digits are not well aligned.