### PR TITLE
Set line width to 2 for feedback figures

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/LayoutEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/LayoutEditPolicy.java
@@ -331,7 +331,8 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 					HSL.fromColor(ColorProvider.SystemColorFactory.getColorProvider().getMenuBackgroundSelected())
 							.darker(0.3).toColor());
 			((Shape) sizeOnDropFeedback).setAlpha(50);
-			((Shape) sizeOnDropFeedback).setLineStyle(Graphics.LINE_DASHDOT);
+			((Shape) sizeOnDropFeedback).setLineStyle(Graphics.LINE_DOT);
+			((Shape) sizeOnDropFeedback).setLineWidth(2);
 			sizeOnDropFeedback.setForegroundColor(ColorConstants.white);
 			addFeedback(sizeOnDropFeedback);
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/NonResizableEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/NonResizableEditPolicy.java
@@ -73,6 +73,7 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 				HSL.fromColor(ColorProvider.SystemColorFactory.getColorProvider().getMenuBackgroundSelected())
 						.darker(0.3).toColor());
 		r.setAlpha(50);
+		r.setLineWidth(2);
 		r.setLineStyle(Graphics.LINE_DOT);
 		r.setForegroundColor(ColorConstants.white);
 		r.setBounds(getInitialFeedbackBounds());


### PR DESCRIPTION
This improves visibility of the outline especially on dark theme

Also change line style to LINE_DOT in LayoutEditPolicy as LINE_DASHDOT can look messy on dark theme