### PR TITLE
Use auto-generated "disabled" icon when supported by SWT

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
@@ -17,6 +17,7 @@ import java.beans.PropertyChangeListener;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Image;
@@ -38,6 +39,8 @@ import org.eclipse.gef.EditPartListener;
 import org.eclipse.gef.GEFColorProvider;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.Version;
 
 public class InternalGEFPlugin extends AbstractUIPlugin {
 	/** Monitor scale property */
@@ -45,6 +48,7 @@ public class InternalGEFPlugin extends AbstractUIPlugin {
 
 	private static BundleContext context;
 	private static AbstractUIPlugin singleton;
+	private static Boolean requiresDisabledIcons;
 
 	public InternalGEFPlugin() {
 		singleton = this;
@@ -159,5 +163,17 @@ public class InternalGEFPlugin extends AbstractUIPlugin {
 				editpart.getViewer().removePropertyChangeListener(autoScaleListener);
 			}
 		};
+	}
+
+	/**
+	 * With Eclipse 4.36 (and therefore SWT 3.130.0), it is no longer necessary to
+	 * set a "disabled" icon in e.g. {@code Actions}.
+	 */
+	public static boolean requiresDisabledIcon() {
+		if (requiresDisabledIcons == null) {
+			Version minVersion = new Version(3, 130, 0);
+			requiresDisabledIcons = FrameworkUtil.getBundle(SWT.class).getVersion().compareTo(minVersion) < 0;
+		}
+		return requiresDisabledIcons;
 	}
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalImages.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalImages.java
@@ -30,8 +30,23 @@ public class InternalImages {
 	public static final ImageDescriptor DESC_MATCH_WIDTH;
 	public static final ImageDescriptor DESC_MATCH_HEIGHT;
 
+	/**
+	 * @deprecated No longer needed with SWT 3.130.0. Can be removed once this is
+	 *             the minimum supported version.
+	 */
+	@Deprecated
 	public static final ImageDescriptor DESC_MATCH_SIZE_DIS;
+	/**
+	 * @deprecated No longer needed with SWT 3.130.0. Can be removed once this is
+	 *             the minimum supported version.
+	 */
+	@Deprecated
 	public static final ImageDescriptor DESC_MATCH_WIDTH_DIS;
+	/**
+	 * @deprecated No longer needed with SWT 3.130.0. Can be removed once this is
+	 *             the minimum supported version.
+	 */
+	@Deprecated
 	public static final ImageDescriptor DESC_MATCH_HEIGHT_DIS;
 
 	public static final ImageDescriptor DESC_HORZ_ALIGN_CENTER;
@@ -42,12 +57,42 @@ public class InternalImages {
 	public static final ImageDescriptor DESC_VERT_ALIGN_TOP;
 	public static final ImageDescriptor DESC_VERT_ALIGN_BOTTOM;
 
+	/**
+	 * @deprecated No longer needed with SWT 3.130.0. Can be removed once this is
+	 *             the minimum supported version.
+	 */
+	@Deprecated
 	public static final ImageDescriptor DESC_HORZ_ALIGN_CENTER_DIS;
+	/**
+	 * @deprecated No longer needed with SWT 3.130.0. Can be removed once this is
+	 *             the minimum supported version.
+	 */
+	@Deprecated
 	public static final ImageDescriptor DESC_HORZ_ALIGN_LEFT_DIS;
+	/**
+	 * @deprecated No longer needed with SWT 3.130.0. Can be removed once this is
+	 *             the minimum supported version.
+	 */
+	@Deprecated
 	public static final ImageDescriptor DESC_HORZ_ALIGN_RIGHT_DIS;
 
+	/**
+	 * @deprecated No longer needed with SWT 3.130.0. Can be removed once this is
+	 *             the minimum supported version.
+	 */
+	@Deprecated
 	public static final ImageDescriptor DESC_VERT_ALIGN_MIDDLE_DIS;
+	/**
+	 * @deprecated No longer needed with SWT 3.130.0. Can be removed once this is
+	 *             the minimum supported version.
+	 */
+	@Deprecated
 	public static final ImageDescriptor DESC_VERT_ALIGN_TOP_DIS;
+	/**
+	 * @deprecated No longer needed with SWT 3.130.0. Can be removed once this is
+	 *             the minimum supported version.
+	 */
+	@Deprecated
 	public static final ImageDescriptor DESC_VERT_ALIGN_BOTTOM_DIS;
 
 	public static final ImageDescriptor DESC_SEPARATOR;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/AlignmentAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/AlignmentAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,6 +30,7 @@ import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.gef.internal.GEFMessages;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 import org.eclipse.gef.requests.AlignmentRequest;
 import org.eclipse.gef.tools.ToolUtilities;
@@ -200,7 +201,9 @@ public final class AlignmentAction extends SelectionAction {
 			setText(GEFMessages.AlignLeftAction_Label);
 			setToolTipText(GEFMessages.AlignLeftAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_HORZ_ALIGN_LEFT);
-			setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_LEFT_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_LEFT_DIS);
+			}
 			break;
 
 		case PositionConstants.RIGHT:
@@ -208,7 +211,9 @@ public final class AlignmentAction extends SelectionAction {
 			setText(GEFMessages.AlignRightAction_Label);
 			setToolTipText(GEFMessages.AlignRightAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_HORZ_ALIGN_RIGHT);
-			setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_RIGHT_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_RIGHT_DIS);
+			}
 			break;
 
 		case PositionConstants.TOP:
@@ -216,7 +221,9 @@ public final class AlignmentAction extends SelectionAction {
 			setText(GEFMessages.AlignTopAction_Label);
 			setToolTipText(GEFMessages.AlignTopAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_VERT_ALIGN_TOP);
-			setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_TOP_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_TOP_DIS);
+			}
 			break;
 
 		case PositionConstants.BOTTOM:
