### PR TITLE
Cleanup configuration of sonar-maven-plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,14 +143,10 @@ def void mvn() {
            --no-transfer-progress \
            -DapiBaselineTargetDirectory=${WORKSPACE} \
            -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-           -Dproject.build.sourceEncoding=UTF-8 \
            -Dbuild.id=${BUILD_TIMESTAMP} \
            -Dcommit.id=$GIT_COMMIT \
            -Dbuild.type=$BUILD_TYPE \
            -Dorg.eclipse.justj.p2.manager.build.url=$JOB_URL \
-           -Dsonar.exclusions=**/.tycho-consumer-pom.xml \
-           -Dsonar.projectKey=gef-classic \
-           -Dsonar.organization=eclipse \
            clean \
            verify \
            sonar:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
 		<jruby.version>9.4.5.0</jruby.version>
 		<target-platform>../target-platform/GEF_classic.target</target-platform>
 		<execution-environment>JavaSE-21</execution-environment>
+		<!-- SonarQube configuration -->
+		<sonar.exclusion>**/.tycho-consumer-pom.xml</sonar.exclusion>
+		<sonar.projectKey>gef-classic</sonar.projectKey>
+		<sonar.java.binaries>${project.build.outputDirectory}</sonar.java.binaries>
+		<sonar.organization>eclipse</sonar.organization>
 	</properties>
 
 	<build>
@@ -315,7 +320,7 @@
 				<plugin>
 					<groupId>org.sonarsource.scanner.maven</groupId>
 					<artifactId>sonar-maven-plugin</artifactId>
-					<version>5.0.0.4389</version>
+					<version>5.1.0.4751</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
This change updates the plugin from 5.0.0.4389 to 5.1.0.4751 and also moves part of its configuration from the Jenkinsfile to the parent pom.

In order to avoid the "'sonar.java.binaries' is empty" warning, this property is now initialized with the project-relative "target/classes" path.