### PR TITLE
Bug 205221 - ZoomManager does not support turkish properly

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/Messages.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Patrick Ziegler and others.
+ * Copyright (c) 2024, 2025 Patrick Ziegler and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,4 +28,5 @@ public class Messages {
 	}
 
 	public static final String LayoutManager_InvalidConstraint = BUNDLE.getString("LayoutManager_InvalidConstraint"); //$NON-NLS-1$
+	public static final String AbstractZoomManager_PercentFormat = BUNDLE.getString("AbstractZoomManager_PercentFormat"); //$NON-NLS-1$
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/Messages.properties
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/Messages.properties
@@ -1,1 +1,2 @@
 LayoutManager_InvalidConstraint = {0} was given {1} as constraint for Figure. {2} expected!
+AbstractZoomManager_PercentFormat = ####%

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,6 +27,7 @@ import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.internal.Messages;
 
 /**
  * Manage the primary zoom function in a graphical viewer.
@@ -64,7 +65,7 @@ public abstract class AbstractZoomManager {
 
 	private List<String> zoomLevelContributions = Collections.emptyList();
 
-	DecimalFormat format = new DecimalFormat("####%"); //$NON-NLS-1$
+	DecimalFormat format = new DecimalFormat(Messages.AbstractZoomManager_PercentFormat);
 
 	/**
 	 * The zoom scroll policy associated with this zoom manager. Zoom scroll


### PR DESCRIPTION
In e.g. Turkish, the percent sign is supposed to be on the left side of the number. This change converts the format used for showing the zoom level to an i18n string, so that language packs can account for such differences.

Closes https://bugs.eclipse.org/bugs/show_bug.cgi?id=205221