@@ -224,7 +231,9 @@ public final class AlignmentAction extends SelectionAction {
 			setText(GEFMessages.AlignBottomAction_Label);
 			setToolTipText(GEFMessages.AlignBottomAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_VERT_ALIGN_BOTTOM);
-			setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_BOTTOM_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_BOTTOM_DIS);
+			}
 			break;
 
 		case PositionConstants.CENTER:
@@ -232,7 +241,9 @@ public final class AlignmentAction extends SelectionAction {
 			setText(GEFMessages.AlignCenterAction_Label);
 			setToolTipText(GEFMessages.AlignCenterAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_HORZ_ALIGN_CENTER);
-			setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_CENTER_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_CENTER_DIS);
+			}
 			break;
 
 		case PositionConstants.MIDDLE:
@@ -240,7 +251,9 @@ public final class AlignmentAction extends SelectionAction {
 			setText(GEFMessages.AlignMiddleAction_Label);
 			setToolTipText(GEFMessages.AlignMiddleAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_VERT_ALIGN_MIDDLE);
-			setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_MIDDLE_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_MIDDLE_DIS);
+			}
 			break;
 		default:
 			break;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/AlignmentRetargetAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/AlignmentRetargetAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,7 @@ import org.eclipse.ui.actions.LabelRetargetAction;
 import org.eclipse.draw2d.PositionConstants;
 
 import org.eclipse.gef.internal.GEFMessages;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 
 /**
@@ -41,42 +42,54 @@ public class AlignmentRetargetAction extends LabelRetargetAction {
 			setText(GEFMessages.AlignBottomAction_Label);
 			setToolTipText(GEFMessages.AlignBottomAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_VERT_ALIGN_BOTTOM);
-			setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_BOTTOM_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_BOTTOM_DIS);
+			}
 			break;
 		case PositionConstants.CENTER:
 			setId(GEFActionConstants.ALIGN_CENTER);
 			setText(GEFMessages.AlignCenterAction_Label);
 			setToolTipText(GEFMessages.AlignCenterAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_HORZ_ALIGN_CENTER);
-			setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_CENTER_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_CENTER_DIS);
+			}
 			break;
 		case PositionConstants.LEFT:
 			setId(GEFActionConstants.ALIGN_LEFT);
 			setText(GEFMessages.AlignLeftAction_Label);
 			setToolTipText(GEFMessages.AlignLeftAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_HORZ_ALIGN_LEFT);
-			setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_LEFT_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_LEFT_DIS);
+			}
 			break;
 		case PositionConstants.MIDDLE:
 			setId(GEFActionConstants.ALIGN_MIDDLE);
 			setText(GEFMessages.AlignMiddleAction_Label);
 			setToolTipText(GEFMessages.AlignMiddleAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_VERT_ALIGN_MIDDLE);
-			setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_MIDDLE_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_MIDDLE_DIS);
+			}
 			break;
 		case PositionConstants.RIGHT:
 			setId(GEFActionConstants.ALIGN_RIGHT);
 			setText(GEFMessages.AlignRightAction_Label);
 			setToolTipText(GEFMessages.AlignRightAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_HORZ_ALIGN_RIGHT);
-			setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_RIGHT_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_HORZ_ALIGN_RIGHT_DIS);
+			}
 			break;
 		case PositionConstants.TOP:
 			setId(GEFActionConstants.ALIGN_TOP);
 			setText(GEFMessages.AlignTopAction_Label);
 			setToolTipText(GEFMessages.AlignTopAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_VERT_ALIGN_TOP);
-			setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_TOP_DIS);
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_TOP_DIS);
+			}
 			break;
 		}
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchHeightAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchHeightAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,7 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.draw2d.geometry.PrecisionRectangle;
 
 import org.eclipse.gef.internal.GEFMessages;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 
 /**
@@ -35,7 +36,9 @@ public class MatchHeightAction extends MatchSizeAction {
 		super(part);
 		setText(GEFMessages.MatchHeightAction_Label);
 		setImageDescriptor(InternalImages.DESC_MATCH_HEIGHT);
-		setDisabledImageDescriptor(InternalImages.DESC_MATCH_HEIGHT_DIS);
+		if (InternalGEFPlugin.requiresDisabledIcon()) {
+			setDisabledImageDescriptor(InternalImages.DESC_MATCH_HEIGHT_DIS);
+		}
 		setToolTipText(GEFMessages.MatchHeightAction_Tooltip);
 		setId(GEFActionConstants.MATCH_HEIGHT);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchHeightRetargetAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchHeightRetargetAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.gef.ui.actions;
 import org.eclipse.ui.actions.LabelRetargetAction;
 
 import org.eclipse.gef.internal.GEFMessages;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 
 /**
@@ -28,7 +29,9 @@ public class MatchHeightRetargetAction extends LabelRetargetAction {
 	public MatchHeightRetargetAction() {
 		super(GEFActionConstants.MATCH_HEIGHT, GEFMessages.MatchHeightAction_Label);
 		setImageDescriptor(InternalImages.DESC_MATCH_HEIGHT);
-		setDisabledImageDescriptor(InternalImages.DESC_MATCH_HEIGHT_DIS);
+		if (InternalGEFPlugin.requiresDisabledIcon()) {
+			setDisabledImageDescriptor(InternalImages.DESC_MATCH_HEIGHT_DIS);
+		}
 		setToolTipText(GEFMessages.MatchHeightAction_Tooltip);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchSizeAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchSizeAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,6 +25,7 @@ import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.gef.internal.GEFMessages;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 import org.eclipse.gef.requests.ChangeBoundsRequest;
 
@@ -46,7 +47,9 @@ public class MatchSizeAction extends SelectionAction {
 		super(part);
 		setText(GEFMessages.MatchSizeAction_Label);
 		setImageDescriptor(InternalImages.DESC_MATCH_SIZE);
-		setDisabledImageDescriptor(InternalImages.DESC_MATCH_SIZE_DIS);
+		if (InternalGEFPlugin.requiresDisabledIcon()) {
+			setDisabledImageDescriptor(InternalImages.DESC_MATCH_SIZE_DIS);
+		}
 		setToolTipText(GEFMessages.MatchSizeAction_Tooltip);
 		setId(GEFActionConstants.MATCH_SIZE);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchSizeRetargetAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchSizeRetargetAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.gef.ui.actions;
 import org.eclipse.ui.actions.LabelRetargetAction;
 
 import org.eclipse.gef.internal.GEFMessages;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 
 /**
@@ -30,7 +31,9 @@ public class MatchSizeRetargetAction extends LabelRetargetAction {
 	public MatchSizeRetargetAction() {
 		super(GEFActionConstants.MATCH_SIZE, GEFMessages.MatchSizeAction_Label);
 		setImageDescriptor(InternalImages.DESC_MATCH_SIZE);
-		setDisabledImageDescriptor(InternalImages.DESC_MATCH_SIZE_DIS);
+		if (InternalGEFPlugin.requiresDisabledIcon()) {
+			setDisabledImageDescriptor(InternalImages.DESC_MATCH_SIZE_DIS);
+		}
 		setToolTipText(GEFMessages.MatchSizeAction_Tooltip);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchWidthAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchWidthAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,7 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.draw2d.geometry.PrecisionRectangle;
 
 import org.eclipse.gef.internal.GEFMessages;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 
 /**
@@ -35,7 +36,9 @@ public class MatchWidthAction extends MatchSizeAction {
 		super(part);
 		setText(GEFMessages.MatchWidthAction_Label);
 		setImageDescriptor(InternalImages.DESC_MATCH_WIDTH);
-		setDisabledImageDescriptor(InternalImages.DESC_MATCH_WIDTH_DIS);
+		if (InternalGEFPlugin.requiresDisabledIcon()) {
+			setDisabledImageDescriptor(InternalImages.DESC_MATCH_WIDTH_DIS);
+		}
 		setToolTipText(GEFMessages.MatchWidthAction_Tooltip);
 		setId(GEFActionConstants.MATCH_WIDTH);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchWidthRetargetAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchWidthRetargetAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.gef.ui.actions;
 import org.eclipse.ui.actions.LabelRetargetAction;
 
 import org.eclipse.gef.internal.GEFMessages;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 
 /**
@@ -28,7 +29,9 @@ public class MatchWidthRetargetAction extends LabelRetargetAction {
 	public MatchWidthRetargetAction() {
 		super(GEFActionConstants.MATCH_WIDTH, GEFMessages.MatchWidthAction_Label);
 		setImageDescriptor(InternalImages.DESC_MATCH_WIDTH);
-		setDisabledImageDescriptor(InternalImages.DESC_MATCH_WIDTH_DIS);
+		if (InternalGEFPlugin.requiresDisabledIcon()) {
+			setDisabledImageDescriptor(InternalImages.DESC_MATCH_WIDTH_DIS);
+		}
 		setToolTipText(GEFMessages.MatchWidthAction_Tooltip);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteCustomizerDialog.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteCustomizerDialog.java
@@ -70,6 +70,7 @@ import org.eclipse.ui.part.PageBook;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.widgets.MultiLineLabel;
 
+import org.eclipse.gef.internal.InternalGEFPlugin;
 import org.eclipse.gef.internal.InternalImages;
 import org.eclipse.gef.internal.ui.palette.ToolbarDropdownContributionItem;
 import org.eclipse.gef.palette.PaletteEntry;
@@ -1070,7 +1071,9 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			setText(PaletteMessages.DELETE_LABEL);
 			ISharedImages sharedImages = PlatformUI.getWorkbench().getSharedImages();
 			setImageDescriptor(sharedImages.getImageDescriptor(ISharedImages.IMG_TOOL_DELETE));
-			setDisabledImageDescriptor(sharedImages.getImageDescriptor(ISharedImages.IMG_TOOL_DELETE_DISABLED));
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(sharedImages.getImageDescriptor(ISharedImages.IMG_TOOL_DELETE_DISABLED));
+			}
 		}
 
 		@Override
@@ -1097,7 +1100,9 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			setEnabled(false);
 			setText(PaletteMessages.MOVE_DOWN_LABEL);
 			setImageDescriptor(InternalImages.createDescriptor("icons/next_nav.svg"));//$NON-NLS-1$
-			setDisabledImageDescriptor(InternalImages.createDescriptor("icons/move_down_disabled.svg"));//$NON-NLS-1$
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.createDescriptor("icons/move_down_disabled.svg"));//$NON-NLS-1$
+			}
 		}
 
 		@Override
@@ -1124,7 +1129,9 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			setEnabled(false);
 			setText(PaletteMessages.MOVE_UP_LABEL);
 			setImageDescriptor(InternalImages.createDescriptor("icons/prev_nav.svg"));//$NON-NLS-1$
-			setDisabledImageDescriptor(InternalImages.createDescriptor("icons/move_up_disabled.svg")); //$NON-NLS-1$
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.createDescriptor("icons/move_up_disabled.svg")); //$NON-NLS-1$
+			}
 		}
 
 		@Override
@@ -1160,7 +1167,9 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 
 			setText(PaletteMessages.NEW_LABEL);
 			setImageDescriptor(InternalImages.createDescriptor("icons/add.svg")); //$NON-NLS-1$
-			setDisabledImageDescriptor(InternalImages.createDescriptor("icons/add-disabled.svg")); //$NON-NLS-1$
+			if (InternalGEFPlugin.requiresDisabledIcon()) {
+				setDisabledImageDescriptor(InternalImages.createDescriptor("icons/add-disabled.svg")); //$NON-NLS-1$
+			}
 		}
 
 		private void addActionToMenu(Menu parent, IAction action) {


### PR DESCRIPTION
SWT version 3.130.0 or newer is able to automatically generate a "disabled" icon. If such a version is used, it is no longer necessary to explicitly set it for e.g. an action.

In short: If SWT < 3.130 is used, both "enabled" and "disabled" icons are set, otherwise only the "enabled" icon is set.

Closes https://github.com/eclipse-gef/gef-classic/issues/732