### PR TITLE
Avoid direct access to deprecated focusPart field in RulerComposite

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/rulers/RulerComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/rulers/RulerComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -512,7 +512,7 @@ public class RulerComposite extends Composite {
 		 */
 		@Override
 		protected void handleFocusGained(FocusEvent fe) {
-			if (focusPart == null) {
+			if (!getFocusEditPart().hasFocus()) {
 				setFocus(getContents());
 			}
 			super.handleFocusGained(fe);
@@ -525,7 +525,7 @@ public class RulerComposite extends Composite {
 		@Override
 		protected void handleFocusLost(FocusEvent fe) {
 			super.handleFocusLost(fe);
-			if (focusPart == getContents()) {
+			if (getFocusEditPart() == getContents()) {
 				setFocus(null);
 			}
 		}


### PR DESCRIPTION
If a "FocusIn" event is fired for the RulerComposite, the contents of the RulerViewer should be focused, unless any other part has already requested focus.

Rather than checking whether the deprecated field is checked, we can check whether the FOCUS flag has been set for the focused edit part. This flag is only set when setFocus(...) is called on the EditPartViewer and should therefore be set exactly when the local variable is set.

Conversely, the focus should be cleared by an "FocusOut" event, unless any other part has taken the focus.

Contributes to https://github.com/eclipse-gef/gef-classic/pull/778