### PR TITLE
Cursors in GEF uses ImageDataProvider instead of ImageData

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
@@ -18,6 +18,7 @@ import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.eclipse.draw2d.Cursors;
 
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 
 /**
@@ -45,15 +46,15 @@ public class SharedCursors extends Cursors {
 	public static final Cursor CURSOR_TREE_MOVE;
 
 	static {
-		CURSOR_PLUG = createCursor("icons/plug-cursor.png"); //$NON-NLS-1$
-		CURSOR_PLUG_NOT = createCursor("icons/plugnot-cursor.png"); //$NON-NLS-1$
-		CURSOR_TREE_ADD = createCursor("icons/tree_add-cursor.png"); //$NON-NLS-1$
-		CURSOR_TREE_MOVE = createCursor("icons/tree_move-cursor.png"); //$NON-NLS-1$
+		CURSOR_PLUG = createCursor("icons/plug-cursor.svg"); //$NON-NLS-1$
+		CURSOR_PLUG_NOT = createCursor("icons/plugnot-cursor.svg"); //$NON-NLS-1$
+		CURSOR_TREE_ADD = createCursor("icons/tree_add-cursor.svg"); //$NON-NLS-1$
+		CURSOR_TREE_MOVE = createCursor("icons/tree_move-cursor.svg"); //$NON-NLS-1$
 	}
 
 	private static Cursor createCursor(String sourceName) {
 		ImageDescriptor src = InternalImages.createDescriptor(sourceName);
-		return new Cursor(null, src.getImageData(100), 0, 0);
+		return InternalGEFPlugin.createCursor(src, 0, 0);
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -34,7 +34,6 @@ import org.eclipse.swt.events.MouseTrackListener;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
@@ -1608,13 +1607,10 @@ public class FlyoutPaletteComposite extends Composite {
 		 */
 		private static Cursor createCursor(String sourceName) {
 			ImageDescriptor source = PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(sourceName);
-			int deviceZoom = InternalGEFPlugin.getOrDefaultDeviceZoom();
-			// Scales the image if the display is using neither 100% nor 200% zoom
-			ImageData sourceData = InternalGEFPlugin.scaledImageData(source, deviceZoom);
 			// Hotspot should be the center of the image. e.g. (16, 16) on 100% zoom
-			int hotspotX = sourceData.width / 2;
-			int hotspotY = sourceData.height / 2;
-			return new Cursor(null, sourceData, hotspotX, hotspotY);
+			int hotspotX = source.getImageData(100).width / 2;
+			int hotspotY = source.getImageData(100).height / 2;
+			return InternalGEFPlugin.createCursor(source, hotspotX, hotspotY);
 		}
 	}
 }


### PR DESCRIPTION
This change ensures that cursor images scale appropriately based on the display's zoom level .


Steps to reproduce

Steps to reproduce cursors  are mentioned in  https://github.com/vi-eclipse/Eclipse-Platform/issues/331 
> To test with GEF, one should check out the GEF Classic repository: https://github.com/eclipse-gef/gef-classic Then import the `org.eclipse.draw2d`, `org.eclipse.gef` and the `org.eclipse.gef.examples.logic` (the latter for testing) to your Eclipse development workspace and add them to the product you are testing. With the "New" wizard, you can create a logic example to test out the cursors via inserting elements, dragging and dropping etc. (see also [this issue](https://github.com/eclipse-platform/eclipse.platform.ui/issues/3047) for an example): ![Image](https://github.com/user-attachments/assets/79212a53-b9f7-4d1c-8f47-2e7c8f3ba450)
Cursors can be seen once a component is selected and mouse is moved around

Cursors from [SharedCursors.java](https://github.com/eclipse-gef/gef-classic/compare/master...vi-eclipse:gef-classic:arunjose696/CursorsHidpi?expand=1#diff-19ba70b004f0b1526dec35c8c77132489b5eb65bf58cf035ec2a9229969acfc7) can be seen during selecting components in pallete and moving them to diagram.

Cursors from [FlyoutPaletteComposite.java](https://github.com/eclipse-gef/gef-classic/compare/master...vi-eclipse:gef-classic:arunjose696/CursorsHidpi?expand=1#diff-ed1af00820d20af3fa12542858ff101ce66e4ad4e1690b9ed0c4e7805e2a183c) appear when dragging and repositioning the palette menu.