### PR TITLE
Migrate to new DND cursors and raise minimum requirement to 2024-09

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
           - java: 21
             target: master
           - java: 17
-            target: baseline
+            target: 2024-09
     runs-on: ${{ matrix.os }} 
     name: OS ${{ matrix.os }} Target ${{ matrix.target }} compile
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## GEF
 
+ - Raised minimum requirement to Eclipse 2024-09
+
 ## Zest
 
 # GEF Classic 3.24.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The code base of the GEF components implemented in JavaFX is located in the [ecl
 
 # Requirements:
 
-- Eclipse 2024-06 or later
+- Eclipse 2024-06 (Draw2D/Zest), Eclipse 2024-09 (GEF) or later
 - Java 17 or later
 
 # Update sites:

--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -34,7 +34,7 @@ Export-Package: org.eclipse.gef,
 Require-Bundle: org.eclipse.draw2d;visibility:=reexport;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.views;resolution:=optional;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.ui.workbench;bundle-version="[3.2.0,4.0.0)",
+ org.eclipse.ui.workbench;bundle-version="[3.133.0,4.0.0)",
  org.eclipse.jface;bundle-version="[3.2.0,4.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -1581,22 +1581,18 @@ public class FlyoutPaletteComposite extends Composite {
 		 * @param code the code
 		 * @return the cursor
 		 */
-		@SuppressWarnings("removal") // Still required for 2024-06
 		public static Cursor getCursor(int code) {
 			if (cursors[code] == null) {
 				switch (code) {
 				case LEFT:
-					cursors[LEFT] = createCursor(ISharedImages.IMG_OBJS_DND_LEFT_SOURCE,
-							ISharedImages.IMG_OBJS_DND_LEFT_MASK);
+					cursors[LEFT] = createCursor(ISharedImages.IMG_OBJS_DND_LEFT);
 					break;
 				case RIGHT:
-					cursors[RIGHT] = createCursor(ISharedImages.IMG_OBJS_DND_RIGHT_SOURCE,
-							ISharedImages.IMG_OBJS_DND_RIGHT_MASK);
+					cursors[RIGHT] = createCursor(ISharedImages.IMG_OBJS_DND_RIGHT);
 					break;
 				default:
 				case INVALID:
-					cursors[INVALID] = createCursor(ISharedImages.IMG_OBJS_DND_INVALID_SOURCE,
-							ISharedImages.IMG_OBJS_DND_INVALID_MASK);
+					cursors[INVALID] = createCursor(ISharedImages.IMG_OBJS_DND_INVALID);
 					break;
 				}
 			}
@@ -1610,17 +1606,15 @@ public class FlyoutPaletteComposite extends Composite {
 		 * The strings passed as arguments must belong to the source and mask ids of a
 		 * cursor contributed by {@link ISharedImages}.
 		 */
-		private static Cursor createCursor(String sourceName, String maskName) {
+		private static Cursor createCursor(String sourceName) {
 			ImageDescriptor source = PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(sourceName);
-			ImageDescriptor mask = PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(maskName);
 			int deviceZoom = InternalGEFPlugin.getOrDefaultDeviceZoom();
 			// Scales the image if the display is using neither 100% nor 200% zoom
 			ImageData sourceData = InternalGEFPlugin.scaledImageData(source, deviceZoom);
-			ImageData maskData = InternalGEFPlugin.scaledImageData(mask, deviceZoom);
 			// Hotspot should be the center of the image. e.g. (16, 16) on 100% zoom
 			int hotspotX = sourceData.width / 2;
 			int hotspotY = sourceData.height / 2;
-			return new Cursor(null, sourceData, maskData, hotspotX, hotspotY);
+			return new Cursor(null, sourceData, hotspotX, hotspotY);
 		}
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -363,9 +363,9 @@
 				<id>master</id>
 			</profile>
 			<profile>
-				<id>baseline</id>
+				<id>2024-09</id>
 				<properties>
-					<target-platform>../org.eclipse.gef.baseline/gef-classic-3.20.0.target</target-platform>
+					<target-platform>../org.eclipse.gef.baseline/gef-classic-3.21.0.target</target-platform>
 					<execution-environment>JavaSE-17</execution-environment>
 					<tycho.p2.baseline.skip>true</tycho.p2.baseline.skip>
 				</properties>


### PR DESCRIPTION
From: https://github.com/eclipse-platform/eclipse.platform.ui/issues/3047#issuecomment-2987267494
> The issue is rooted in the SVG image rasterization. When the
> rasterization result is converted into SWT image data, that image data
> is created with a 32bit data palette. This leads to a difference in
> the image data used for the cursors, as they originally contained 24
> bit data (not having an alpha channel).

With the 2024-09, those constants have been deprecated and replaced with equivalent cursors that don't require a mask.