### PR TITLE
Mark deprecated fields in Edge as "forRemoval"

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/BreakCycles.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/BreakCycles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -176,6 +176,7 @@ class BreakCycles extends GraphVisitor {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	private static void invertEdges(DirectedGraph g) {
 		for (Edge e : g.edges) {
 			if (getOrderIndex(e.source) > getOrderIndex(e.target)) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundBreakCycles.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundBreakCycles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -238,6 +238,7 @@ class CompoundBreakCycles extends GraphVisitor {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	private void invertEdges(DirectedGraph g) {
 		// Assign order indices
 		int orderIndex = 0;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Edge.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Edge.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -56,26 +56,29 @@ public class Edge {
 	 * The minimum rank separation between the source and target nodes. The default
 	 * value is 1.
 	 *
-	 * @deprecated use accessors instead
+	 * @deprecated use accessors instead. This field will be made private after the
+	 *             2027-12 release.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public int delta = 1;
 
 	/**
 	 * The ending point.
 	 *
-	 * @deprecated use {@link #getPoints()}
+	 * @deprecated use {@link #getPoints()}. This field will be made package-private
+	 *             after the 2027-12 release.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public Point end;
 
 	boolean flag;
 
 	/**
 	 * @deprecated INTERNAL field, use accessor method Indicates an edge was
-	 *             inverted during the layout
+	 *             inverted during the layout. This field will be made
+	 *             package-private after the 2027-12 release.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public boolean isFeedback = false;
 
 	/**
@@ -83,9 +86,10 @@ public class Edge {
 	 * -1, which indicates that the edge should use the node's default
 	 * {@link Node#getOffsetOutgoing() outgoing} attachment point.
 	 *
-	 * @deprecated use accessors instead
+	 * @deprecated use accessors instead. This field will be made package-private
+	 *             after the 2027-12 release.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public int offsetSource = -1;
 
 	/**
@@ -93,18 +97,20 @@ public class Edge {
 	 * -1, which indicates that the edge should use the node's default
 	 * {@link Node#getOffsetIncoming() incoming} attachment point.
 	 *
-	 * @deprecated use accessors instead
+	 * @deprecated use accessors instead. This field will be made package-private
+	 *             after the 2027-12 release.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public int offsetTarget = -1;
 
 	/**
 	 * The minimum amount of space to leave on both the left and right sides of the
 	 * edge.
 	 *
-	 * @deprecated use accessors instead
+	 * @deprecated use accessors instead. This field will be made private after the
+	 *             2027-12 release.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public int padding = 10;
 
 	private PointList points;
@@ -116,9 +122,10 @@ public class Edge {
 	/**
 	 * The starting point.
 	 *
-	 * @deprecated use {@link #getPoints()}
+	 * @deprecated use {@link #getPoints()}. This field will be made package-private
+	 *             after the 2027-12 release.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public Point start;
 
 	/**
@@ -143,9 +150,10 @@ public class Edge {
 	public int weight = 1;
 
 	/**
-	 * @deprecated use accessors instead
+	 * @deprecated use accessors instead. This field will be made private after the
+	 *             2027-12 release.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public int width = 1;
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/RouteEdges.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/RouteEdges.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,6 +26,7 @@ class RouteEdges extends GraphVisitor {
 	 * @see GraphVisitor#visit(DirectedGraph)
 	 */
 	@Override
+	@SuppressWarnings("removal")
 	public void revisit(DirectedGraph g) {
 		for (Edge edge : g.edges) {
 			edge.start = new Point(edge.getSourceOffset() + edge.source.x, edge.source.y + edge.source.height);
@@ -47,6 +48,7 @@ class RouteEdges extends GraphVisitor {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	static void routeLongEdge(Edge edge, DirectedGraph g) {
 		ShortestPathRouter router = new ShortestPathRouter();
 		Path path = new Path(edge.start, edge.end);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/TransposeMetrics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/TransposeMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2023 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -41,6 +41,7 @@ class TransposeMetrics extends GraphVisitor {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public void revisit(DirectedGraph g) {
 		if (g.getDirection() == PositionConstants.SOUTH) {
 			return;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNodeCreation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNodeCreation.java
@@ -85,6 +85,7 @@ class VirtualNodeCreation extends RevertableChange {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	void revert() {
 		edge.start = edges[0].start;
 		edge.end = edges[edges.length - 1].end;


### PR DESCRIPTION
Those field has been marked as deprecated since forever and is only referenced within the same package and can therefore be made package-private (or private) in a future release.

The "removal" warning needs to be suppressed, wherever this field is referenced.

Contributes to https://github.com/eclipse-gef/gef-classic/pull/778