### PR TITLE
Minor cleanup of online help

### DIFF
--- a/org.eclipse.draw2d.doc.isv/guide-src/guide.adoc
+++ b/org.eclipse.draw2d.doc.isv/guide-src/guide.adoc
@@ -4,8 +4,7 @@ endif::[]
 
 = Draw2d Guide
 
-== Draw2d Programmer's Guide +
-org.eclipse.draw2d +
+== Draw2d Programmer's Guide
 
 * xref:overview.adoc[Overview] - the big picture
 * xref:painting.adoc[Painting] - details of the paint process and how

--- a/org.eclipse.gef.doc.isv/about.html
+++ b/org.eclipse.gef.doc.isv/about.html
@@ -1,24 +1,3 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
-<html>
-<head>
-<title>About</title>
-<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
-</head>
-<body lang="EN-US">
-<h2>About This Content</h2>
- 
-<p>June 5, 2007</p>	
-<h3>License</h3>
-
-<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise indicated below, the Content is provided to you under the terms and conditions of the
-Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available at <a href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/legal/epl-v10.html</a>.
-For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
-
-<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
-apply to your use of any object code in the Content.  Check the Redistributor's license that was provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
-indicated below, the terms and conditions of the EPL still apply to any source code in the Content and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
-</body>
-</html><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 
 <head>

--- a/org.eclipse.gef.doc.isv/guide-src/guide.adoc
+++ b/org.eclipse.gef.doc.isv/guide-src/guide.adoc
@@ -4,8 +4,7 @@ endif::[]
 
 = GEF Developer's Guide
 
-== GEF Programmer's Guide +
-org.eclipse.gef
+== GEF Programmer's Guide
 
 * xref:#overview[Overview] - Description of the "big picture"
 * xref:#when-can-i-use-gef[When to Use] - How can GEF and the Eclipse Platform

--- a/org.eclipse.gef.doc.isv/guide-src/index.adoc
+++ b/org.eclipse.gef.doc.isv/guide-src/index.adoc
@@ -4,8 +4,7 @@ endif::[]
 
 = org.eclipse.gef Programmer's Guide
 
-== GEF Programmer's Guide +
-org.eclipse.gef
+== GEF Programmer's Guide
 
 Draw2d focuses on efficient painting and layout of figures. The GEF
 plug-in adds an editing layer on top of Draw2d. The purpose of this

--- a/org.eclipse.gef.doc.isv/topics_Guide.xml
+++ b/org.eclipse.gef.doc.isv/topics_Guide.xml
@@ -7,13 +7,13 @@
 	<anchor id="draw2d" />
 	<anchor id="zest" />
 	<topic label="GEF (MVC)" href="guide/guide.html">
-		<topic label="Overview" href="guide/guide.html#Overview"/>
-		<topic label="When and Where to Use GEF" href="guide/guide.html#When"/>
-		<topic label="EditParts" href="guide/guide.html#EditParts"/>
-		<topic label="Creating a Graphical View" href="guide/guide.html#GraphicalView"/>
-		<topic label="Editing and EditPolicies" href="guide/guide.html#Editing"/>
-		<topic label="The EditPart Lifecycle" href="guide/guide.html#Lifecycle"/>
-		<topic label="Tools and the Palette" href="guide/guide.html#ToolPalette"/>
-		<topic label="Types of Interactions" href="guide/guide.html#Interactions"/>
+		<topic label="Overview" href="guide/guide.html#overview"/>
+		<topic label="When and Where to Use GEF" href="guide/guide.html#when-can-i-use-gef"/>
+		<topic label="EditParts" href="guide/guide.html#an-introduction-to-editparts"/>
+		<topic label="Creating a Graphical View" href="guide/guide.html#creating-a-graphical-view-of-a-model"/>
+		<topic label="Editing and EditPolicies" href="guide/guide.html#editing-and-editpolicies"/>
+		<topic label="The EditPart Lifecycle" href="guide/guide.html#the-editpart-lifecycle"/>
+		<topic label="Tools and the Palette" href="guide/guide.html#tools-and-the-palette"/>
+		<topic label="Types of Interactions" href="guide/guide.html#types-of-interactions-in-gef"/>
 	</topic>
 </toc>


### PR DESCRIPTION
This cleans up some artifacts that remained when the HTML document was converted to AsciiDoc, the broken about.html file and the broken HREF attributes in the topics xml file.