### PR TITLE
Mark "ranks" field in DirectedGraph as "forRemoval"

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LocalOptimizerTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LocalOptimizerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -202,6 +202,7 @@ public class LocalOptimizerTest {
 	private void checkResults(Node[][] nodes) {
 		for (int r = 0; r < nodes.length; r++) {
 			Node[] row = nodes[r];
+			@SuppressWarnings("removal")
 			Rank rank = graph.ranks.getRank(r);
 			assertEquals(rank.size(), row.length);
 			for (int n = 0; n < row.length; n++) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundHorizontalPlacement.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundHorizontalPlacement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -46,6 +46,7 @@ class CompoundHorizontalPlacement extends HorizontalPlacement {
 	 * @see HorizontalPlacement#buildRankSeparators(RankList)
 	 */
 	@Override
+	@SuppressWarnings("removal")
 	void buildRankSeparators(RankList ranks) {
 		CompoundDirectedGraph g = (CompoundDirectedGraph) graph;
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundPopulateRanks.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundPopulateRanks.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -51,6 +51,7 @@ class CompoundPopulateRanks extends PopulateRanks {
 	/**
 	 * @param subgraph
 	 */
+	@SuppressWarnings("removal")
 	private static void bridgeSubgraph(Subgraph subgraph, CompoundDirectedGraph g) {
 		int offset = subgraph.head.rank;
 		boolean[] occupied = new boolean[subgraph.tail.rank - subgraph.head.rank + 1];

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundRankSorter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundRankSorter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -116,6 +116,7 @@ class CompoundRankSorter extends RankSorter {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public void init(DirectedGraph g) {
 		super.init(g);
 		init = true;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/DirectedGraph.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/DirectedGraph.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -49,9 +49,10 @@ public class DirectedGraph {
 	/**
 	 * For internal use only. The list of rows which makeup the final graph layout.
 	 *
-	 * @deprecated
+	 * @deprecated This field will be made package-private after the 2027-12
+	 *             release.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public RankList ranks = new RankList();
 
 	Node forestRoot;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/GraphUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/GraphUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -83,6 +83,7 @@ class GraphUtilities {
 	 * @param graph the graph whose crossed edges are counted
 	 * @return the number of edge crossings in the graph
 	 */
+	@SuppressWarnings("removal")
 	public static int numberOfCrossingsInGraph(DirectedGraph graph) {
 		int crossings = 0;
 		for (Rank rank : graph.ranks) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/HorizontalPlacement.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/HorizontalPlacement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -254,6 +254,7 @@ class HorizontalPlacement extends SpanningTreeVisitor {
 	// return false;
 	// }
 
+	@SuppressWarnings("removal")
 	void buildGPrime() {
 		RankList ranks = graph.ranks;
 		buildRankSeparators(ranks);
@@ -293,6 +294,7 @@ class HorizontalPlacement extends SpanningTreeVisitor {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	private void calculateCellLocations() {
 		graph.cellLocations = new int[graph.ranks.size() + 1][];
 		for (int row = 0; row < graph.ranks.size(); row++) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/LocalOptimizer.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/LocalOptimizer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -89,6 +89,7 @@ class LocalOptimizer extends GraphVisitor {
 	 * @see GraphVisitor#visit(org.eclipse.draw2d.graph.DirectedGraph)
 	 */
 	@Override
+	@SuppressWarnings("removal")
 	public void visit(DirectedGraph g) {
 		boolean flag;
 		do {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/MinCross.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/MinCross.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,6 +39,7 @@ class MinCross extends GraphVisitor {
 		this.sorter = sorter;
 	}
 
+	@SuppressWarnings("removal")
 	void solve() {
 		Rank rank;
 		for (int loop = 0; loop < MAX; loop++) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/PopulateRanks.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/PopulateRanks.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,6 +36,7 @@ class PopulateRanks extends GraphVisitor {
 	 * @see GraphVisitor#visit(DirectedGraph)
 	 */
 	@Override
+	@SuppressWarnings("removal")
 	public void visit(DirectedGraph g) {
 		if (g.forestRoot != null) {
 			for (int i = g.forestRoot.outgoing.size() - 1; i >= 0; i--) {
@@ -67,6 +68,7 @@ class PopulateRanks extends GraphVisitor {
 	 * @see GraphVisitor#revisit(DirectedGraph)
 	 */
 	@Override
+	@SuppressWarnings("removal")
 	public void revisit(DirectedGraph g) {
 		for (Rank rank : g.ranks) {
 			Node prev = null;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/RankSorter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/RankSorter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,6 +31,7 @@ class RankSorter {
 	double progress;
 	DirectedGraph g;
 
+	@SuppressWarnings("removal")
 	protected void assignIncomingSortValues() {
 		rankSize = rank.total;
 		prevRankSize = g.ranks.getRank(currentRow - 1).total;
@@ -43,6 +44,7 @@ class RankSorter {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	protected void assignOutgoingSortValues() {
 		rankSize = rank.total;
 		prevRankSize = g.ranks.getRank(currentRow + 1).total;
@@ -152,6 +154,7 @@ class RankSorter {
 		postSort();
 	}
 
+	@SuppressWarnings("removal")
 	public void init(DirectedGraph g) {
 		this.g = g;
 		for (int i = 0; i < g.ranks.size(); i++) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/SortSubgraphs.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/SortSubgraphs.java
@@ -87,6 +87,7 @@ class SortSubgraphs extends GraphVisitor {
 		} while (cycleRoot != null);
 	}
 
+	@SuppressWarnings("removal")
 	private void buildSubgraphOrderingGraph() {
 		RankList ranks = g.ranks;
 		nestingTrees = new NestingTree[ranks.size()];
@@ -134,6 +135,7 @@ class SortSubgraphs extends GraphVisitor {
 	 * Runs in approximately linear time with respect to the number of nodes,
 	 * including virtual nodes.
 	 */
+	@SuppressWarnings("removal")
 	private void calculateSortValues() {
 		RankList ranks = g.ranks;
 
@@ -164,6 +166,7 @@ class SortSubgraphs extends GraphVisitor {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	private void repopulateRanks() {
 		for (int i = 0; i < nestingTrees.length; i++) {
 			Rank rank = g.ranks.getRank(i);
@@ -195,6 +198,7 @@ class SortSubgraphs extends GraphVisitor {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	void init() {
 		g.ranks.forEach(rank -> rank.forEach(n -> n.workingData[0] = new NodeList()));
 		for (Node element : g.subgraphs) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VerticalPlacement.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VerticalPlacement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,6 +24,7 @@ import org.eclipse.draw2d.geometry.Insets;
 class VerticalPlacement extends GraphVisitor {
 
 	@Override
+	@SuppressWarnings("removal")
 	void visit(DirectedGraph g) {
 		Insets pad;
 		int currentY = g.getMargin().top;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNodeCreation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNodeCreation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2010 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -37,6 +37,7 @@ class VirtualNodeCreation extends RevertableChange {
 	 * @param edge  The edge to convert
 	 * @param graph the graph containing the edge
 	 */
+	@SuppressWarnings("removal")
 	public VirtualNodeCreation(Edge edge, DirectedGraph graph) {
 		this.edge = edge;
 		this.graph = graph;


### PR DESCRIPTION
This field has been marked as deprecated since forever and is only referenced within the same package and can therefore be made package-private in a future release.

The "removal" warning needs to be suppressed, wherever this field is referenced.