### PR TITLE
Make FlyPaletteComposite contents use native double buffering

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -1168,7 +1168,7 @@ public class FlyoutPaletteComposite extends Composite {
 		private LightweightSystem lws;
 
 		public ButtonCanvas(Composite parent) {
-			super(parent, SWT.NO_REDRAW_RESIZE | SWT.NO_BACKGROUND);
+			super(parent, SWT.NO_REDRAW_RESIZE | SWT.NO_BACKGROUND | SWT.DOUBLE_BUFFERED);
 			init();
 			provideAccSupport();
 		}
@@ -1314,7 +1314,7 @@ public class FlyoutPaletteComposite extends Composite {
 		private LightweightSystem lws;
 
 		public TitleCanvas(Composite parent, boolean horizontal) {
-			super(parent, SWT.NO_REDRAW_RESIZE | SWT.NO_BACKGROUND);
+			super(parent, SWT.NO_REDRAW_RESIZE | SWT.NO_BACKGROUND | SWT.DOUBLE_BUFFERED);
 			init(horizontal);
 			provideAccSupport();
 		}


### PR DESCRIPTION
The `FlyoutPaletteComposite` is instantiated with style flag `SWT.DOUBLE_BUFFERED` to use native double buffering. It's contained `TitleCanvas` and `ButtonCanvas` do not use that flag. In consequence, their `LightweightSystem` creates a `BufferedGraphicsSource` instead of a `NativeGraphicsSource` for them.

This change adapts the `TitleCanvas` and `ButtonCanvas` instantiation to add the `SWT.DOUBLE_BUFFERED` style, such that they use native double buffering.

I just accidentally found this because we had an exception in the instantiation of the `BufferedGraphicsSource` for one of those canvases (caused by an unrelated consumer-side issue). So there is no specific bug driving this change but just my assumption that there is no benefit in using a `BufferGraphicsSource` instead of a `NativeGraphicsSource` for those canvases.