### PR TITLE
[PoC] Modernize Zest Graph styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@
 
 ## Zest
 
+- Updated  the styling and color theme of the Zest graph and its items.
+  
+  The color constants defines in the `Graph` class have been deprecated for removal in favor of the new 
+  `GraphColorProvider` class, which provides the colors used by the graph items. The highlight color has been adapted 
+  and is now configurable for both the foreground and the background color.
+  
+  Furthermore, the old gradient-based colors have been removed and the blue background color replaced with gray. For the
+  `GraphLabel`, the new `RectangleDropShadowBorder` is used to give the items a more modern look. As a side-effect, it
+  is therefore no longer possible to define the border color and width of this figure, which is why the
+  `IStyleableFigure` has been removed from this class.
+  
+  For the graph connections, the line width has been changed to 2 and anti-alias enabled, to provide a higher contrast
+  against the background.
+
 ## General
 
 

--- a/org.eclipse.zest.core/.settings/.api_filters
+++ b/org.eclipse.zest.core/.settings/.api_filters
@@ -114,4 +114,46 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/zest/core/widgets/internal/GraphLabel.java" type="org.eclipse.zest.core.widgets.internal.GraphLabel">
+        <filter id="572522506">
+            <message_arguments>
+                <message_argument value="RectangleDropShadowBorder"/>
+                <message_argument value="GraphLabel"/>
+            </message_arguments>
+        </filter>
+        <filter id="640708718">
+            <message_arguments>
+                <message_argument value="RectangleDropShadowBorder(int)"/>
+                <message_argument value="GraphLabel"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="AbstractDropShadowBorder"/>
+                <message_argument value="GraphLabel"/>
+                <message_argument value="setDropShadowSize(int)"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="AbstractDropShadowBorder"/>
+                <message_argument value="GraphLabel"/>
+                <message_argument value="setHaloSize(int)"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="AbstractDropShadowBorder"/>
+                <message_argument value="GraphLabel"/>
+                <message_argument value="setShadowColor(Color)"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="AbstractDropShadowBorder"/>
+                <message_argument value="GraphLabel"/>
+                <message_argument value="setSoftness(double)"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Localization: plugin
 Bundle-Version: 1.18.0.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.draw2d;bundle-version="[3.21.0,4.0.0)";visibility:=reexport
