### PR TITLE
GraphicalEditor registers for CommandStackEvents #21

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditor.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditor.java
@@ -178,7 +178,7 @@ public abstract class GraphicalEditor extends EditorPart
 	 */
 	@Override
 	public void dispose() {
-		getCommandStack().removeCommandStackListener(this);
+		getCommandStack().removeCommandStackEventListener(this);
 		getSite().getWorkbenchWindow().getSelectionService().removeSelectionListener(this);
 		getEditDomain().setActiveTool(null);
 		getActionRegistry().dispose();
@@ -354,7 +354,7 @@ public abstract class GraphicalEditor extends EditorPart
 	public void init(IEditorSite site, IEditorInput input) throws PartInitException {
 		setSite(site);
 		setInput(input);
-		getCommandStack().addCommandStackListener(this);
+		getCommandStack().addCommandStackEventListener(this);
 		getSite().getWorkbenchWindow().getSelectionService().addSelectionListener(this);
 		initializeActionRegistry();
 	}


### PR DESCRIPTION
GraphicalEditor still used the deprecated commandstack listener API. With previous work the new api was added now also the registration is moved.

Addresses: https://github.com/eclipse-gef/gef-classic/issues/21