### PR TITLE
Use Rectangle#scale in IScalablePane#getScaledRect

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/IScalablePane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/IScalablePane.java
@@ -30,10 +30,7 @@ public interface IScalablePane extends ScalableFigure {
 
 	public default Rectangle getScaledRect(Rectangle rect) {
 		double scale = getScale();
-		rect.width /= scale;
-		rect.height /= scale;
-		rect.x /= scale;
-		rect.y /= scale;
+		rect.scale(1 / scale);
 		return rect;
 	}
 


### PR DESCRIPTION
This PR replaces the scaling in IScalablePane#getScaledRect for width and height of a Rectangle with using Rectangle#scale instead.

In https://github.com/eclipse-gef/gef-classic/pull/770 I stumbled open the issue. If you execute the following small Snippet

```
public class LabelIssueExample {
	public static void main(String[] args) {
		Shell shell = new Shell();
		shell.setSize(400, 400);
		shell.setLayout(new FillLayout());

		FigureCanvas canvas = new FigureCanvas(shell, SWT.NONE, new LightweightSystem());
		Figure root = new Figure();
		root.setLayoutManager(new ListLayout());

		ScalableLayeredPane layeredPane = new ScalableLayeredPane(false);
		layeredPane.setScale(1.5);
		Label label = new Label("Representing a half adder");
		root.add(layeredPane);
		layeredPane.add(label);
		canvas.getViewport().setContentsTracksHeight(true);
		canvas.getViewport().setContentsTracksWidth(true);
		canvas.getViewport().setContents(root);

		shell.open();

		print(canvas.getLightweightSystem().getRootFigure(), 0);

		Display display = shell.getDisplay();
		while (!display.isDisposed()) {
			display.readAndDispatch();
		}
	}

	private static class ListLayout extends FlowLayout {
		public ListLayout() {
			setMajorSpacing(0);
		}
	}

	public static void print(IFigure figure, int depth) {
		for (int i = 0; i < depth * 2; ++i) {
			System.out.print(" ");
		}
		System.out.println(figure + ": " + figure.getBounds());
		for (IFigure c : figure.getChildren()) {
			print(c, depth + 1);
		}
	}
}
```
 you will see
<img width="709" height="57" alt="image" src="https://github.com/user-attachments/assets/0c05179b-1e8e-49dd-a249-db7447a26abd" />

Left before, right this PR. Reason is that the calculated **preferred size** is different from the **size** of the label.

**Important** is to execute this on a 100% monitor, otherwise you won't run into the rounding issue with this Snippet

Using the scale method of Rectangle instead of manipulating the attributes directly does sound reasonable to me anyway, but is there a reason for the current implementation?
