### PR TITLE
Replacing usages of Device#getDPI

### DIFF
--- a/org.eclipse.draw2d.examples/sandbox/swt/bugs/Bug81467.java
+++ b/org.eclipse.draw2d.examples/sandbox/swt/bugs/Bug81467.java
@@ -15,7 +15,6 @@ package swt.bugs;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.printing.Printer;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.PrinterGraphics;
 import org.eclipse.draw2d.SWTGraphics;
@@ -23,6 +22,7 @@ import org.eclipse.draw2d.SWTGraphics;
 public class Bug81467 {
 
 	public static void main(String[] args) {
+		final float DOTS_PER_INCH = 96.0f;
 		Font font = new Font(null, "Helvetica", 12, 0); //$NON-NLS-1$
 		Printer printer = new Printer();
 		printer.startJob("bugzilla 81467"); //$NON-NLS-1$
@@ -31,7 +31,7 @@ public class Bug81467 {
 		SWTGraphics graphics = new SWTGraphics(gc);
 		PrinterGraphics printGraphics = new PrinterGraphics(graphics, printer);
 
-		printGraphics.scale((double) printer.getDPI().x / Display.getDefault().getDPI().x);
+		printGraphics.scale(printer.getDPI().x / DOTS_PER_INCH);
 		printGraphics.setFont(font);
 		printGraphics.drawString("Hello world", 50, 50); //$NON-NLS-1$
 		printGraphics.dispose();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
@@ -13,7 +13,6 @@
 package org.eclipse.gef.internal.ui.rulers;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Figure;
@@ -52,6 +51,7 @@ public class RulerFigure extends Figure {
 	 * paintFigure(Graphics) method.
 	 */
 	private static final int BORDER_WIDTH = 3;
+	private static final float DOTS_PER_INCH = 96.0f;
 
 	private boolean horizontal;
 	private int unit;
@@ -78,7 +78,7 @@ public class RulerFigure extends Figure {
 			case RulerProvider.UNIT_PIXELS -> dpu = 1.0;
 			case RulerProvider.UNIT_CUSTOM -> dpu = rulerProvider.getCustomRulerDPU();
 			default -> {
-				dpu = transposer.t(new Dimension(Display.getCurrent().getDPI())).height;
+				dpu = DOTS_PER_INCH;
 				if (getUnit() == RulerProvider.UNIT_CENTIMETERS) {
 					dpu = dpu / 2.54;
 				}


### PR DESCRIPTION
Having the scale factor being based on the screen DPI leads to unexpected result. Having a screen dpi independent factor leads to consistent results.

### How to test

- Run this example 
- See if it doesn't break after the current changes. 
```
import org.eclipse.swt.layout.FillLayout;
import org.eclipse.swt.widgets.Display;
import org.eclipse.swt.widgets.Shell;

import org.eclipse.draw2d.FigureCanvas;
import org.eclipse.draw2d.Graphics;
import org.eclipse.draw2d.LightweightSystem;
import org.eclipse.draw2d.SWTGraphics;
import org.eclipse.draw2d.geometry.Dimension;
import org.eclipse.draw2d.geometry.Rectangle;

import org.eclipse.gef.rulers.RulerProvider;

public class RulerFigureExample {

	public static void main(String[] args) {
		Display display = new Display();
		Shell shell = new Shell(display);
		shell.setText("RulerFigure Standalone Example");
		shell.setSize(400, 100);
		shell.setLayout(new FillLayout());

		// Create FigureCanvas (Draw2D widget)
		FigureCanvas canvas = new FigureCanvas(shell);
		LightweightSystem lws = new LightweightSystem(canvas);

		// Create horizontal RulerFigure
		RulerFigure ruler = new RulerFigure(true, new RulerProvider() {
		});
		// Optionally set interval: major marks every 10 units, 5 divisions
		ruler.setInterval(10, 5);

		// Set preferred size
		Dimension prefSize = ruler.getPreferredSize(-1, -1);
		ruler.setBounds(new Rectangle(0, 0, 380, prefSize.height));

		// Set the root figure of the canvas to the ruler
		lws.setContents(ruler);

		// Add a PaintListener to the canvas's SWT control to explicitly call
		// paintFigure
		canvas.addPaintListener(e -> {
			// Create Draw2D Graphics from SWT GC
			Graphics graphics = new SWTGraphics(e.gc);
			// Manually call paintFigure on the ruler
			ruler.paintFigure(graphics);
		});

		shell.open();

		while (!shell.isDisposed()) {
			if (!display.readAndDispatch()) {
				display.sleep();
			}
		}
		display.dispose();
	}
}

```

### Screenshot
![image](https://github.com/user-attachments/assets/5edbb759-4869-4185-867b-299e713cc783)
