### PR TITLE
Fix several issues with the Zest SubGraph feature

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -31,12 +31,10 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Item;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.zest.core.viewers.internal.ZoomManager;
@@ -883,98 +881,51 @@ public class Graph extends FigureCanvas implements IContainer2 {
 
 			GraphItem itemUnderMouse = figure2ItemMap.get(figureUnderMouse);
 			if (itemUnderMouse instanceof GraphContainer container) {
-				// GraphContainer under this mouse
-
-				Display display = Display.getCurrent();
-				Shell shell = display.getActiveShell();
-				shell.setLayout(new FillLayout());
-
-				String oldShellLabel = display.getActiveShell().getText();
-				StringBuilder labelBuilder = new StringBuilder();
-				IContainer currentContainer = container;
-				while (currentContainer instanceof GraphContainer current) {
-					labelBuilder.insert(0, current.getText());
-					labelBuilder.insert(0, '/');
-					currentContainer = current.getParent();
-				}
-				labelBuilder.insert(0, oldShellLabel);
-				shell.setText(labelBuilder.toString());
-
-				Graph g = new Graph(shell, SWT.NONE);
-				container.getGraph().setParent(new Shell()); // remove old graph from shell
-				shell.layout();
-
-				for (GraphNode node : container.getNodes()) {
-					container.graph.removeNode(node); // remove nodes from old graph
-					g.addNode(node); // add node to new graph
-					g.registerItem(node); // register figure in new graph
-					node.parent = g; // change parent and graph of node
-					node.graph = g;
-					node.setVisible(true); // make sure the nodes are visible
-					node.unhighlight();
-					HideNodeHelper hideNodeHelper = node.getHideNodeHelper();
-					if (hideNodeHelper != null) {
-						hideNodeHelper.resetCounter();
-					}
-
-					if (node instanceof GraphContainer containerNode) {
-						g.registerChildrenOfContainer(containerNode, true); // recursively add childNodes to graph
-					}
-				}
-				for (GraphNode node : g.getNodes()) {
-					for (GraphConnection connection : node.getTargetConnections()) {
-						container.graph.removeConnection(connection);
-						g.addConnection(connection, true);
-						g.registerItem(connection);
-					}
-					for (GraphConnection connection : node.getSourceConnections()) {
-						container.graph.removeConnection(connection);
-						g.addConnection(connection, true);
-						g.registerItem(connection);
-					}
-				}
-				g.setLayoutAlgorithm(container.getLayoutAlgorithm(), false);
+				List<IFigure> graphFigures = new ArrayList<>(zestRootLayer.getChildren());
 
 				Button backButton = new Button(BACK_ARROW);
 				backButton.setBounds(new Rectangle(new Point(0, 0), backButton.getPreferredSize()));
 				backButton.addActionListener(event -> {
-					for (GraphNode node : new ArrayList<>(g.getNodes())) {
-						g.removeNode(node); // remove nodes from graph
-						container.addNode(node); // add nodes to container
-						container.graph.registerItem(node); // register figure in old graph
-						node.parent = container; // change parent and graph of node
-						node.graph = container.getGraph();
-						node.unhighlight();
-
-						if (node instanceof GraphContainer containerNode) {
-							registerChildrenOfContainer(containerNode, false); // recursively add childNodes to graph
+					rootlayer.remove(backButton);
+					for (GraphNode containerNode : container.getNodes()) {
+						zestRootLayer.remove(containerNode.getNodeFigure());
+						// Connections may also be added to a GraphContainer figure
+						for (GraphConnection sourceConnection : containerNode.getSourceConnections()) {
+							zestRootLayer.remove(sourceConnection.getConnectionFigure());
+						}
+						for (GraphConnection targetConnection : containerNode.getTargetConnections()) {
+							zestRootLayer.remove(targetConnection.getConnectionFigure());
+						}
+						container.zestLayer.addNode(containerNode.getNodeFigure());
+					}
+					for (IFigure graphFigure : graphFigures) {
+						zestRootLayer.add(graphFigure);
+					}
+					container.applyLayout();
+				});
+				// GraphContainer under this mouse
+				container.open(false);
+				for (IFigure graphFigure : graphFigures) {
+					zestRootLayer.remove(graphFigure);
+				}
+				for (GraphNode containerNode : container.getNodes()) {
+					zestRootLayer.add(containerNode.getNodeFigure());
+					// Connections may also be added to a GraphContainer figure
+					for (GraphConnection sourceConnection : containerNode.getSourceConnections()) {
+						IFigure connectionFigure = sourceConnection.getConnectionFigure();
+						if (connectionFigure.getParent() == zestRootLayer) {
+							zestRootLayer.addConnection(connectionFigure);
 						}
 					}
-					for (GraphConnection connection : new ArrayList<GraphConnection>(g.getConnections())) {
-						g.removeConnection(connection);
-						container.graph.addConnection(connection, false);
-						container.graph.registerItem(connection);
-						connection.registerConnection(connection.getSource(), connection.getDestination());
-						connection.setVisible(true);
+					for (GraphConnection targetConnection : containerNode.getTargetConnections()) {
+						IFigure connectionFigure = targetConnection.getConnectionFigure();
+						if (connectionFigure.getParent() == zestRootLayer) {
+							zestRootLayer.addConnection(connectionFigure);
+						}
 					}
-
-					container.applyLayout();
-
-					g.setParent(new Shell()); // remove graph from shell
-					container.getGraph().setParent(shell);
-					shell.layout();
-					shell.setText(oldShellLabel);
-
-					g.release();
-				});
-
-				g.rootlayer.add(backButton);
-
-				shell.addDisposeListener(e -> {
-					g.connections.clear();
-					g.nodes.clear();
-					g.release();
-				});
+				}
+				rootlayer.add(backButton);
+				applyLayout();
 			}
 		}
 
@@ -1280,7 +1231,6 @@ public class Graph extends FigureCanvas implements IContainer2 {
 			this.getSelection().remove(node);
 		}
 		figure2ItemMap.remove(figure);
-		node.getLayout().dispose();
 	}
 
 	void addConnection(GraphConnection connection, boolean addToEdgeLayer) {
@@ -1353,21 +1303,6 @@ public class Graph extends FigureCanvas implements IContainer2 {
 			figure2ItemMap.put(figure, item);
 		} else {
 			throw new RuntimeException("Unknown item type: " + item.getItemType()); //$NON-NLS-1$
-		}
-	}
-
-	private void registerChildrenOfContainer(GraphContainer container, boolean addToMap) {
-		for (GraphNode node : container.getNodes()) {
-			if (node instanceof GraphContainer childContainer) {
-				registerChildrenOfContainer(childContainer, addToMap);
-			} else {
-				node.graph = this;
-				node.unhighlight();
-				if (addToMap) {
-					IFigure figure = node.getFigure();
-					figure2ItemMap.put(figure, node);
-				}
-			}
 		}
 	}
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright 2005, 2025, CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria,
+ *                       BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -249,6 +250,9 @@ public class GraphNode extends GraphItem {
 			this.fishEye(false, false);
 		}
 		super.dispose();
