### PR TITLE
Explicitly erase drop shadow border together with figure

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -379,6 +379,9 @@ public class Figure implements IFigure {
 		}
 
 		Rectangle r = new Rectangle(getBounds());
+		if (getBorder() instanceof BackgroundBorder border) {
+			border.eraseBackground(this, r);
+		}
 		getParent().translateToParent(r);
 		getParent().repaint(r.x, r.y, r.width, r.height);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/backgrounds/BackgroundBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/backgrounds/BackgroundBorder.java
@@ -19,6 +19,7 @@ import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Insets;
+import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
  * An interface for a special border which can paint both underneath and on top
@@ -45,4 +46,30 @@ public interface BackgroundBorder extends Border {
 	 */
 	void paintBackground(IFigure figure, Graphics graphics, Insets insets);
 
+	/**
+	 * Called when this background should be erased. If the background is drawn
+	 * outside of the figure bounds, the area needs to be expanded to avoid visual
+	 * artifacts. Does nothing by default.
+	 * <p>
+	 * Note: This method is called within the {@link IFigure#erase()} method before
+	 * {@link IFigure#repaint(int, int, int, int)}. Subclasses only need to extend
+	 * the rectangle to cover the area painted by the background.
+	 * </p>
+	 *
+	 * Example:
+	 *
+	 * <pre>
+	 * public void eraseBackground(IFigure figure, Rectangle area) {
+	 * 	area.expand(1, 1);
+	 * }
+	 * </pre>
+	 *
+	 * @param figure The figure whose representation is being erased. Never
+	 *               {@code null}.
+	 * @param area   The area of the figure that is being erased (in parent
+	 *               coordinates)
+	 */
+	default void eraseBackground(IFigure figure, Rectangle area) {
+		// nothing to erase
+	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/backgrounds/shadows/AbstractDropShadowBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/backgrounds/shadows/AbstractDropShadowBorder.java
@@ -220,10 +220,19 @@ public abstract class AbstractDropShadowBorder extends AbstractBackgroundBorder 
 	}
 
 	private void updateClip(Graphics graphics, Rectangle shadowRect) {
-		int shadowSize = Math.max(haloSize, dropShadowSize) + 1;
+		int shadowSize = getShadowSize();
 		shadowRect.expand(shadowSize, shadowSize);
 		graphics.setClip(shadowRect);
 		shadowRect.shrink(shadowSize, shadowSize);
 	}
 
+	@Override
+	public void eraseBackground(IFigure figure, Rectangle area) {
+		int shadowSize = getShadowSize();
+		area.expand(shadowSize, shadowSize);
+	}
+
+	private int getShadowSize() {
+		return Math.max(haloSize, dropShadowSize) + 1;
+	}
 }


### PR DESCRIPTION
The shadow of the drop-shadow border is drawn outside of the figure bounds. As a result, this overpaint is not removed when the figure is erased.

To fix this problem, a new `eraseBorder()` method is added to the `BackgroundBorder` interface, which is called within the `erase()` method of the figure. This method is overridden for the drop-shadow classes to also mark the shadow as dirty.