### PR TITLE
Override getChildren() in ScalableRootFigure of PopUpHelper

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d;
 
+import java.util.List;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Rectangle;
@@ -263,6 +265,11 @@ public abstract class PopUpHelper {
 			@Override
 			public void add(IFigure figure, Object constraint, int index) {
 				scalablePane.add(figure, constraint, index);
+			}
+
+			@Override
+			public List<? extends IFigure> getChildren() {
+				return scalablePane.getChildren();
 			}
 
 			@Override


### PR DESCRIPTION
This is a follow-up to 4b38172a5fc7aff628a73eb9172cff7aa6c38d78, where a custom RootFigure class was created, which injects a ScalableLayeredPane between itself and its content.

The add() method was already overridden to add any additional children to the scalable figure. One also needs to override the getChildren() method to delegate to the same figure.