### PR TITLE
Add utility functions for printing figures and graphical viewers #999

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   This feature was originally request in [Bug 172463](https://bugs.eclipse.org/bugs/show_bug.cgi?id=172463)   
 - Implemented `SWTGraphics.getAbsoluteScale()`
   This feature was originally requested in [Bug 267462](https://bugs.eclipse.org/bugs/show_bug.cgi?id=267462)
+  Added `ImagePrintFigureOperation` for painting a Figure on an Image.
 
 ## GEF
 
@@ -65,6 +66,8 @@ specifically, the `TreeViewer` is using `EditPart`'s as exclusion set.
   contribute their own implementation via an OSGi service.
   Alternatively, clients may inject a custom `ToolTipHelper` instance directly
   by overriding `createToolTipHelper()` in `SWTEventDispatcher`.
+  Added `ImagePrintGraphicalViewerOperation` for painting the printable layer
+  of a GraphicalViewer on an Image.
 
 ## Zest
 

--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/printing/ImagePrintExample.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/printing/ImagePrintExample.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.examples.printing;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+
+import org.eclipse.draw2d.FigureCanvas;
+import org.eclipse.draw2d.ImagePrintFigureOperation;
+import org.eclipse.draw2d.SWTGraphics;
+import org.eclipse.draw2d.ScalableLightweightSystem;
+import org.eclipse.draw2d.text.FlowPage;
+import org.eclipse.draw2d.text.ParagraphTextLayout;
+import org.eclipse.draw2d.text.TextFlow;
+
+/**
+ * This example shows how to use the {@link ImagePrintFigureOperation}.
+ */
+public class ImagePrintExample {
+
+	public static void main(String[] args) {
+		Shell shell = new Shell();
+		shell.setSize(400, 200);
+		shell.setLayout(new GridLayout(3, true));
+
+		TextFlow textFlow = new TextFlow("Hello World"); //$NON-NLS-1$
+		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_SOFT));
+
+		FlowPage flowPage = new FlowPage();
+		flowPage.add(textFlow);
+
+		Label original = new Label(shell, SWT.NONE);
+		original.setText("Original:"); //$NON-NLS-1$
+		original.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+
+		Label imagePrinter = new Label(shell, SWT.NONE);
+		imagePrinter.setText("ImagePrinter:"); //$NON-NLS-1$
+		imagePrinter.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+
+		Label image = new Label(shell, SWT.NONE);
+		image.setText("Image:"); //$NON-NLS-1$
+		image.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+
+		FigureCanvas canvas = new FigureCanvas(shell, new ScalableLightweightSystem());
+		canvas.setContents(flowPage);
+		canvas.getLightweightSystem().getUpdateManager().performUpdate();
+		canvas.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		ImagePrintFigureOperation imagePrintOperation = new ImagePrintFigureOperation(shell, textFlow);
+		Image printResult = imagePrintOperation.run();
+
+		Composite composite1 = new Composite(shell, SWT.NONE);
+		composite1.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		composite1.addPaintListener(event -> event.gc.drawImage(printResult, 0, 0));
+
+		Composite composite2 = new Composite(shell, SWT.NONE);
+		composite2.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		composite2.addPaintListener(event -> {
+			GC gc = event.gc;
+			SWTGraphics graphics = new SWTGraphics(gc);
+			textFlow.paint(graphics);
+			graphics.dispose();
+		});
+
+		shell.requestLayout();
+		shell.open();
+
+		Display display = shell.getDisplay();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+
+		printResult.dispose();
+	}
+
+}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
@@ -65,7 +65,8 @@ import org.junit.platform.suite.api.Suite;
 	LabelTest.class,
 	PrecisionTests.class,
 	ScaledGraphicsTest.class,
