### PR TITLE
Remove usage of deprecated CommandStackListener in example editors

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/LogicEditor.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/LogicEditor.java
@@ -20,7 +20,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.EventObject;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
@@ -94,6 +93,7 @@ import org.eclipse.gef.MouseWheelZoomHandler;
 import org.eclipse.gef.RootEditPart;
 import org.eclipse.gef.SnapToGeometry;
 import org.eclipse.gef.SnapToGrid;
+import org.eclipse.gef.commands.CommandStackEvent;
 import org.eclipse.gef.dnd.TemplateTransferDragSourceListener;
 import org.eclipse.gef.dnd.TemplateTransferDropTargetListener;
 import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
@@ -427,9 +427,9 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 	}
 
 	@Override
-	public void commandStackChanged(EventObject event) {
+	public void stackChanged(CommandStackEvent event) {
 		firePropertyChange(IEditorPart.PROP_DIRTY);
-		super.commandStackChanged(event);
+		super.stackChanged(event);
 	}
 
 	@Override

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditor.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditor.java
@@ -19,7 +19,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
-import java.util.EventObject;
 
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -48,6 +47,7 @@ import org.eclipse.gef.ContextMenuProvider;
 import org.eclipse.gef.DefaultEditDomain;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.gef.commands.CommandStackEvent;
 import org.eclipse.gef.dnd.TemplateTransferDragSourceListener;
 import org.eclipse.gef.dnd.TemplateTransferDropTargetListener;
 import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
@@ -118,9 +118,9 @@ public class ShapesEditor extends GraphicalEditorWithFlyoutPalette {
 	 * .EventObject)
 	 */
 	@Override
-	public void commandStackChanged(EventObject event) {
+	public void stackChanged(CommandStackEvent event) {
 		firePropertyChange(IEditorPart.PROP_DIRTY);
-		super.commandStackChanged(event);
+		super.stackChanged(event);
 	}
 
 	private void createOutputStream(OutputStream os) throws IOException {

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/TextEditor.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/TextEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2023 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,6 @@ import java.io.EOFException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.EventObject;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -47,6 +46,7 @@ import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.MouseWheelHandler;
 import org.eclipse.gef.MouseWheelZoomHandler;
 import org.eclipse.gef.commands.CommandStack;
+import org.eclipse.gef.commands.CommandStackEvent;
 import org.eclipse.gef.editparts.ScalableRootEditPart;
 import org.eclipse.gef.tools.SelectionTool;
 import org.eclipse.gef.ui.actions.ActionRegistry;
@@ -130,9 +130,9 @@ public class TextEditor extends GraphicalEditor {
 	}
 
 	@Override
-	public void commandStackChanged(EventObject event) {
+	public void stackChanged(CommandStackEvent event) {
 		firePropertyChange(PROP_DIRTY);
-		super.commandStackChanged(event);
+		super.stackChanged(event);
 	}
 
 	/**


### PR DESCRIPTION
The example editors override the deprecated commandStackChanged() method to manage the "dirty" flag of the editor. For backwards-compatibility, this method is call by the non-deprecated stackChanged method.

Contributes to https://github.com/eclipse-gef/gef-classic/pull/778