### PR TITLE
Force repaint in NativeGraphicsSource to fix broken animation

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Animation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Animation.java
@@ -251,7 +251,7 @@ public class Animation {
 	 * @since 3.2
 	 */
 	public static void run(int duration) {
-		if (state == 0) {
+		if (state == 0 || state == PLAYBACK) {
 			return;
 		}
 		try {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/NativeGraphicsSource.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/NativeGraphicsSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2010 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -56,6 +56,9 @@ public final class NativeGraphicsSource implements GraphicsSource {
 
 		// canvas.update();
 
+		// canvas.update() paints too much and only works on Windows. Use
+		// readAndDispatch() to only paint the redraw() event.
+		canvas.getDisplay().readAndDispatch();
 		return null;
 	}
 

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/AbstractSWTBotTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/AbstractSWTBotTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Patrick Ziegler and others.
+ * Copyright (c) 2024, 2025 Patrick Ziegler and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ package org.eclipse.gef.test.swtbot;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +27,9 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.swtbot.eclipse.gef.finder.SWTGefBot;
 import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
 import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefViewer;
+import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
 
+import org.eclipse.draw2d.Animation;
 import org.eclipse.draw2d.FigureCanvas;
 
 import org.eclipse.gef.EditPart;
@@ -103,5 +106,24 @@ public abstract class AbstractSWTBotTests {
 		EditPart gefEditPart = editPart.part();
 		FigureCanvas figureCanvas = (FigureCanvas) gefEditPart.getViewer().getControl();
 		figureCanvas.getLightweightSystem().getUpdateManager().performUpdate();
+	}
+
+	/**
+	 * Blocks until the current animation has finished.
+	 */
+	protected static void waitForAnimation() {
+		while (UIThreadRunnable.syncExec(() -> getAnimationState() != 0)) {
+			Thread.yield();
+		}
+	}
+
+	private static final int getAnimationState() {
+		try {
+			Field f = Animation.class.getDeclaredField("state");
+			f.setAccessible(true);
+			return f.getInt(null);
+		} catch (ReflectiveOperationException e) {
+			throw new RuntimeException(e);
+		}
 	}
 }

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/FlowDiagramTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/FlowDiagramTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Patrick Ziegler and others.
+ * Copyright (c) 2024, 2025 Patrick Ziegler and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,16 +39,19 @@ public class FlowDiagramTests extends AbstractSWTBotEditorTests {
 		editor.activateTool("Parallel Activity");
 		assertEquals(editor.getEditPart("Sleep.....").sourceConnections().size(), 1);
 		editor.getEditPart("Sleep.....").click();
+		waitForAnimation();
 		assertEquals(editor.getEditPart("Sleep.....").sourceConnections().size(), 2);
 
 		editor.activateTool("Sequential Activity");
 		assertEquals(editor.getEditPart("a 12").children().size(), 0);
 		editor.getEditPart("a 12").click();
+		waitForAnimation();
 		assertEquals(editor.getEditPart("a 12").children().size(), 1);
 
 		editor.activateTool("Activity");
 		assertEquals(editor.getEditPart("a 12").children().size(), 1);
 		editor.getEditPart("a 12").click();
+		waitForAnimation();
 		assertEquals(editor.getEditPart("a 12").children().size(), 2);
 	}
 
@@ -84,7 +87,9 @@ public class FlowDiagramTests extends AbstractSWTBotEditorTests {
 
 		editor.activateTool("Connection Creation");
 		editor.getEditPart("Sleep.....").click();
+		waitForAnimation();
 		editor.getEditPart("Wake up").click();
+		waitForAnimation();
 		assertEquals(editor.getEditPart("Sleep.....").sourceConnections().size(), 2);
 		assertEquals(editor.getEditPart("Wake up").targetConnections().size(), 2);
 	}

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/LogicDiagramTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/LogicDiagramTests.java
@@ -125,9 +125,11 @@ public class LogicDiagramTests extends AbstractSWTBotEditorTests {
 		SWTBotGefEditor editor = bot.gefEditor("emptyModel1.logic");
 		editor.activateTool("LED");
 		editor.click(50, 49);
+		waitForAnimation();
 
 		editor.activateTool("Label");
 		editor.click(200, 200);
+		waitForAnimation();
 
 		List<SWTBotGefEditPart> editParts = editor.editParts(IsInstanceOf.instanceOf(LogicLabelEditPart.class));
 		assertEquals(editParts.size(), 1);
@@ -229,9 +231,11 @@ public class LogicDiagramTests extends AbstractSWTBotEditorTests {
 		SWTBotGefEditor editor = bot.gefEditor("emptyModel1.logic");
 		editor.activateTool(tool1);
 		editor.click(5, 5);
+		waitForAnimation();
 
 		editor.activateTool(tool2);
 		editor.click(205, 5);
+		waitForAnimation();
 
 		List<SWTBotGefEditPart> editParts = editor.mainEditPart().children();
 		assertEquals(editParts.size(), 2);
@@ -294,9 +298,11 @@ public class LogicDiagramTests extends AbstractSWTBotEditorTests {
 		SWTBotGefEditor editor = bot.gefEditor("emptyModel1.logic");
 		editor.activateTool(tool1);
 		editor.click(5, 5);
+		waitForAnimation();
 
 		editor.activateTool(tool2);
 		editor.click(205, 205);
+		waitForAnimation();
 
 		List<SWTBotGefEditPart> editParts = editor.mainEditPart().children();
 		assertEquals(editParts.size(), 2);

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/AbstractGraphTest.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/AbstractGraphTest.java
@@ -123,7 +123,7 @@ public abstract class AbstractGraphTest {
 				robot = new GraphicalRobot(graph);
 				shell = graph.getShell();
 				// Wait for layout to be applied
-				waitEventLoop(0);
+				waitEventLoop(10);
 				// Run the actual test
 				statement.proceed();
 			} catch (Throwable e) {

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
@@ -78,7 +78,6 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
 import org.eclipse.draw2d.geometry.Point;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -110,7 +109,6 @@ public class GraphSWTTests extends AbstractGraphTest {
 	 * @see <a href="https://github.com/eclipse-gef/gef-classic/issues/376">here</a>
 	 */
 	@Test
-	@Disabled
 	@Snippet(type = AnimationSnippet.class)
 	public void testAnimationSnippet() {
 		AtomicInteger repaintCount = new AtomicInteger();


### PR DESCRIPTION
When the FigureCanvas is created with SWT.DOUBLE_BUFFERED, animations are not painted correctly. This is because an instance of NativeGraphicsSource is used internally, which doesn't paint synchronously.

Because the animation is done inside the UI thread, this paint operation is only processed after the animation is done.

Resolves https://github.com/eclipse/gef-classic/issues/376