### PR TITLE
Handle HiDPI scaling in GEF diagrams

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 /**
  * Provides miscellaneous Figure operations.
@@ -73,7 +74,9 @@ public class FigureUtilities {
 	@Deprecated
 	protected static GC getGC() {
 		if (gc == null) {
-			gc = new GC(new Shell());
+			Shell shell = new Shell();
+			InternalDraw2dUtils.configureForAutoscalingMode(shell);
+			gc = new GC(shell);
 			appliedFont = gc.getFont();
 		}
 		return gc;
@@ -424,5 +427,4 @@ public class FigureUtilities {
 		}
 		return !figBounds.isEmpty();
 	}
-
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -77,6 +77,9 @@ public class FigureUtilities {
 			Shell shell = new Shell();
 			InternalDraw2dUtils.configureForAutoscalingMode(shell);
 			gc = new GC(shell);
+			if (InternalDraw2dUtils.disableAutoscale) {
+				gc.setAdvanced(true);
+			}
 			appliedFont = gc.getFont();
 		}
 		return gc;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableFigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableFigureUtilities.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.draw2d.internal;
+
+import java.util.Objects;
+
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontMetrics;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.widgets.Control;
+
+import org.eclipse.draw2d.geometry.Dimension;
+
+/**
+ * Provides miscellaneous Figure operations calculated with the zoom context of
+ * the the provided {@code Drawable}.
+ *
+ * All GC related operations are mirrored from {@code FigureUtilities}
+ */
+public class DrawableFigureUtilities {
+	private final GC gc;
+	private Font appliedFont;
+	private FontMetrics metrics;
+
+	public DrawableFigureUtilities(Control source) {
+		gc = new GC(source);
+		source.addDisposeListener(e -> {
+			gc.dispose();
+		});
+		appliedFont = gc.getFont();
+	}
+
+	/**
+	 * Returns the FontMetrics associated with the passed Font.
+	 *
+	 * @param f the font
+	 * @return the FontMetrics for the given font
+	 * @see GC#getFontMetrics()
+	 */
+	public FontMetrics getFontMetrics(Font f) {
+		setFont(f);
+		if (metrics == null) {
+			metrics = gc.getFontMetrics();
+		}
+		return metrics;
+	}
+
+	/**
+	 * Returns the dimensions of the String <i>s</i> using the font <i>f</i>. Tab
+	 * expansion and carriage return processing are performed.
+	 *
+	 * @param s the string
+	 * @param f the font
+	 * @return the text's dimensions
+	 * @see GC#textExtent(String)
+	 */
+	protected org.eclipse.swt.graphics.Point getTextDimension(String s, Font f) {
+		setFont(f);
+		return gc.textExtent(s);
+	}
+
+	/**
+	 * Returns the dimensions of the String <i>s</i> using the font <i>f</i>. No tab
+	 * expansion or carriage return processing will be performed.
+	 *
+	 * @param s the string
+	 * @param f the font
+	 * @return the string's dimensions
+	 * @see GC#stringExtent(java.lang.String)
+	 */
+	protected org.eclipse.swt.graphics.Point getStringDimension(String s, Font f) {
+		setFont(f);
+		return gc.stringExtent(s);
+	}
+
+	/**
+	 * Returns the Dimensions of the given text, converting newlines and tabs
+	 * appropriately.
+	 *
+	 * @param text the text
+	 * @param f    the font
+	 * @return the dimensions of the given text
+	 */
+	public Dimension getTextExtents(String text, Font f) {
+		return new Dimension(getTextDimension(text, f));
+	}
+
+	/**
+	 * Returns the Dimensions of <i>s</i> in Font <i>f</i>.
+	 *
+	 * @param s the string
+	 * @param f the font
+	 * @return the dimensions of the given string
+	 */
+	public Dimension getStringExtents(String s, Font f) {
+		return new Dimension(getStringDimension(s, f));
+	}
+
+	/**
+	 * Returns the Dimensions of the given text, converting newlines and tabs
+	 * appropriately.
+	 *
+	 * @param s      the string
+	 * @param f      the font
+	 * @param result the Dimension that will contain the result of this calculation
+	 */
+	public void getTextExtents(String s, Font f, Dimension result) {
+		org.eclipse.swt.graphics.Point pt = getTextDimension(s, f);
+		result.width = pt.x;
+		result.height = pt.y;
+	}
+
+	/**
+	 * Returns the width of <i>s</i> in Font <i>f</i>.
+	 *
+	 * @param s the string
+	 * @param f the font
+	 * @return the width
+	 */
+	public int getTextWidth(String s, Font f) {
+		return getTextDimension(s, f).x;
+	}
+
+	private void setFont(Font f) {
+		if (Objects.equals(appliedFont, f)) {
+			return;
+		}
+		gc.setFont(f);
+		appliedFont = f;
+		metrics = null;
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableTextUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableTextUtilities.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.internal;
+
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontMetrics;
+import org.eclipse.swt.widgets.Control;
+
+import org.eclipse.draw2d.TextUtilities;
+import org.eclipse.draw2d.geometry.Dimension;
+
+/**
+ * Provides miscellaneous text operations calculated with the zoom context of
+ * the the provided {@code Drawable}.
+ */
+public class DrawableTextUtilities extends TextUtilities {
+
+	private final DrawableFigureUtilities figureUtilities;
+
+	public DrawableTextUtilities(Control source) {
+		figureUtilities = new DrawableFigureUtilities(source);
+	}
+
+	/**
+	 * Returns the Dimensions of <i>s</i> in Font <i>f</i>.
+	 *
+	 * @param s the string
+	 * @param f the font
+	 * @return the dimensions of the given string
+	 */
+	@Override
+	public Dimension getStringExtents(String s, Font f) {
+		return figureUtilities.getStringExtents(s, f);
+	}
+
+	/**
+	 * Returns the Dimensions of the given text, converting newlines and tabs
+	 * appropriately.
+	 *
+	 * @param s the text
+	 * @param f the font
+	 * @return the dimensions of the given text
+	 */
+	@Override
+	public Dimension getTextExtents(String s, Font f) {
+		return figureUtilities.getTextExtents(s, f);
+	}
+
+	/**
+	 * Gets the font's ascent.
+	 *
+	 * @param font
+	 * @return the font's ascent
+	 */
+	@Override
+	public int getAscent(Font font) {
+		FontMetrics fm = figureUtilities.getFontMetrics(font);
+		return fm.getHeight() - fm.getDescent();
+	}
+
+	/**
+	 * Gets the font's descent.
+	 *
+	 * @param font
+	 * @return the font's descent
+	 */
+	@Override
+	public int getDescent(Font font) {
+		return figureUtilities.getFontMetrics(font).getDescent();
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.draw2d.internal;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Control;
+
+public class InternalDraw2dUtils {
+	/**
+	 * System property that controls the disablement of any autoScale functionality.
+	 * Currently it only has effects when executed on Windows.
+	 *
+	 * <ul>
+	 * <li><b>false</b>: autoScale functionality is enabled</li>
+	 * <li><b>true</b>: autoScale functionality is disabled<</li>
+	 *
+	 * </ul>
+	 * The current default is "false".
+	 */
+	private static final String DRAW2D_DISABLE_AUTOSCALE = "draw2d.disableAutoscale"; //$NON-NLS-1$
+
+	public static boolean disableAutoscale;
+
+	static {
+		disableAutoscale = "win32".equals(SWT.getPlatform()) //$NON-NLS-1$
+				&& Boolean.parseBoolean(System.getProperty(DRAW2D_DISABLE_AUTOSCALE));
+	}
+
+	public static void configureForAutoscalingMode(Control control) {
+		if (control != null && disableAutoscale) {
+			control.setData("AUTOSCALE_DISABLED", true); //$NON-NLS-1$
+		}
+	}
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
@@ -20,6 +20,7 @@ import org.eclipse.draw2d.FreeformLayeredPane;
 import org.eclipse.draw2d.FreeformViewport;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.LayeredPane;
+import org.eclipse.draw2d.ScalableFreeformLayeredPane;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 
@@ -30,6 +31,7 @@ import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.LayerConstants;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.SnapToGrid;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.tools.MarqueeDragTracker;
 
 /**
@@ -86,7 +88,7 @@ import org.eclipse.gef.tools.MarqueeDragTracker;
  */
 public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements LayerConstants, LayerManager {
 
-	private LayeredPane innerLayers;
+	private ScalableFreeformLayeredPane innerLayers;
 	private LayeredPane printableLayers;
 	private final PropertyChangeListener gridListener = evt -> {
 		String property = evt.getPropertyName();
@@ -102,7 +104,8 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	@Override
 	protected IFigure createFigure() {
 		FreeformViewport viewport = new FreeformViewport();
-		innerLayers = new FreeformLayeredPane();
+		innerLayers = new ScalableFreeformLayeredPane();
+		this.addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(innerLayers));
 		createLayers(innerLayers);
 		viewport.setContents(innerLayers);
 		return viewport;

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableRootEditPart.java
@@ -32,6 +32,7 @@ import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.LayerConstants;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.SnapToGrid;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.tools.MarqueeDragTracker;
 
 /**
@@ -121,7 +122,7 @@ public class ScalableRootEditPart extends SimpleRootEditPart implements LayerCon
 
 	}
 
-	private LayeredPane innerLayers;
+	private ScalableLayeredPane innerLayers;
 	private LayeredPane printableLayers;
 	private ScalableLayeredPane scaledLayers;
 	private final PropertyChangeListener gridListener = (PropertyChangeEvent evt) -> {
@@ -174,7 +175,8 @@ public class ScalableRootEditPart extends SimpleRootEditPart implements LayerCon
 	protected IFigure createFigure() {
 		Viewport viewport = createViewport();
 
-		innerLayers = new LayeredPane();
+		innerLayers = new ScalableLayeredPane();
+		this.addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(innerLayers));
 		createLayers(innerLayers);
 
 		viewport.setContents(innerLayers);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/SimpleAutoscaledRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/SimpleAutoscaledRootEditPart.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gef.internal;
+
+import org.eclipse.draw2d.ScalableFigure;
+import org.eclipse.draw2d.ScalableLayeredPane;
+
+import org.eclipse.gef.editparts.SimpleRootEditPart;
+
+public final class SimpleAutoscaledRootEditPart extends SimpleRootEditPart {
+
+	@Override
+	protected final ScalableFigure createFigure() {
+		ScalableFigure scalableFigure = new ScalableLayeredPane();
+		this.addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(scalableFigure));
+		return scalableFigure;
+	}
+
+	@Override
+	public ScalableFigure getFigure() {
+		return (ScalableFigure) super.getFigure();
+	}
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -81,8 +81,10 @@ import org.eclipse.draw2d.Label;
 import org.eclipse.draw2d.LightweightSystem;
 import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.Triangle;
 import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.internal.DrawableTextUtilities;
 
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.dnd.TemplateTransfer;
@@ -1114,6 +1116,7 @@ public class FlyoutPaletteComposite extends Composite {
 	private class TitleLabel extends Label {
 		protected static final Border BORDER = new MarginBorder(4, 3, 4, 3);
 		protected static final Border TOOL_TIP_BORDER = new MarginBorder(0, 2, 0, 2);
+		private TextUtilities textUtilities;
 
 		public TitleLabel(boolean isHorizontal) {
 			super(GEFMessages.Palette_Label, InternalImages.get(InternalImages.IMG_PALETTE));
@@ -1123,6 +1126,14 @@ public class FlyoutPaletteComposite extends Composite {
 			tooltip.setBorder(TOOL_TIP_BORDER);
 			setToolTip(tooltip);
 			setForegroundColor(ColorConstants.listForeground);
+		}
+
+		@Override
+		public TextUtilities getTextUtilities() {
+			if (textUtilities == null) {
+				textUtilities = new DrawableTextUtilities(paletteContainer);
+			}
+			return textUtilities;
 		}
 
 		@Override

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
@@ -31,7 +31,7 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.gef.EditDomain;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
-import org.eclipse.gef.editparts.SimpleRootEditPart;
+import org.eclipse.gef.internal.SimpleAutoscaledRootEditPart;
 import org.eclipse.gef.internal.ui.palette.PaletteSelectionTool;
 import org.eclipse.gef.internal.ui.palette.editparts.DrawerEditPart;
 import org.eclipse.gef.internal.ui.palette.editparts.PaletteStackEditPart;
@@ -127,7 +127,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	 */
 	@Override
 	protected void createDefaultRoot() {
-		setRootEditPart(new SimpleRootEditPart());
+		setRootEditPart(new SimpleAutoscaledRootEditPart());
 	}
 
 	private void disposeFont() {

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DragSource;
 import org.eclipse.swt.dnd.DropTarget;
@@ -46,6 +47,7 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.eclipse.gef.AccessibleEditPart;
 import org.eclipse.gef.EditDomain;
@@ -55,6 +57,7 @@ import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.KeyHandler;
 import org.eclipse.gef.RootEditPart;
 import org.eclipse.gef.SelectionManager;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 
 /**
  * The base implementation for EditPartViewer.
@@ -484,6 +487,11 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 		if (contextMenu != null) {
 			control.setMenu(contextMenu.createContextMenu(getControl()));
 		}
+		if (InternalDraw2dUtils.disableAutoscale) {
+			control.addListener(SWT.ZoomChanged,
+					e -> setProperty(InternalGEFPlugin.MONITOR_SCALE_PROPERTY, e.detail / 100.0));
+		}
+		setProperty(InternalGEFPlugin.MONITOR_SCALE_PROPERTY, calculateScale());
 	}
 
 	/**
@@ -855,4 +863,10 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	public void unregisterAccessibleEditPart(AccessibleEditPart acc) {
 	}
 
+	private double calculateScale() {
+		if (!InternalDraw2dUtils.disableAutoscale || control == null) {
+			return 1.0;
+		}
+		return control.getMonitor().getZoom() / 100.0;
+	}
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -119,6 +119,11 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	private PropertyChangeSupport changeSupport;
 
 	/**
+	 * Internal flag for fetching the shell zoom
+	 */
+	private static final String DATA_SHELL_ZOOM = "SHELL_ZOOM"; //$NON-NLS-1$
+
+	/**
 	 * Constructs the viewer and calls {@link #init()}.
 	 */
 	public AbstractEditPartViewer() {
@@ -867,6 +872,12 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 		if (!InternalDraw2dUtils.disableAutoscale || control == null) {
 			return 1.0;
 		}
-		return control.getMonitor().getZoom() / 100.0;
+		int shellZooom;
+		try {
+			shellZooom = (int) control.getData(DATA_SHELL_ZOOM);
+		} catch (ClassCastException | NullPointerException e) {
+			shellZooom = 100;
+		}
+		return shellZooom / 100.0;
 	}
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/ScrollingGraphicalViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/ScrollingGraphicalViewer.java
@@ -21,6 +21,7 @@ import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
@@ -52,7 +53,9 @@ public class ScrollingGraphicalViewer extends GraphicalViewerImpl {
 	 */
 	@Override
 	public final Control createControl(Composite parent) {
-		setControl(new FigureCanvas(parent, getLightweightSystem()));
+		FigureCanvas control = new FigureCanvas(parent, getLightweightSystem());
+		InternalDraw2dUtils.configureForAutoscalingMode(control);
+		setControl(control);
 		hookRootFigure();
 		return getControl();
 	}


### PR DESCRIPTION
I updated my approach for improving HiDPI scaling in GEF diagrams.

Central orchestrator is currently the `MonitorAwareZoomManager` which connects the `Control` (usually a `FigureCanvas`) and `ScalableFigures` to apply the monitor zoom as scale on. Linking is done via the `AbstractEditPartViewer` ( `MonitorAwareZoomManager` and `FigureCanvas`) `FreeformGraphicalRootEditPart/ScalableRootEditPart` (register `ScalableFigures`). Adaptions were made in `FreeformGraphicalRootEditPart` and `ScalableRootEditPart` to replace the innerLayer with a scalable layer that will registered into `MonitorAwareZoomManager`. For the flyout palette I added `SimpleAutoscaledRootEditPart` as a simple addition to do the same as the other two. The pattern is now everywhere one central scalable layer somewhere up in the hierarchy. 

It would be nice to move that into the root figure, but was not able to fully make it work. The problem described in https://github.com/eclipse-gef/gef-classic/pull/768#issuecomment-3168160441 by @ptziegler is to my analysis a "wrong" clipping caused by the zoom break in the root figure. Lets imaging having the flag active, so the FigureCanvas is at 100% and we have a monitor of 200%, so the root figure scale would be 2.0:
First, the client area of canvas is fetched, e.g. 1000x1000. Then the bounds of root figure are set with the value:

- if the bounds are scaled down, the bounds would be 500x500, which will be used as clipping area and will be too small for later calls
- if the bounds are not scaled down, so they remain 1000x1000, the clipping will be fine, but the children will be positioned at the wrong place

I was not able to properly solve this discrepancy, but I think that would enable us to move all the logic into a specific root figure.

One additional problem (for which I added some workarounds in the PR) are `TextUtilities` and `FigureUtilities` that use a static GC for its calculations. This means the GC will always the bound to the zoom that `new Shell()` is bounds to. At least in windows that mustn't even be the primary monitor, but could be a secondary or any additional monitor as well, which leads to cut off texts, when you wouldn't expect it. What we would need is the possibility to initialize the GC with a given control (e.g. either the parent Shell or the FigureCanvas) to provide the proper context for all calculations on this GC. As they are used at a lot of different places I didn't have a good idea, how to change these. This is a prerequisite for any proper solution for the underlying problem.

