### PR TITLE
Update changelog and tags regarind `ImagePrintFigureOperation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 # GEF Classic 3.28.0
 
 ## Draw2D
+- Added `ImagePrintFigureOperation` for painting a Figure on an Image. Using this class in favor of `IFigure.paint(...)`
+  avoids visual artifacts and clipping that result from fractional scaling.
+  
 
 ## GEF
 
@@ -43,7 +46,6 @@
   This feature was originally request in [Bug 172463](https://bugs.eclipse.org/bugs/show_bug.cgi?id=172463)   
 - Implemented `SWTGraphics.getAbsoluteScale()`
   This feature was originally requested in [Bug 267462](https://bugs.eclipse.org/bugs/show_bug.cgi?id=267462)
-  Added `ImagePrintFigureOperation` for painting a Figure on an Image.
 
 ## GEF
 

--- a/org.eclipse.gef/src/org/eclipse/gef/print/ImagePrintGraphicalViewerOperation.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/print/ImagePrintGraphicalViewerOperation.java
@@ -31,7 +31,7 @@ import org.eclipse.gef.editparts.LayerManager;
 /**
  * Implementation of GEF image drawing capabilities.
  *
- * @since 3.25
+ * @since 3.26
  */
 public class ImagePrintGraphicalViewerOperation extends ImagePrintFigureOperation {
 	private final GraphicalViewer viewer;


### PR DESCRIPTION
This is a continuation of 2de146224e28f54ce98cf3f7528d5950f9ebf121. The `ImagePrintFigureOperation` was now introduced with the 3.28, not the 3.27.