### PR TITLE
Minor version bump for org.eclipse.gef

### DIFF
--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef; singleton:=true
-Bundle-Version: 3.23.100.qualifier
+Bundle-Version: 3.24.0.qualifier
 Bundle-Activator: org.eclipse.gef.internal.InternalGEFPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
With 1f5cf49c0a0750c70039d138651e79d5483dd3f7, the type hierarchy of the CreateRequest was changed. This requires a minor version increase.