-	HSLTest.class
+	HSLTest.class,
+	ImagePrintFigureOperationTest.class
 })
 public class Draw2dTestSuite {
 }

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ImagePrintFigureOperationTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ImagePrintFigureOperationTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.widgets.Shell;
+
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.ImagePrintFigureOperation;
+import org.eclipse.draw2d.geometry.Rectangle;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ImagePrintFigureOperationTest {
+	private Shell shell;
+	private IFigure figure;
+
+	@BeforeEach
+	public void setUp() {
+		figure = new Figure();
+		figure.setBounds(new Rectangle(10, 20, 16, 32));
+		shell = new Shell();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		shell.dispose();
+	}
+
+	@Test
+	public void testPrintWithAutoScaling() {
+		testPrintWithOperation(new ImagePrintFigureOperation(shell, figure) {
+			@Override
+			protected boolean isDraw2DAutoScalingEnabled() {
+				return true;
+			}
+		});
+	}
+
+	@Test
+	public void testPrintWithoutAutoScaling() {
+		testPrintWithOperation(new ImagePrintFigureOperation(shell, figure) {
+			@Override
+			protected boolean isDraw2DAutoScalingEnabled() {
+				return false;
+			}
+		});
+	}
+
+	private static void testPrintWithOperation(ImagePrintFigureOperation printer) {
+		Image image = printer.run();
+		try {
+			assertImageDataSize(image.getImageData(400), 64, 128);
+			assertImageDataSize(image.getImageData(200), 32, 64);
+			assertImageDataSize(image.getImageData(150), 24, 48);
+			assertImageDataSize(image.getImageData(100), 16, 32);
+			assertImageDataSize(image.getImageData(50), 8, 16);
+			assertImageDataSize(image.getImageData(25), 4, 8);
+			// Image is too small (width=0 and height=0)
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+					() -> assertImageDataSize(image.getImageData(1), 1, 1));
+			assertEquals("Argument not valid", e.getMessage()); //$NON-NLS-1$
+		} finally {
+			image.dispose();
+		}
+
+	}
+
+	private static void assertImageDataSize(ImageData data, int width, int height) {
+		assertEquals(width, data.width, "Unexpected width of image data."); //$NON-NLS-1$
+		assertEquals(height, data.height, "Unexpected height of image data."); //$NON-NLS-1$
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ImagePrintFigureOperation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ImagePrintFigureOperation.java
@@ -1,0 +1,246 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d;
+
+import java.util.Objects;
+
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageDataProvider;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.internal.ImageUtils;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
+
+/**
+ * Implementation of Draw2D's image drawing capabilities.
+ * <p>
+ * <strong>Important:</strong>To make sure that the created image is properly
+ * scaled on zoom changes, the {@link FigureCanvas} hosting the {@link IFigure}
+ * must <b>not</b> be disposed.
+ * </p>
+ *
+ * @since 3.23
+ */
+public class ImagePrintFigureOperation {
+	private final Display display;
+	private final Control control;
+	private IFigure printSource;
+
+	/**
+	 * Constructor for PrintFigureOperation.
+	 *
+	 * @param control     control to to print on. Must not be {@code null}.
+	 * @param printSource figure to print
+	 */
+	public ImagePrintFigureOperation(Control control, IFigure printSource) {
+		this(control);
+		setPrintSource(printSource);
+	}
+
+	/**
+	 * Constructor for PrintFigureOperation.
+	 * <p>
+	 * Note: Descendants must call setPrintSource(IFigure) to set the IFigure that
+	 * is to be printed.
+	 * </p>
+	 *
+	 * @param control device to print on. Must not be {@code null}.
+	 */
+	protected ImagePrintFigureOperation(Control control) {
+		Objects.requireNonNull(control, "Control must not be null"); //$NON-NLS-1$
+		this.control = control;
+		this.display = control.getDisplay();
+	}
+
+	/**
+	 * This method contains all operations performed to {@link #printSource} prior
+	 * to being printed.
+	 *
+	 * @param graphics The {@link Graphics} instance used for painting.
+	 */
+	protected void preparePrintSource(Graphics graphics) {
+		// may be overridden by subclasses.
+	}
+
+	/**
+	 * This method contains all operations performed to sourceFigure after being
+	 * printed.
+	 *
+	 * @param graphics The {@link Graphics} instance used for painting.
+	 */
+	protected void restorePrintSource(Graphics graphics) {
+		// may be overridden by subclasses.
+	}
+
+	/**
+	 * Sets the printSource.
+	 *
+	 * @param printSource The printSource to set
+	 */
+	protected void setPrintSource(IFigure printSource) {
+		this.printSource = printSource;
+	}
+
+	/**
+	 * Returns the size of the image to create. Returns {@link IFigure#getSize()} by
+	 * default. May be overridden by subclasses.
+	 *
+	 * @return The image size.
+	 */
+	protected Dimension getImageSize() {
+		return printSource.getSize();
+	}
+
+	/**
+	 * Calculates and returns the image data for the given monitor zoom. May be
+	 * overridden by subclasses.
+	 *
+	 * @param zoom The monitor zoom for which the image data is created for.
+	 * @return The image data for the given monitor zoom
+	 */
+	protected ImageData getImageDataAtZoom(int zoom) {
+		Image image = createImageAtScale(zoom / 100.0);
+		try {
+			return image.getImageData(100);
+		} finally {
+			image.dispose();
+		}
+	}
+
+	/**
+	 * Returns whether Draw2D-based scaling is enabled. Depending on whether this
+	 * method returns {@code true}, the image is drawn as if at 100% and then scaled
+	 * to match the monitor zoom.
+	 *
+	 * @return {@code true} if Draw2D-based scaling is enabled.
+	 */
+	@SuppressWarnings("static-method")
+	protected boolean isDraw2DAutoScalingEnabled() {
+		return InternalDraw2dUtils.isAutoScaleEnabled();
+	}
+
+	/**
+	 * Sets the print job into motion.
+	 */
+	public Image run() {
+		Objects.requireNonNull(printSource, "Print source must not be null"); //$NON-NLS-1$
+		if (isDraw2DAutoScalingEnabled()) {
+			return createAutoScaledImage();
+		}
+		return createImage();
+	}
+
+	/**
+	 * Creates and returns an {@link Image} created as if at 100% zoom but scaled by
+	 * the current zoom. This image has two {@link ImageData}, one at 100% and one
+	 * at the current monitor zoom.
+	 *
+	 * @return The image if Draw2D-based auto-scaling is enabled.
+	 */
+	private Image createAutoScaledImage() {
+		double scale = InternalDraw2dUtils.calculateScale(control);
+		Image image = createImageAtScale(scale);
+		try {
+			ImageData imageData = image.getImageData(100);
+			return new Image(display, new ScaledImageDataProvider(imageData, (int) (scale * 100)));
+		} finally {
+			image.dispose();
+		}
+	}
+
+	/**
+	 * Creates and returns an {@link Image} created at the current monitor zoom.
+	 *
+	 * @return The image if Draw2D-based auto-scaling is disabled.
+	 */
+	private Image createImage() {
+		return createImageAtScale(1.0);
+	}
+
+	/**
+	 * Creates and returns an {@link Image} capturing the contents of
+	 * {@link #printSource}. The size of the image is determined by
+	 * {@link #getImageSize()} and scaled by {@code scale} (if Draw2D-based scaling
+	 * is enabled).
+	 *
+	 * @param scale The scaling factor. Only used if Draw2D-based scaling is enabled
+	 * @return The created image.
+	 */
+	private Image createImageAtScale(double scale) {
+		if (scale != 1.0 && !isDraw2DAutoScalingEnabled()) {
+			throw new IllegalArgumentException("Scaling factor must be 1.0 if Draw2D-based scaling is disabled."); //$NON-NLS-1$
+		}
+
+		Dimension size = getImageSize().getCopy();
+		if (isDraw2DAutoScalingEnabled()) {
+			size.scale(scale);
+		}
+
+		Image image = new Image(display, size.width, size.height);
+
+		GC gc = new GC(image);
+		if (isDraw2DAutoScalingEnabled()) {
+			// Force image to be drawn as if at 100% zoom
+			image.getImageData(100);
+		}
+
+		SWTGraphics graphics = new SWTGraphics(gc);
+		if (isDraw2DAutoScalingEnabled()) {
+			graphics.scale(scale);
+		}
+
+		try {
+			preparePrintSource(graphics);
+			printSource.paint(graphics);
+		} finally {
+			restorePrintSource(graphics);
+		}
+
+		graphics.dispose();
+		gc.dispose();
+		return image;
+	}
+
+	/**
+	 * {@link ImageData} provider containing the image data at the current monitor
+	 * zoom and at 100% zoom (as required by SWT). This class is used if
+	 * Draw2D-based scaling to make sure that the image remains sharp.
+	 */
+	private class ScaledImageDataProvider implements ImageDataProvider {
+		private final ImageData imageData;
+		private final int zoom;
+
+		public ScaledImageDataProvider(ImageData imageData, int zoom) {
+			this.imageData = imageData;
+			this.zoom = zoom;
+		}
+
+		@Override
+		public ImageData getImageData(int zoom) {
+			if (this.zoom == zoom) {
+				return imageData;
+			}
+			try {
+				return getImageDataAtZoom(zoom);
+			} catch (SWTException e) {
+				return ImageUtils.smoothScaleTo(display, imageData, zoom * 1.0 / this.zoom);
+			}
+		}
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/ImageUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/ImageUtils.java
@@ -19,7 +19,12 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ServiceConfigurationError;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageLoader;
 
 /**
@@ -73,5 +78,32 @@ public final class ImageUtils {
 			isSvgSupported = false;
 		}
 		return isSvgSupported;
+	}
+
+	/**
+	 * Scales the {@link ImageData} by the given factor using anti-alias and
+	 * interpolation.
+	 *
+	 * @param device The device to draw on.
+	 * @param data   The image data to scale.
+	 * @param scale  The factor by which the image is scaled.
+	 */
+	public static ImageData smoothScaleTo(Device device, ImageData data, double scale) {
+		int scaledWidth = Math.max(1, (int) (data.width * scale));
+		int scaledHeight = Math.max(1, (int) (data.height * scale));
+
+		Image source = new Image(device, data);
+		Image target = new Image(device, scaledWidth, scaledHeight);
+		GC gc = new GC(target);
+		try {
+			gc.setAntialias(SWT.ON);
+			gc.setInterpolation(SWT.HIGH);
+			gc.drawImage(source, 0, 0, data.width, data.height, 0, 0, scaledWidth, scaledHeight);
+			gc.dispose();
+			return target.getImageData(100);
+		} finally {
+			target.dispose();
+			source.dispose();
+		}
 	}
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/print/ImagePrintGraphicalViewerOperation.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/print/ImagePrintGraphicalViewerOperation.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.print;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.viewers.StructuredSelection;
+
+import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.ImagePrintFigureOperation;
+import org.eclipse.draw2d.Layer;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.gef.LayerConstants;
+import org.eclipse.gef.editparts.LayerManager;
+
+/**
+ * Implementation of GEF image drawing capabilities.
+ *
+ * @since 3.25
+ */
+public class ImagePrintGraphicalViewerOperation extends ImagePrintFigureOperation {
+	private final GraphicalViewer viewer;
+	private List<EditPart> selectedEditParts;
+
+	/**
+	 * Constructor for PrintGraphicalViewerOperation
+	 *
+	 * @param viewer The viewer containing what is to be printed NOTE: The
+	 *               GraphicalViewer to be printed must have a {@link Layer Layer}
+	 *               with the {@link LayerConstants PRINTABLE_LAYERS} key.
+	 */
+	public ImagePrintGraphicalViewerOperation(GraphicalViewer viewer) {
+		super(viewer.getControl());
+		this.viewer = viewer;
+		LayerManager layerManager = LayerManager.Helper.find(viewer);
+		IFigure layer = layerManager.getLayer(LayerConstants.PRINTABLE_LAYERS);
+		setPrintSource(layer);
+	}
+
+	/**
+	 * @see ImagePrintFigureOperation#preparePrintSource(Graphics)
+	 */
+	@Override
+	protected void preparePrintSource(Graphics graphics) {
+		super.preparePrintSource(graphics);
+		selectedEditParts = new ArrayList<>(viewer.getSelectedEditParts());
+		viewer.deselectAll();
+	}
+
+	/**
+	 * @see ImagePrintFigureOperation#restorePrintSource(Graphics)
+	 */
+	@Override
+	protected void restorePrintSource(Graphics graphics) {
+		viewer.setSelection(new StructuredSelection(selectedEditParts));
+		super.restorePrintSource(graphics);
+	}
+}


### PR DESCRIPTION
This adds the new utility classes `ImagePrintFigureOperation` and `ImagePrintGraphicalViewerOperation` which can be used to paint the contents of a Figure/GraphicalViewer onto an SWT Image.

When capturing a figure, clipping may occur because text sizes are not consistent across different zoom levels. When Draw2D-based scaling is enabled, the `FigureCanvas` is configured to always draw as if at 100% zoom and then scale its contents to match the actual monitor zoom.

However, when painting on an Image, the Image GC may use the monitor zoom, leading to inconsistencies. To avoid this, the GC must be forced into "100% mode" by first calling `Image.getImageData(100)`. Then the SWTGraphics instance must be scaled by the monitor zoom so that the Figure can be painted.

The result is an exact representation of the source figure.