### PR TITLE
[Zest] Fix memory-leak in GraphLabel when images are cached

### DIFF
--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Localization: plugin
 Bundle-Version: 1.18.0.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.draw2d;bundle-version="[3.21.0,4.0.0)";visibility:=reexport
+ org.eclipse.draw2d;bundle-version="[3.22.0,4.0.0)";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.zest.core.viewers,
  org.eclipse.zest.core.viewers.internal;x-internal:=true,

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -43,6 +43,8 @@ import org.eclipse.zest.core.viewers.internal.ZoomManager;
 import org.eclipse.zest.core.widgets.gestures.RotateGestureListener;
 import org.eclipse.zest.core.widgets.gestures.ZoomGestureListener;
 import org.eclipse.zest.core.widgets.internal.ContainerFigure;
+import org.eclipse.zest.core.widgets.internal.GraphLightweightSystem;
+import org.eclipse.zest.core.widgets.internal.ImageRegistry;
 import org.eclipse.zest.core.widgets.internal.ZestRootLayer;
 import org.eclipse.zest.layouts.InvalidLayoutConfiguration;
 import org.eclipse.zest.layouts.LayoutAlgorithm;
@@ -183,7 +185,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	 * @since 1.8
 	 */
 	public Graph(Composite parent, int style, boolean enableHideNodes) {
-		super(parent, style | SWT.DOUBLE_BUFFERED);
+		super(parent, style | SWT.DOUBLE_BUFFERED, new GraphLightweightSystem());
 		this.setBackground(ColorConstants.white);
 
 		LIGHT_BLUE = new Color(Display.getDefault(), 216, 228, 248);
@@ -206,6 +208,9 @@ public class Graph extends FigureCanvas implements IContainer2 {
 			}
 		});
 
