### PR TITLE
Use monitor client area for tool tip positions

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ToolTipHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ToolTipHelper.java
@@ -57,18 +57,21 @@ public class ToolTipHelper extends PopUpHelper {
 	 * otherwise it will be painted directly above cursor.
 	 */
 	private Point computeWindowLocation(IFigure tip, int eventX, int eventY) {
-		org.eclipse.swt.graphics.Rectangle clientArea = control.getDisplay().getClientArea();
+		org.eclipse.swt.graphics.Rectangle clientArea = control.getMonitor().getClientArea();
+
 		Point preferredLocation = new Point(eventX, eventY + 26);
 
 		Dimension tipSize = getLightweightSystem().getRootFigure().getPreferredSize().getExpanded(getShellTrimSize());
 
 		// Adjust location if tip is going to fall outside display
-		if (preferredLocation.y + tipSize.height > clientArea.height) {
+		int clientRangeY = clientArea.height + clientArea.y;
+		if (preferredLocation.y + tipSize.height > clientRangeY) {
 			preferredLocation.y = eventY - tipSize.height;
 		}
 
-		if (preferredLocation.x + tipSize.width > clientArea.width) {
-			preferredLocation.x -= (preferredLocation.x + tipSize.width) - clientArea.width;
+		int clientRangeX = clientArea.width + clientArea.x;
+		if (preferredLocation.x + tipSize.width > clientRangeX) {
+			preferredLocation.x -= (preferredLocation.x + tipSize.width) - clientRangeX;
 		}
 
 		return preferredLocation;


### PR DESCRIPTION
This PR adapts the calculation to correct tooltip positions. With monitor specific scaling added for the windows implementation of SWT Display#getClientArea is currently no reliable source to calculate whether the tooltip is inside the display bounds. It is replaced with Monitor#getClientArea instead.

### How to test
Setup similar to:
- Windows
- Multiple monitors with different zoom settings, most left monitor is primary monitor
- monitor-specific UI scaling activated

Move the IDE to the right monitor and position it so e.g. the tooltip of the Palette would be outside of the monitor -> without this PR the tooltip will be either positioned completely outside of the view of way more left as expected

In my opinion it makes more sense to position the tooltips always completely on the current monitor anyway independent of the mentioned issue.