### PR TITLE
Fix incorrect palette minimum width

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -623,7 +623,7 @@ public class FlyoutPaletteComposite extends Composite {
 					restorePaletteState(pViewer, capturedPaletteState);
 				}
 				capturedPaletteState = null;
-				minWidth = Math.round(Math.max(pViewer.getControl().computeSize(0, 0).x * scale, MIN_PALETTE_SIZE));
+				minWidth = Math.round(Math.max(pViewer.getControl().computeSize(0, 0).x, MIN_PALETTE_SIZE));
 			}
 			/*
 			 * Fix for Bug# 63901 When the flyout collapses, if the palette has focus, throw


### PR DESCRIPTION
If on Windows at say 200% display scaling the minumim palette width is twice as big compared with 100% display scaling or on Mac and Linux

Remove scaling factor from minWidth computation