### PR TITLE
Deprecate createFlyoutPreferences(Preferences) for removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 ## GEF
 
  - When used with SWT 3.130.0 or newer, the `org.eclipse.swt.svg` bundle (or similar) is required.
+ - FlyoutPaletteComposite: createFlyoutPreferences(Preferences) has been marked for removal.
+   Please use createFlyoutPreferences(IPreferenceStore) instead.
 
 ## Zest
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditorWithFlyoutPalette.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditorWithFlyoutPalette.java
@@ -129,7 +129,7 @@ public abstract class GraphicalEditorWithFlyoutPalette extends GraphicalEditor {
 	 */
 	@SuppressWarnings("static-method")
 	protected FlyoutPreferences getPalettePreferences() {
-		return FlyoutPaletteComposite.createFlyoutPreferences(InternalGEFPlugin.getDefault().getPluginPreferences());
+		return FlyoutPaletteComposite.createFlyoutPreferences(InternalGEFPlugin.getDefault().getPreferenceStore());
 	}
 
 	/**


### PR DESCRIPTION
The Preferences class has been deprecated since forever with the IEclipsePreferences as its replacement. Instances of this type can be used via the ScopedPreferenceStore, but other implementations are also permitted.