### PR TITLE
Separate cursor icon from its decoration for the shared cursors.

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
@@ -15,9 +15,12 @@ package org.eclipse.gef;
 import org.eclipse.swt.graphics.Cursor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
+import org.eclipse.jface.viewers.IDecoration;
 
 import org.eclipse.draw2d.Cursors;
 
+import org.eclipse.gef.internal.InternalCursor;
 import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 
@@ -53,6 +56,12 @@ public class SharedCursors extends Cursors {
 	}
 
 	private static Cursor createCursor(String sourceName) {
+		if (InternalGEFPlugin.isSvgSupported()) {
+			ImageDescriptor src1 = InternalImages.createDescriptor(sourceName);
+			ImageDescriptor src2 = InternalCursor.getCursorDescriptor();
+			ImageDescriptor src = new DecorationOverlayIcon(src1, src2, IDecoration.TOP_LEFT);
+			return new Cursor(null, src.getImageData(100), 0, 0);
+		}
 		ImageDescriptor src = InternalImages.createDescriptor(sourceName);
 		return InternalGEFPlugin.createCursor(src, 0, 0);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalCursor.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalCursor.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.PaletteData;
+import org.eclipse.swt.graphics.Path;
+import org.eclipse.swt.widgets.Display;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+
+import org.eclipse.draw2d.ColorConstants;
+
+/**
+ * This class defines the shape of the default GEF-cursor used for the plug/tree
+ * images. The cursor can't be part of the SVG itself, as it is a)
+ * platform-specific and b) because SWT doesn't respect the
+ * {@code non-scaling-stroke} vector effect, which ensures that the cursor
+ * always has a stroke-width of 1px.
+ */
+public class InternalCursor {
+	/**
+	 * Defines the shape of the cursor at 100% zoom.
+	 */
+	//@formatter:off
+	private static final float[] CURSOR_POINTS = {
+			 0f,  0f,
+			 0f, 17f,
+			 4f, 13f,
+			 7f, 19f,
+			 9f, 18f,
+			 7f, 13f,
+			 7f, 12f,
+			12f, 12f,
+			 0f,  0f
+	};
+	//@formatter:on
+	/**
+	 * Local cache to store the cursor data for each zoom level.
+	 */
+	private static final Map<Integer, ImageData> CURSOR_AT_ZOOM = new HashMap<>();
+	/**
+	 * The default cursor that is constructed using {link {@link #CURSOR_POINTS}.
+	 * May be replaced with a custom cursor by calling
+	 * {@link #setCursorDescriptor(ImageDescriptor)}.
+	 */
+	private static ImageDescriptor CURRENT_CURSOR_DESCRIPTOR = ImageDescriptor
+			.createFromImageDataProvider(zoom -> CURSOR_AT_ZOOM.computeIfAbsent(zoom, InternalCursor::getCursorAtZoom));
+
+	/**
+	 * This method generates the image data for the cursor at the given zoom level.
+	 * The points defined with {@link #CURSOR_POINTS} are scaled by the given zoom
+	 * and painted onto an image.
+	 *
+	 * @param zoom The zoom level. e.g. 100, 125, 200
+	 * @return The cursor image data at the given zoom level.
+	 */
+	private static ImageData getCursorAtZoom(int zoom) {
+		float maxWidth = 0f;
+		float maxHeight = 0f;
+
+		for (int i = 0; i < CURSOR_POINTS.length; i += 2) {
+			maxWidth = Math.max(maxWidth, CURSOR_POINTS[i]);
+			maxHeight = Math.max(maxHeight, CURSOR_POINTS[i + 1]);
+		}
+
+		float zoomFactor = zoom / 100.0f;
+
+		int width = 1 + (int) Math.ceil(zoomFactor * maxWidth);
+		int height = 1 + (int) Math.ceil(zoomFactor * maxHeight);
+
+		//
+		Display display = Display.getDefault();
+		// Construct path
+		Path path = new Path(display);
+		for (int i = 0; i < CURSOR_POINTS.length; i += 2) {
+			float x = zoomFactor * CURSOR_POINTS[i];
+			float y = zoomFactor * CURSOR_POINTS[i + 1];
+			if (i == 0) {
+				path.moveTo(x, y);
+			} else {
+				path.lineTo(x, y);
+			}
+		}
+		// Construct image
+		ImageData imageData = new ImageData(width, height, 32, new PaletteData(0xFF0000, 0x00FF00, 0x0000FF));
+		imageData.alphaData = new byte[width * height];
+		Image image = new Image(display, imageData);
+		GC gc = new GC(image);
+		gc.setAlpha(0);
+		gc.fillRectangle(0, 0, width, height);
+		gc.setAlpha(255);
+		gc.setAntialias(SWT.ON);
+		gc.setLineWidth(1);
+		gc.setBackground(ColorConstants.white);
+		gc.fillPath(path);
+		gc.setBackground(ColorConstants.black);
+		gc.drawPath(path);
+		gc.dispose();
+		path.dispose();
+		// Image is already scaled to expected zoom level
+		imageData = image.getImageData(100);
+		image.dispose();
+		return imageData;
+	}
+
+	/**
+	 * Returns the image descriptor for the GEF cursor. Never {@code null}.
+	 *
+	 * @return Either the default or a custom cursor descriptor.
+	 */
+	public static ImageDescriptor getCursorDescriptor() {
+		return CURRENT_CURSOR_DESCRIPTOR;
+	}
+
+	/**
+	 * Convenience method to allow replacing the default cursor descriptor. An
+	 * exception is thrown if {@code cursorDescriptor} is {@code null}.
+	 *
+	 * @param cursorDescriptor The new cursor descriptor.
+	 */
+	public static void setCursorDescriptor(ImageDescriptor cursorDescriptor) {
+		Objects.requireNonNull(cursorDescriptor, "The new cursor descriptor must not be null!"); //$NON-NLS-1$
+		CURRENT_CURSOR_DESCRIPTOR = cursorDescriptor;
+	}
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/plug-cursor.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/plug-cursor.svg
@@ -56,8 +56,4 @@
            id="path6150-7" /><path
            style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
            d="m 6.121797,4.7626052 c 0.032741,0.032741 0.1061657,0.032741 0.1389062,0 0.032741,-0.032741 0.032741,-0.1061658 0,-0.1389063 -0.032741,-0.032741 -0.1061657,-0.032741 -0.1389062,0 -0.032741,0.032741 -0.032741,0.1061657 0,0.1389063 z"
-           id="path6204-5" /></g></g></g><g
-     id="layer2"><path
-       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 0.1322915,0.31937993 V 4.8172967 L 1.1906248,3.49438 l 0.79375,1.8520834 c 0,0 0.1493518,0.2168528 0.2645834,0.2645833 0.081481,0.033751 0.1831023,0.033751 0.2645833,0 0.1152316,-0.047731 0.2168529,-0.1493517 0.2645834,-0.2645833 0.033751,-0.081481 0,-0.2645834 0,-0.2645834 L 1.9843748,3.49438 V 3.2297967 h 1.0583334 z"
-       id="path3819" /></g></svg>
+           id="path6204-5" /></g></g></g></svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/plugnot-cursor.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/plugnot-cursor.svg
@@ -100,12 +100,4 @@
       </g>
     </g>
   </g>
-  <g
-     id="layer2"
-     style="display:inline">
-    <path
-       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 0.1322915,0.31937993 V 4.8172967 L 1.1906248,3.49438 l 0.79375,1.8520834 c 0,0 0.1493518,0.2168528 0.2645834,0.2645833 0.081481,0.033751 0.1831023,0.033751 0.2645833,0 0.1152316,-0.047731 0.2168529,-0.1493517 0.2645834,-0.2645833 0.033751,-0.081481 0,-0.2645834 0,-0.2645834 L 1.9843748,3.49438 V 3.2297967 h 1.0583334 z"
-       id="path3819" />
-  </g>
 </svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/tree_add-cursor.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/tree_add-cursor.svg
@@ -367,14 +367,4 @@
        d="M 3.9687501,7.1437502 V 6.8791668 H 4.4979168 V 6.3500002 H 4.7625001 V 6.8791668 H 5.2916668 V 7.1437502 H 4.7625001 V 7.6729169 H 4.4979168 V 7.1437502 Z"
        id="path7764" />
   </g>
-  <g
-     id="layer3"
-     style="display:inline">
-       id=&quot;layer1&quot;
-       transform=&quot;matrix(0.6666441,0,0,0.6666441,3.5705122e-5,0.02583344)&quot;&gt;
-    <path
-   style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-   d="M 0.13229167,0.31937993 V 4.8172967 L 1.190625,3.49438 1.984375,5.3464634 c 0,0 0.1493518,0.2168528 0.2645834,0.2645833 0.081481,0.033751 0.1831023,0.033751 0.2645833,0 0.1152316,-0.047731 0.2168529,-0.1493517 0.2645834,-0.2645833 0.033751,-0.081481 0,-0.2645834 0,-0.2645834 L 1.984375,3.49438 V 3.2297967 h 1.0583334 z"
-   id="path3819" />
-</g>
 </svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/tree_move-cursor.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/tree_move-cursor.svg
@@ -350,14 +350,4 @@
        d="M 3.4395834,4.7625001 V 5.0270834 H 3.7041667 V 4.7625001 Z"
        id="path3804-3-9-1-7" />
   </g>
-  <g
-     id="layer3"
-     style="display:inline">
-       id=&quot;layer1&quot;
-       transform=&quot;matrix(0.6666441,0,0,0.6666441,3.5705122e-5,0.02583344)&quot;&gt;
-    <path
-   style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-   d="M 0.13229167,0.31937993 V 4.8172967 L 1.190625,3.49438 1.984375,5.3464634 c 0,0 0.1493518,0.2168528 0.2645834,0.2645833 0.081481,0.033751 0.1831023,0.033751 0.2645833,0 0.1152316,-0.047731 0.2168529,-0.1493517 0.2645834,-0.2645833 0.033751,-0.081481 0,-0.2645834 0,-0.2645834 L 1.984375,3.49438 V 3.2297967 h 1.0583334 z"
-   id="path3819" />
-</g>
 </svg>


### PR DESCRIPTION
The way cursors are rendered on Windows is that regardless of the zoom level, the stroke width of the cursor is always 1px wide. When using an SVG, this would normally be achieved by setting the "non-scaling-stroke" vector effect.

Sadly, this effect is not supported by the jSVG rasterizer that is used by SWT and as a result, the stroke width is scaled proportionally to the zoom level. I.e. 1px at 100%, 2px at 200% and so on.

To work around this limitation, the cursor is separated from the remaining components and constructed on-the-fly, The complete cursor is then a composite of the SVG and this generated cursor.