+		if (layout != null) {
+			layout.dispose();
+		}
 		this.isDisposed = true;
 		while (!getSourceConnections().isEmpty()) {
 			GraphConnection connection = getSourceConnections().get(0);

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalLayoutContext.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalLayoutContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009-2010, 2024 Mateusz Matela and others.
+ * Copyright (c) 2009, 2026, Mateusz Matela and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -362,7 +362,7 @@ class InternalLayoutContext implements LayoutContext {
 	@SuppressWarnings("removal")
 	void setLayoutAlgorithm(LayoutAlgorithm algorithm) {
 		this.layoutAlgorithm = algorithm;
-		if (!(layoutAlgorithm instanceof LayoutAlgorithm.Zest1)) {
+		if (layoutAlgorithm != null && !(layoutAlgorithm instanceof LayoutAlgorithm.Zest1)) {
 			this.layoutAlgorithm.setLayoutContext(this);
 		}
 	}

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Fabian Steeg. All rights reserved.
+ * Copyright (c) 2011, 2026 Fabian Steeg. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,7 @@
 package org.eclipse.zest.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -21,14 +22,20 @@ import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
+import org.eclipse.zest.core.widgets.GraphContainer;
 import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
 import org.eclipse.zest.core.widgets.internal.ZestRootLayer;
 import org.eclipse.zest.layouts.interfaces.LayoutContext;
+import org.eclipse.zest.tests.utils.SWTBotGraph;
 
 import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +50,7 @@ public class GraphTests {
 	private GraphNode[] nodes;
 
 	private Graph graph;
+	private SWTBotGraph graphRobot;
 
 	private GraphConnection connection;
 
@@ -52,8 +60,15 @@ public class GraphTests {
 	public void setUp() throws Exception {
 		shell = new Shell();
 		graph = new Graph(shell, SWT.NONE);
+		graph.setSize(400, 400);
+		graphRobot = new SWTBotGraph(graph);
 		nodes = new GraphNode[] { new GraphNode(graph, SWT.NONE), new GraphNode(graph, SWT.NONE) };
 		connection = new GraphConnection(graph, SWT.NONE, nodes[0], nodes[1]);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		shell.dispose();
 	}
 
 	@Test
@@ -184,5 +199,25 @@ public class GraphTests {
 		assertEquals(graph.getListeners(SWT.Gesture).length, 0);
 		graph.setGraphStyle(ZestStyles.NONE);
 		assertEquals(graph.getListeners(SWT.Gesture).length, 2);
+	}
+
+	@Test
+	public void testDoubleClickOnGraphContainer() {
+		GraphContainer c = new GraphContainer(graph, SWT.NONE);
+		IFigure containerFigure = c.getNodeFigure();
+		containerFigure.setBounds(new Rectangle(0, 0, 100, 100));
+
+		GraphNode n = new GraphNode(c, SWT.NONE);
+		n.setText("Hello World"); //$NON-NLS-1$
+		IFigure nodeFigure = n.getNodeFigure();
+
+		Point containerCenter = containerFigure.getBounds().getCenter();
+		graphRobot.mouseDoubleClick(containerCenter.x, containerCenter.y);
+		// no changes to the SWT structure
+		assertSame(graph, c.getGraphModel());
+		assertSame(graph, n.getGraphModel());
+		// Graph only shows the container figures
+		ZestRootLayer rootLayer = (ZestRootLayer) graph.getRootLayer().getChildren().get(0);
+		assertEquals(rootLayer.getChildren(), List.of(nodeFigure));
 	}
 }

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/utils/SWTBotGraph.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/utils/SWTBotGraph.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Patrick Ziegler and others.
+ * Copyright (c) 2025, 2026 Patrick Ziegler and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -177,6 +177,22 @@ public class SWTBotGraph extends AbstractSWTBotControl<Graph> implements ISWTBot
 		Assert.isTrue(getBounds().contains(x, y), "Coordinates are not inside the graph."); //$NON-NLS-1$
 		syncExec(() -> {
 			Event event = createGraphMouseEvent(SWT.MouseDown, x, y);
+			widget.notifyListeners(event.type, event);
+		});
+	}
+
+	/**
+	 * This method simulates a {@link SWT#MouseDoubleClick} event using the given
+	 * {@code x} and {@code y} coordinates. Events are sent to the current
+	 * {@link #widget} instance. The coordinates must be inside the graph.
+	 *
+	 * @param x The x coordinate of the simulated mouse cursor.
+	 * @param y The y coordinate of the simulated mouse cursor.
+	 */
+	public void mouseDoubleClick(int x, int y) {
+		Assert.isTrue(getBounds().contains(x, y), "Coordinates are not inside the graph."); //$NON-NLS-1$
+		syncExec(() -> {
+			Event event = createGraphMouseEvent(SWT.MouseDoubleClick, x, y);
 			widget.notifyListeners(event.type, event);
 		});
 	}


### PR DESCRIPTION
1) If the sub-graph is opened and a node moved, a NullPointerException is thrown because the underlying NodeLayout has already been disposed. Rather than disposing this layout when removing it from the Graph, it is now disposed together with the node itself.

2) When opening the sub-graph while no layout algorithm is set, a NullPointerException is thrown when trying to set the layout context.

3) Rather than modifying the SWT structure of the graph, a sub-graph now only modifies the Zest layer. When switching to the sub-graph, all nodes of the graph are removed and replaced with the nodes of the graph container.