### PR TITLE
Update JavaDoc copyright to 2025 and fix invalid URL to JDK docs

### DIFF
--- a/org.eclipse.draw2d.doc.isv/javadocOptions.txt
+++ b/org.eclipse.draw2d.doc.isv/javadocOptions.txt
@@ -9,8 +9,8 @@
 -windowtitle "Draw2d API Specification"
 -doctitle "Draw2d API Specification"
 -header "<b>Draw2d</b><br>@build@"
--bottom "Copyright (c) IBM Corp. and others 2000, 2024.  All Rights Reserved."
--link https://docs.oracle.com/en/java/javase/17/
+-bottom "Copyright (c) IBM Corp. and others 2000, 2025.  All Rights Reserved."
+-link https://docs.oracle.com/en/java/javase/17/docs/api/
 -linkoffline PLUGINS_ROOT/org.eclipse.platform.doc.isv/reference/api @linkoffline-target@/org.eclipse.platform.doc.isv/reference/api
 -tag noextend:t:"@noextend"
 -tag noimplement:t:"@noimplement"

--- a/org.eclipse.gef.doc.isv/javadocOptions.txt
+++ b/org.eclipse.gef.doc.isv/javadocOptions.txt
@@ -9,8 +9,8 @@
 -windowtitle "GEF (MVC) API Specification"
 -doctitle "GEF (MVC) API Specification"
 -header "<b>GEF (MVC)</b><br>@build@"
--bottom "Copyright (c) IBM Corp. and others 2000, 2024.  All Rights Reserved."
--link https://docs.oracle.com/en/java/javase/17/
+-bottom "Copyright (c) IBM Corp. and others 2000, 2025.  All Rights Reserved."
+-link https://docs.oracle.com/en/java/javase/17/docs/api/
 -linkoffline PLUGINS_ROOT/org.eclipse.platform.doc.isv/reference/api/ @linkoffline-target@/org.eclipse.platform.doc.isv/reference/api/
 -linkoffline PLUGINS_ROOT/org.eclipse.draw2d.doc.isv/reference/api/ ../org.eclipse.draw2d.doc.isv/reference/api/
 -tag noextend:t:"@noextend"

--- a/org.eclipse.zest.doc.isv/javadocOptions.txt
+++ b/org.eclipse.zest.doc.isv/javadocOptions.txt
@@ -9,8 +9,8 @@
 -windowtitle "Zest API Specification"
 -doctitle "Zest API Specification"
 -header "<b>Zest</b><br>@build@
--bottom "Copyright (c) IBM Corp. and others 2000, 2024.  All Rights Reserved."
--link https://docs.oracle.com/en/java/javase/17/
+-bottom "Copyright (c) IBM Corp. and others 2000, 2025.  All Rights Reserved."
+-link https://docs.oracle.com/en/java/javase/17/docs/api/
 -linkoffline PLUGINS_ROOT/org.eclipse.platform.doc.isv/reference/api @linkoffline-target@/org.eclipse.platform.doc.isv/reference/api
 -linkoffline PLUGINS_ROOT/org.eclipse.draw2d.doc.isv/reference/api/ ../org.eclipse.draw2d.doc.isv/reference/api/
 -tag noextend:t:"@noextend"


### PR DESCRIPTION
Fixes: Error fetching URL: https://docs.oracle.com/en/java/javase/17/