### PR TITLE
Avoid using non-disposed resources in LabelTest

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LabelTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LabelTest.java
@@ -135,7 +135,7 @@ public class LabelTest extends BaseTestCase {
 		assertSame(size2, label.getPreferredSize());
 		//
 		// check calc preferred size if font is changed
-		label.setFont(new Font(null, "", 100, SWT.NONE)); //$NON-NLS-1$
+		label.setFont(testFont);
 		assertNotSame(size2, label.getPreferredSize());
 		assertTextSize(label);
 		//


### PR DESCRIPTION
This corrects a minor oversight introduced with
2e46a0b3f2d40e5777c864b1f5a2d069e4e4b988. One of the tests creates a new Font, but never disposes it, even though an identical Font is created that is disposed once the test finishes.