+		ImageRegistry registry = new ImageRegistry(getDisplay());
+		addDisposeListener(event -> registry.dispose());
+		((GraphLightweightSystem) getLightweightSystem()).setImageRegistry(registry);
 		// @tag CGraph.workaround : this allows me to handle mouse events
 		// outside of the canvas
 		this.getLightweightSystem().setEventDispatcher(new SWTEventDispatcher() {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/CachedLabel.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/CachedLabel.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2024 CHISEL Group, University of Victoria, Victoria,
- *                           BC, Canada and others.
+ * Copyright 2005, 2026 CHISEL Group, University of Victoria, Victoria,
+ *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -207,8 +207,7 @@ public abstract class CachedLabel extends Label implements ILabeledFigure {
 			cleanImage();
 			cachedImage = new Image(Display.getCurrent(), width, height);
 
-			// @tag TODO : Dispose of the image properly
-			// ZestPlugin.getDefault().addImage(cachedImage.toString(), cachedImage);
+			getImageRegistry().put(cachedImage.toString(), cachedImage);
 
 			GC gc = new GC(cachedImage);
 
@@ -246,9 +245,16 @@ public abstract class CachedLabel extends Label implements ILabeledFigure {
 	protected void cleanImage() {
 		if (cachedImage != null) {
 
-			// ZestPlugin.getDefault().removeImage(cachedImage.toString());
+			getImageRegistry().remove((cachedImage.toString()));
 			cachedImage.dispose();
 			cachedImage = null;
 		}
+	}
+
+	private ImageRegistry getImageRegistry() {
+		if (internalGetLightweightSystem() instanceof GraphLightweightSystem lws) {
+			return lws.internalGetImageRegistry();
+		}
+		return ImageRegistry.getSharedRegistry();
 	}
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/GraphLightweightSystem.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/GraphLightweightSystem.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.zest.core.widgets.internal;
+
+import org.eclipse.swt.graphics.Image;
+
+import org.eclipse.zest.core.widgets.Graph;
+
+import org.eclipse.draw2d.LightweightSystem;
+
+/**
+ * Custom lightweight-system used by the Zest {@link Graph} in order to handle
+ * the lifecycle of the {@link Image}s created by the {@link CachedLabel}.
+ */
+public class GraphLightweightSystem extends LightweightSystem {
+	private ImageRegistry registry = ImageRegistry.getSharedRegistry();
+
+	/**
+	 * Updates the image registry used by this {@link LightweightSystem}. If
+	 * {@code null} is passed as an argument, the global image registry is used.
+	 *
+	 * @param registry The new image registry.
+	 */
+	public void setImageRegistry(ImageRegistry registry) {
+		if (registry == null) {
+			this.registry = ImageRegistry.getSharedRegistry();
+		} else {
+			this.registry = registry;
+		}
+	}
+
+	/**
+	 * @return The image registry used by this {@link LightweightSystem}. Never
+	 *         {@code null}.
+	 */
+	public ImageRegistry internalGetImageRegistry() {
+		return registry;
+	}
+}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ImageRegistry.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ImageRegistry.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.zest.core.widgets.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
+
+import org.eclipse.zest.core.widgets.Graph;
+
+/**
+ * An image registry maintains a mapping between symbolic image names and SWT
+ * image objects or special image descriptor objects which defer the creation of
+ * SWT image objects until they are needed.
+ * <p>
+ * An image registry owns all of the image objects registered with it, and
+ * automatically disposes of them when the SWT Display that creates the images
+ * is disposed. Because of this, clients do not need to (indeed, must not
+ * attempt to) dispose of these images themselves.
+ * </p>
+ * <p>
+ * Note: This class is heavily inspired by the JFace {@code ImageRegistry},
+ * which can't be used without introducing an additional dependency to the Zest
+ * {@link Graph}.
+ * </p>
+ */
+public class ImageRegistry {
+	private static final ImageRegistry INSTANCE = new ImageRegistry(Display.getDefault());
+	private final Map<String, Image> registry = new HashMap<>();
+	private final Display display;
+
+	public ImageRegistry(Display display) {
+		this.display = display;
+		this.display.disposeExec(this::dispose);
+	}
+
+	/**
+	 * @return The global image registry shared between among all labels.
+	 */
+	public static ImageRegistry getSharedRegistry() {
+		return INSTANCE;
+	}
+
+	/**
+	 * Adds an image to this registry. This method fails if there is already an
+	 * image or descriptor for the given key.
+	 * <p>
+	 * Note that an image registry owns all of the image objects registered with it,
+	 * and automatically disposes of them when the SWT Display is disposed. Because
+	 * of this, clients must not register an image object that is managed by another
+	 * object.
+	 * </p>
+	 *
+	 * @param key   the key
+	 * @param image the image, must not be {@code null}
+	 * @exception IllegalArgumentException if the key already exists or if the image
+	 *                                     is {@code null}
+	 */
+	public void put(String key, Image image) {
+		if (registry.containsKey(key)) {
+			throw new IllegalArgumentException("ImageRegistry key already in use: " + key); //$NON-NLS-1$
+		}
+		if (image == null) {
+			throw new IllegalArgumentException("Image is 'null' for key: " + key); //$NON-NLS-1$
+		}
+		registry.put(key, image);
+	}
+
+	/**
+	 * Removes an image from this registry. If an SWT image was allocated, it is
+	 * disposed. This method has no effect if there is no image or descriptor for
+	 * the given key.
+	 *
+	 * @param key the key
+	 */
+	public void remove(String key) {
+		registry.remove(key);
+	}
+
+	/**
+	 * Disposes this image registry, disposing any images that were allocated for
+	 * it, and clearing its entries.
+	 */
+	public void dispose() {
+		registry.values().forEach(Image::dispose);
+		registry.clear();
+	}
+}

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphTests.java
@@ -14,9 +14,14 @@ package org.eclipse.zest.tests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.zest.core.widgets.Graph;
@@ -24,10 +29,14 @@ import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
+import org.eclipse.zest.core.widgets.internal.GraphLabel;
+import org.eclipse.zest.core.widgets.internal.GraphLightweightSystem;
+import org.eclipse.zest.core.widgets.internal.ImageRegistry;
 import org.eclipse.zest.core.widgets.internal.ZestRootLayer;
 import org.eclipse.zest.layouts.interfaces.LayoutContext;
 
 import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.SWTGraphics;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -104,6 +113,31 @@ public class GraphTests {
 		assertTrue(connection.isDisposed(), "Connection should be disposed"); //$NON-NLS-1$
 		graph.dispose();
 		assertTrue(graph.isDisposed(), "Graph should be disposed"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testDisposeCachedLabel() throws Exception {
+		GraphLabel label = new GraphLabel("Test", true); //$NON-NLS-1$
+		graph.getRootLayer().add(label);
+
+		GC gc = new GC(shell);
+		SWTGraphics graphics = new SWTGraphics(gc);
+		label.paint(graphics);
+		graphics.dispose();
+		gc.dispose();
+
+		Map<String, Image> registry = getCachedImages();
+		assertEquals(1, registry.size());
+		graph.dispose();
+		assertTrue(registry.isEmpty());
+	}
+
+	private Map<String, Image> getCachedImages() throws Exception {
+		MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(ImageRegistry.class, MethodHandles.lookup());
+		VarHandle handle = lookup.findVarHandle(ImageRegistry.class, "registry", Map.class); //$NON-NLS-1$
+
+		ImageRegistry registry = ((GraphLightweightSystem) graph.getLightweightSystem()).internalGetImageRegistry();
+		return (Map<String, Image>) handle.get(registry);
 	}
 
 	/**


### PR DESCRIPTION
The Zest `GraphLabel` has a potential memory leak when the `NODES_CACHE_LABEL` graph style is used.

When this style is set, the `CachedLabel` will create an internal `Image` onto which the label of this figure is painted. This `Image` is not disposed when the figure is destroyed.

If such an image is created, it will now be registered to an `ImageRegistry`. The lifecycle of this registry is bound to the underlying `Graph`, which will make sure that the `Images` are destroyed, once the `Graph` is disposed.