+ org.eclipse.draw2d;bundle-version="[3.23.0,4.0.0)";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.zest.core.viewers,
  org.eclipse.zest.core.viewers.internal;x-internal:=true,

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphItemStyler.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphItemStyler.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2024 CHISEL Group, University of Victoria, Victoria,
- *                           BC, Canada.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria,
+ *                       BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -246,7 +246,7 @@ public class GraphItemStyler {
 			node.setBorderHighlightColor(c);
 		}
 		if ((c = provider.getNodeHighlightColor(entity)) != null) {
-			node.setHighlightColor(c);
+			node.setBackgroundHighlightColor(c);
 		}
 		if ((c = provider.getBackgroundColour(entity)) != null) {
 			node.setBackgroundColor(c);

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -106,14 +107,62 @@ public class Graph extends FigureCanvas implements IContainer2 {
 
 	// @tag CGraph.Colors : These are the colour constants for the graph, they
 	// are disposed on clean-up
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-06 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-06", forRemoval = true)
 	public Color LIGHT_BLUE = null;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-06 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-06", forRemoval = true)
 	public Color LIGHT_BLUE_CYAN = null;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-06 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-06", forRemoval = true)
 	public Color GREY_BLUE = null;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-06 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-06", forRemoval = true)
 	public Color DARK_BLUE = null;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-06 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-06", forRemoval = true)
 	public Color LIGHT_YELLOW = null;
 
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-06 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-06", forRemoval = true)
 	public Color HIGHLIGHT_COLOR = ColorConstants.yellow;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-06 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-06", forRemoval = true)
 	public Color HIGHLIGHT_ADJACENT_COLOR = ColorConstants.orange;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-06 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-06", forRemoval = true)
 	public Color DEFAULT_NODE_COLOR = LIGHT_BLUE;
 
 	/**
@@ -154,6 +203,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 
 	private final ZoomGestureListener zoomListener;
 	private final RotateGestureListener rotateListener;
+	private GraphColorProvider colorProvider = new GraphColorProvider();
 
 	/**
 	 * Constructor for a Graph. This widget represents the root of the graph, and
@@ -184,7 +234,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	 */
 	public Graph(Composite parent, int style, boolean enableHideNodes) {
 		super(parent, style | SWT.DOUBLE_BUFFERED);
-		this.setBackground(ColorConstants.white);
+		this.setBackground(getColorProvider().getBackgroundColor(this));
 
 		LIGHT_BLUE = new Color(216, 228, 248);
 		LIGHT_BLUE_CYAN = new Color(213, 243, 255);
@@ -1780,5 +1830,27 @@ public class Graph extends FigureCanvas implements IContainer2 {
 			zoomManager = new ZoomManager(getRootLayer(), getViewport());
 		}
 		return zoomManager;
+	}
+
+	/**
+	 * Sets the color provider used by this graph and its items. A color provider
+	 * defines the palette used for e.g. the fore- and background of all elements
+	 * and ensures a uniform look-and-feel. This method should be called
+	 * <i>before</i> adding elements to this graph.
+	 *
+	 * @param colorProvider The color provider used for this graph. Must not be
+	 *                      {@code null}.
+	 * @throws NullPointerException if {@code colorProvider} is {@code null}.
+	 * @since 1.18
+	 */
+	public void setColorProvider(GraphColorProvider colorProvider) throws NullPointerException {
+		this.colorProvider = Objects.requireNonNull(colorProvider);
+	}
+
+	/**
+	 * Used by the {@link GraphItem} subclasses to get the current color provider.
+	 */
+	/* package */ GraphColorProvider getColorProvider() {
+		return colorProvider;
 	}
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphColorProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphColorProvider.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.zest.core.widgets;
+
+import org.eclipse.swt.graphics.Color;
+
+import org.eclipse.draw2d.BasicColorProvider;
+import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.ColorProvider;
+
+/**
+ * Default implementation of the {@link ColorProvider} used by the Zest
+ * {@link Graph}. This provider is defines the color of e.g. all
+ * {@link GraphNode}s. May be extended to provide custom colors.
+ * <p>
+ * Additional methods may be added in the future.
+ * </p>
+ *
+ * @since 1.18
+ * @see Graph#setColorProvider(GraphColorProvider)
+ */
+public class GraphColorProvider extends BasicColorProvider {
+	/**
+	 * Provides a background color for the given element.
+	 *
+	 * @param element the element
+	 * @return the background color for the element, or {@code null} to use the
+	 *         default background color
+	 */
+	@SuppressWarnings("static-method")
+	public Color getBackgroundColor(Object element) {
+		if (element instanceof Graph) {
+			return ColorConstants.white;
+		}
+		if (element instanceof GraphNode) {
+			return ColorConstants.lightGray;
+		}
+		return null;
+	}
+
+	/**
+	 * Provides a highlight background color for the given element.
+	 *
+	 * @param element the element
+	 * @return the highlight background color for the element, or {@code null} to
+	 *         use the default highlight background color
+	 */
+	@SuppressWarnings("static-method")
+	public Color getBackgroundHighlightColor(Object element) {
+		if (element instanceof GraphNode) {
+			return ColorConstants.menuBackgroundSelected;
+		}
+		if (element instanceof GraphConnection) {
+			return ColorConstants.darkBlue;
+		}
+		return null;
+	}
+
+	/**
+	 * Provides a border color for the given element.
+	 *
+	 * @param element the element
+	 * @return the border color for the element, or {@code null} to use the default
+	 *         border color
+	 */
+	@SuppressWarnings("static-method")
+	public Color getBorderColor(Object element) {
+		if (element instanceof GraphContainer) {
+			return ColorConstants.black;
+		}
+		if (element instanceof GraphNode) {
+			return ColorConstants.lightGray;
+		}
+		return null;
+	}
+
+	/**
+	 * Provides a border highlight color for the given element.
+	 *
+	 * @param element the element
+	 * @return the border highlight color for the element, or {@code null} to use
+	 *         the default border highlight color
+	 */
+	@SuppressWarnings("static-method")
+	public Color getBorderHighlightColor(Object element) {
+		if (element instanceof GraphNode) {
+			return ColorConstants.blue;
+		}
+		return null;
+	}
+
+	/**
+	 * Provides a foreground color for the given element.
+	 *
+	 * @param element the element
+	 * @return the foreground color for the element, or {@code null} to use the
+	 *         default foreground color
+	 */
+	@SuppressWarnings("static-method")
+	public Color getForegroundColor(Object element) {
+		if (element instanceof GraphContainer || element instanceof GraphNode) {
+			return ColorConstants.black;
+		}
+		if (element instanceof GraphConnection) {
+			return ColorConstants.lightGray;
+		}
+		return null;
+	}
+
+	/**
+	 * Provides a highlight foreground color for the given element.
+	 *
+	 * @param element the element
+	 * @return the highlight foreground color for the element, or {@code null} to
+	 *         use the default highlight foreground color
+	 */
+	@SuppressWarnings("static-method")
+	public Color getForegroundHighlightColor(Object element) {
+		if (element instanceof GraphContainer || element instanceof GraphNode) {
+			return ColorConstants.menuForegroundSelected;
+		}
+		return null;
+	}
+}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2025, CHISEL Group, University of Victoria, Victoria,
- *                            BC, Canada and others.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria,
+ *                       BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@
  ******************************************************************************/
 package org.eclipse.zest.core.widgets;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Display;
@@ -106,9 +107,9 @@ public class GraphConnection extends GraphItem {
 		this.destinationNode = destination;
 		this.visible = true;
 		this.color = ColorConstants.lightGray;
-		this.foreground = ColorConstants.lightGray;
-		this.highlightColor = graphModel.DARK_BLUE;
-		this.lineWidth = 1;
+		this.foreground = graphModel.getColorProvider().getForegroundColor(this);
+		this.highlightColor = graphModel.getColorProvider().getBackgroundHighlightColor(this);
+		this.lineWidth = 2;
 		this.lineStyle = Graphics.LINE_SOLID;
 		setWeight(weight);
 		this.graphModel = graphModel;
@@ -759,7 +760,12 @@ public class GraphConnection extends GraphItem {
 	 * @since 1.7
 	 */
 	protected PolylineConnection cachedOrNewConnectionFigure() {
-		return cachedConnectionFigure == null ? new PolylineArcConnection() : cachedConnectionFigure;
+		if (cachedConnectionFigure != null) {
+			return cachedConnectionFigure;
+		}
+		PolylineConnection connectionFigure = new PolylineArcConnection();
+		connectionFigure.setAntialias(SWT.ON);
+		return connectionFigure;
 	}
 
 	/**

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphContainer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphContainer.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2024, CHISEL Group, University of Victoria, Victoria, BC,
- *                            Canada and others.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria,
+ *                       BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -37,7 +37,6 @@ import org.eclipse.zest.layouts.dataStructures.DisplayIndependentRectangle;
 import org.eclipse.zest.layouts.interfaces.LayoutContext;
 
 import org.eclipse.draw2d.Animation;
-import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.FreeformLayout;
 import org.eclipse.draw2d.FreeformViewport;
 import org.eclipse.draw2d.IFigure;
@@ -771,17 +770,18 @@ public class GraphContainer extends GraphNode implements IContainer2 {
 		zestLayer.setLayoutManager(new FreeformLayout());
 		scrollPane.setSize(computeChildArea());
 		scrollPane.setLocation(new Point(0, containerDimension.labelHeight - SUBLAYER_OFFSET));
-		scrollPane.setForegroundColor(ColorConstants.gray);
+		scrollPane.setForegroundColor(getGraph().getColorProvider().getForegroundColor(this));
 
 		expandGraphLabel.setBackgroundColor(getBackgroundColor());
 		expandGraphLabel.setForegroundColor(getForegroundColor());
 		expandGraphLabel.setLocation(new Point(0, 0));
+		expandGraphLabel.setBorder(new LineBorder(getGraph().getColorProvider().getBorderColor(this)));
 
 		containerFigure.add(scrollPane);
 		containerFigure.add(expandGraphLabel);
 
 		scrollPane.getViewport().setContents(scalledLayer);
-		scrollPane.setBorder(new LineBorder());
+		scrollPane.setBorder(new LineBorder(getGraph().getColorProvider().getBorderColor(this)));
 
 		return containerFigure;
 	}
@@ -826,8 +826,8 @@ public class GraphContainer extends GraphNode implements IContainer2 {
 		expandGraphLabel.setFont(getFont());
 
 		if (highlighted == HIGHLIGHT_ON) {
-			expandGraphLabel.setForegroundColor(getForegroundColor());
-			expandGraphLabel.setBackgroundColor(getHighlightColor());
+			expandGraphLabel.setForegroundColor(getForegroundHighlightColor());
+			expandGraphLabel.setBackgroundColor(getBackgroundHighlightColor());
 		}
 		// @tag ADJACENT : Removed highlight adjacent
 		/*

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright 2005, 2025, CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria,
+ *                       BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,7 +31,6 @@ import org.eclipse.zest.layouts.LayoutEntity;
 import org.eclipse.zest.layouts.constraints.LayoutConstraint;
 
 import org.eclipse.draw2d.Animation;
-import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.FigureListener;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
@@ -64,8 +64,9 @@ public class GraphNode extends GraphItem {
 	private List<GraphConnection> targetConnections;
 
 	private Color foreColor;
+	private Color foreHighlightColor;
 	private Color backColor;
-	private Color highlightColor;
+	private Color backHighlightColor;
 	// @tag ADJACENT : Removed highlight adjacent
 	// private Color highlightAdjacentColor;
 	private Color borderColor;
@@ -191,14 +192,15 @@ public class GraphNode extends GraphItem {
 		this.parent = parent;
 		this.sourceConnections = new ArrayList<>();
 		this.targetConnections = new ArrayList<>();
-		this.foreColor = parent.getGraph().DARK_BLUE;
-		this.backColor = parent.getGraph().LIGHT_BLUE;
-		this.highlightColor = parent.getGraph().HIGHLIGHT_COLOR;
+		this.foreColor = parent.getGraph().getColorProvider().getForegroundColor(this);
+		this.foreHighlightColor = parent.getGraph().getColorProvider().getForegroundHighlightColor(this);
+		this.backColor = parent.getGraph().getColorProvider().getBackgroundColor(this);
+		this.backHighlightColor = parent.getGraph().getColorProvider().getBackgroundHighlightColor(this);
 		// @tag ADJACENT : Removed highlight adjacent
 		// this.highlightAdjacentColor = ColorConstants.orange;
 		this.nodeStyle = SWT.NONE;
-		this.borderColor = ColorConstants.lightGray;
-		this.borderHighlightColor = ColorConstants.blue;
+		this.borderColor = parent.getGraph().getColorProvider().getBorderColor(this);
+		this.borderHighlightColor = parent.getGraph().getColorProvider().getBorderHighlightColor(this);
 		this.borderWidth = 1;
 		this.currentLocation = new PrecisionPoint(0, 0);
 		this.size = new Dimension(-1, -1);
@@ -445,16 +447,60 @@ public class GraphNode extends GraphItem {
 
 	/**
 	 * Get the highlight colour for this node
+	 *
+	 * @deprecated Use {@link #getBackgroundHighlightColor()} instead. This method
+	 *             will be removed after the 2028-06 release.
 	 */
+	@Deprecated(since = "2026-06", forRemoval = true)
 	public Color getHighlightColor() {
-		return highlightColor;
+		return backHighlightColor;
+	}
+
+	/**
+	 * Get the highlight background colour for this node
+	 *
+	 * @since 1.18
+	 */
+	public Color getBackgroundHighlightColor() {
+		return getHighlightColor();
 	}
 
 	/**
 	 * Set the highlight colour for this node
+	 *
+	 * @deprecated Use {@link #setBackgroundHighlightColor(Color)} instead. This
+	 *             method will be removed after the 2028-06 release.
 	 */
+	@Deprecated(since = "2026-06", forRemoval = true)
 	public void setHighlightColor(Color c) {
-		this.highlightColor = c;
+		this.backHighlightColor = c;
+	}
+
+	/**
+	 * Set the highlight background colour for this node
+	 *
+	 * @since 1.18
+	 */
+	public void setBackgroundHighlightColor(Color c) {
+		setHighlightColor(c);
+	}
+
+	/**
+	 * Get the highlight background colour for this node
+	 *
+	 * @since 1.18
+	 */
+	public Color getForegroundHighlightColor() {
+		return foreHighlightColor;
+	}
+
+	/**
+	 * Set the highlight background colour for this node
+	 *
+	 * @since 1.18
+	 */
+	public void setForegroundHighlightColor(Color c) {
+		this.foreHighlightColor = c;
 	}
 
 	/**
@@ -853,23 +899,15 @@ public class GraphNode extends GraphItem {
 		}
 
 		if (figure instanceof IStyleableFigure styleableFigure) {
-			// update styles (colors, border) for figures implementing
-			// IStyleableFigure
-			if (highlighted == HIGHLIGHT_ON) {
-				styleableFigure.setForegroundColor(getForegroundColor());
-				styleableFigure.setBackgroundColor(getHighlightColor());
-				styleableFigure.setBorderColor(getBorderHighlightColor());
-			} else {
-				styleableFigure.setForegroundColor(getForegroundColor());
-				styleableFigure.setBackgroundColor(getBackgroundColor());
-				styleableFigure.setBorderColor(getBorderColor());
-			}
-
+			// update styles (colors, border) for figures implementing IStyleableFigure
+			styleableFigure.setBorderColor(highlighted == HIGHLIGHT_ON ? getBorderHighlightColor() : getBorderColor());
 			styleableFigure.setBorderWidth(getBorderWidth());
+		}
+		figure.setForegroundColor(highlighted == HIGHLIGHT_ON ? getForegroundHighlightColor() : getForegroundColor());
+		figure.setBackgroundColor(highlighted == HIGHLIGHT_ON ? getBackgroundHighlightColor() : getBackgroundColor());
 
-			if (figure.getFont() != getFont()) {
-				figure.setFont(getFont());
-			}
+		if (figure.getFont() != getFont()) {
+			figure.setFont(getFont());
 		}
 
 		if (this.getTooltip() == null && hasCustomTooltip == false) {
@@ -941,17 +979,8 @@ public class GraphNode extends GraphItem {
 
 		// @tag TODO: Add border and foreground colours to highlight
 		// (this.borderColor)
-		if (highlighted == HIGHLIGHT_ON) {
-			label.setForegroundColor(getForegroundColor());
-			label.setBackgroundColor(getHighlightColor());
-			label.setBorderColor(getBorderHighlightColor());
-		} else {
-			label.setForegroundColor(getForegroundColor());
-			label.setBackgroundColor(getBackgroundColor());
-			label.setBorderColor(getBorderColor());
-		}
-
-		label.setBorderWidth(getBorderWidth());
+		label.setForegroundColor(highlighted == HIGHLIGHT_ON ? getForegroundHighlightColor() : getForegroundColor());
+		label.setBackgroundColor(highlighted == HIGHLIGHT_ON ? getBackgroundHighlightColor() : getBackgroundColor());
 		label.setFont(getFont());
 		return label;
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ExpandGraphLabel.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ExpandGraphLabel.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005-2006, CHISEL Group, University of Victoria, Victoria, BC,
- *                      Canada.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria,
+ *                       BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,10 +12,8 @@
  ******************************************************************************/
 package org.eclipse.zest.core.widgets.internal;
 
-import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.zest.core.widgets.GraphContainer;
@@ -101,7 +99,6 @@ public class ExpandGraphLabel extends Figure implements ActionListener {
 		}
 	}
 
-	private final int arcWidth;
 	private Label label = null;
 	private final GraphContainer container;
 	private final ToolbarLayout layout;
@@ -151,7 +148,6 @@ public class ExpandGraphLabel extends Figure implements ActionListener {
 		this.setImage(image);
 		this.container = container;
 		this.expander = new Expander();
-		this.arcWidth = 8;
 		this.setFont(Display.getDefault().getSystemFont());
 		layout = new ToolbarLayout(true);
 		layout.setSpacing(5);
@@ -159,6 +155,7 @@ public class ExpandGraphLabel extends Figure implements ActionListener {
 		this.setLayoutManager(layout);
 		this.add(this.expander);
 		this.add(this.label);
+		this.setOpaque(true);
 		// this.remove(this.label);
 	}
 
@@ -188,62 +185,6 @@ public class ExpandGraphLabel extends Figure implements ActionListener {
 
 	private String getText() {
 		return this.label.getText();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.eclipse.draw2d.Label#paintFigure(org.eclipse.draw2d.Graphics)
-	 */
-	@Override
-	public void paint(Graphics graphics) {
-		Color baseColor = getBackgroundColor();
-		int blue = (int) (baseColor.getBlue() * 0.8 + 0.5);
-		int red = (int) (baseColor.getRed() * 0.8 + 0.5);
-		int green = (int) (baseColor.getGreen() * 0.8 + 0.5);
-		Color darkerBackground = new Color(new RGB(red, green, blue));
-		graphics.setForegroundColor(darkerBackground);
-		graphics.setBackgroundColor(getBackgroundColor());
-
-		graphics.pushState();
-
-		// fill in the background
-		Rectangle bounds = getBounds().getCopy();
-		Rectangle r = bounds.getCopy();
-		// r.x += arcWidth / 2;
-		r.y += arcWidth / 2;
-		// r.width -= arcWidth;
-		r.height -= arcWidth;
-
-		Rectangle top = bounds.getCopy();
-		top.height /= 2;
-		// graphics.setForegroundColor(lightenColor);
-		// graphics.setBackgroundColor(lightenColor);
-		graphics.setForegroundColor(getBackgroundColor());
-		graphics.setBackgroundColor(getBackgroundColor());
-		graphics.fillRoundRectangle(top, arcWidth, arcWidth);
-
-		top.y = top.y + top.height;
-		// graphics.setForegroundColor(getBackgroundColor());
-		// graphics.setBackgroundColor(getBackgroundColor());
-		graphics.setForegroundColor(darkerBackground);
-		graphics.setBackgroundColor(darkerBackground);
-		graphics.fillRoundRectangle(top, arcWidth, arcWidth);
-
-		// graphics.setForegroundColor(lightenColor);
-		// graphics.setBackgroundColor(getBackgroundColor());
-		graphics.setBackgroundColor(darkerBackground);
-		graphics.setForegroundColor(getBackgroundColor());
-		graphics.fillGradient(r, true);
-
-		super.paint(graphics);
-		graphics.popState();
-		graphics.setForegroundColor(darkerBackground);
-		graphics.setBackgroundColor(darkerBackground);
-		// paint the border
-		bounds.setSize(bounds.width - 1, bounds.height - 1);
-		graphics.drawRoundRectangle(bounds, arcWidth, arcWidth);
-		darkerBackground.dispose();
 	}
 
 //	public Dimension getPreferredSize(int hint, int hint2) {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/GraphLabel.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/GraphLabel.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2025 CHISEL Group, University of Victoria, Victoria,
- *                           BC, Canada.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria,
+ *                       BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,17 +15,12 @@ package org.eclipse.zest.core.widgets.internal;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Path;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
-
-import org.eclipse.zest.core.widgets.IStyleableFigure;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.FigureUtilities;
-import org.eclipse.draw2d.Graphics;
-import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.StackLayout;
+import org.eclipse.draw2d.backgrounds.shadows.RectangleDropShadowBorder;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -35,11 +30,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  *
  * @author Chris Callendar
  */
-public class GraphLabel extends CachedLabel implements IStyleableFigure {
-
-	private Color borderColor;
-	private int borderWidth;
-	private int arcWidth;
+public class GraphLabel extends CachedLabel {
 
 	private final boolean painting = false;
 
@@ -97,11 +88,13 @@ public class GraphLabel extends CachedLabel implements IStyleableFigure {
 	 */
 	protected void initLabel() {
 		super.setFont(Display.getDefault().getSystemFont());
-		this.borderColor = ColorConstants.black;
-		this.borderWidth = 0;
-		this.arcWidth = 8;
 		this.setLayoutManager(new StackLayout());
-		this.setBorder(new MarginBorder(1));
+		this.setOpaque(true);
+		RectangleDropShadowBorder border = new RectangleDropShadowBorder(8);
+		border.setShadowColor(ColorConstants.black);
+		border.setHaloSize(6);
+		border.setSoftness(4.5);
+		this.setBorder(border);
 	}
 
 	/*
@@ -129,69 +122,10 @@ public class GraphLabel extends CachedLabel implements IStyleableFigure {
 					int expandHeight = Math.max(imageRect.height - minSize.height, 0);
 					minSize.expand(imageRect.width + 4, expandHeight);
 				}
-				minSize.expand(10 + (2 * borderWidth), 4 + (2 * borderWidth));
+				minSize.expand(10, 4);
 				setBounds(new Rectangle(getLocation(), minSize));
 			}
 		}
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.eclipse.draw2d.Label#paintFigure(org.eclipse.draw2d.Graphics)
-	 */
-	@Override
-	public void paint(Graphics graphics) {
-		int blue = getBackgroundColor().getBlue();
-		blue = (int) (blue - (blue * 0.20));
-		blue = blue > 0 ? blue : 0;
-
-		int red = getBackgroundColor().getRed();
-		red = (int) (red - (red * 0.20));
-		red = red > 0 ? red : 0;
-
-		int green = getBackgroundColor().getGreen();
-		green = (int) (green - (green * 0.20));
-		green = green > 0 ? green : 0;
-
-		Color lightenColor = new Color(new RGB(red, green, blue));
-		graphics.setForegroundColor(lightenColor);
-		graphics.setBackgroundColor(getBackgroundColor());
-
-		graphics.pushState();
-
-		Rectangle bounds = getBounds().getCopy();
-		bounds.shrink(1, 1);
-
-		Path p = new Path(Display.getCurrent());
-		p.addArc(bounds.left(), bounds.top(), arcWidth, arcWidth, 90, 90);
-		p.addArc(bounds.left(), bounds.bottom() - arcWidth, arcWidth, arcWidth, 180, 90);
-		p.addArc(bounds.right() - arcWidth, bounds.bottom() - arcWidth, arcWidth, arcWidth, 270, 90);
-		p.addArc(bounds.right() - arcWidth, bounds.top(), arcWidth, arcWidth, 0, 90);
-		graphics.clipPath(p);
-
-		graphics.setBackgroundColor(lightenColor);
-		graphics.setForegroundColor(getBackgroundColor());
-		graphics.fillGradient(bounds, true);
-
-		// Paint the border
-		if (borderWidth > 0) {
-			graphics.setClip(getBounds());
-			graphics.setForegroundColor(borderColor);
-			graphics.setBackgroundColor(borderColor);
-			graphics.setLineWidth(borderWidth);
-			graphics.drawRoundRectangle(bounds, arcWidth, arcWidth);
-		}
-
-		graphics.restoreState();
-
-		p.dispose();
-
-		super.paint(graphics);
-
-		graphics.popState();
-
-		lightenColor.dispose();
 	}
 
 	@Override
@@ -236,29 +170,7 @@ public class GraphLabel extends CachedLabel implements IStyleableFigure {
 		adjustBoundsToFit();
 	}
 
-	public Color getBorderColor() {
-		return borderColor;
-	}
-
-	@Override
-	public void setBorderColor(Color c) {
-		this.borderColor = c;
-	}
-
-	public int getBorderWidth() {
-		return borderWidth;
-	}
-
-	@Override
-	public void setBorderWidth(int width) {
-		this.borderWidth = width;
-	}
-
-	public int getArcWidth() {
-		return arcWidth;
-	}
-
 	public void setArcWidth(int arcWidth) {
-		this.arcWidth = arcWidth;
+		((RectangleDropShadowBorder) getBorder()).setDropShadowSize(arcWidth);
 	}
 }


### PR DESCRIPTION
- Use RectangleDropShadowBorder for GraphLabel.
- Increase line-width for connections to 2 and enable anti-alias.