### PR TITLE
Don't set "advanced mode" for FigureUtilities GC

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -79,9 +79,6 @@ public class FigureUtilities {
 				// ignored
 			});
 			gc = new GC(shell);
-			if (InternalDraw2dUtils.disableAutoscale) {
-				gc.setAdvanced(true);
-			}
 			appliedFont = gc.getFont();
 		}
 		return gc;


### PR DESCRIPTION
This reverts the changes done to the FigureUtilities class that was done with 2cb016edf26332580c2dd2925656ebf4fcc5577e, as it introduces rounding errors at 100% zoom.