### PR TITLE
Use PrecisionRectangle when calculating Freeform bounds #1116

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AutoscaleFreeformViewportTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AutoscaleFreeformViewportTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.draw2d.AutoscaleFreeformViewport;
+import org.eclipse.draw2d.FreeformLayer;
+import org.eclipse.draw2d.geometry.Rectangle;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class AutoscaleFreeformViewportTest {
+	private static final Rectangle VIEWPORT_BOUNDS = new Rectangle(0, 0, 931, 687);
+	private AutoscaleFreeformViewport viewport;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		viewport = new AutoscaleFreeformViewport(false);
+		viewport.setContents(new FreeformLayer());
+		viewport.setBounds(VIEWPORT_BOUNDS);
+	}
+
+	/**
+	 * @see <a href="https://github.com/eclipse-gef/gef-classic/issues/1116">here</a>
+	 */
+	@ParameterizedTest
+	@ValueSource(doubles = { 1.0, 1.25, 1.33, 1.5, 1.66, 1.75, 2.0, 2.5, 3.0 })
+	public void testLayerBoundsWithScale(double scale) {
+		viewport.setScale(scale);
+		viewport.validate();
+
+		Rectangle layerBounds = viewport.getContents().getBounds().getCopy();
+		viewport.getContents().translateToAbsolute(layerBounds);
+		assertTrue(layerBounds.width <= VIEWPORT_BOUNDS.width,
+				"Layer width should not exceed viewport width: " + layerBounds.width); //$NON-NLS-1$
+		assertTrue(layerBounds.height <= VIEWPORT_BOUNDS.height,
+				"Layer height should not exceed viewport height: " + layerBounds.height); //$NON-NLS-1$
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
@@ -15,6 +15,9 @@ package org.eclipse.draw2d;
 
 import org.eclipse.pde.api.tools.annotations.NoReference;
 
+import org.eclipse.draw2d.geometry.PrecisionRectangle;
+import org.eclipse.draw2d.geometry.Rectangle;
+
 /**
  * <b>IMPORTANT:</b> This class is <em>not</em> part of the GEF public API. It
  * is marked public only so that it can be by other GEF plugins and should never
@@ -62,5 +65,10 @@ public class AutoscaleFreeformViewport extends FreeformViewport {
 	@Override
 	protected FreeformFigure getFreeformFigure() {
 		return getAutoScaleLayerPane();
+	}
+
+	@Override
+	Rectangle getFreeformBounds(FreeformFigure ff) {
+		return new PrecisionRectangle(ff.getFreeformExtent());
 	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformViewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformViewport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -71,12 +71,17 @@ public class FreeformViewport extends Viewport {
 			return;
 		}
 		Rectangle clientArea = getClientArea();
-		Rectangle bounds = ff.getFreeformExtent().getCopy();
+		Rectangle bounds = getFreeformBounds(ff);
 		bounds.union(0, 0, clientArea.width, clientArea.height);
 		ff.setFreeformBounds(bounds);
 
 		getVerticalRangeModel().setAll(bounds.y, clientArea.height, bounds.bottom());
 		getHorizontalRangeModel().setAll(bounds.x, clientArea.width, bounds.right());
+	}
+
+	@SuppressWarnings("static-method")
+	/* package */ Rectangle getFreeformBounds(FreeformFigure ff) {
+		return ff.getFreeformExtent().getCopy();
 	}
 
 	/**


### PR DESCRIPTION
When the `AutoscaleFreeformViewport` is used, the bounds for the `FreeformFigure`s have to be set using a `PrecisionRectangle`, to account for rounding errors that are introduced when scaling the figure bounds by the monitor zoom.

Closes https://github.com/eclipse-gef/gef-classic/issues/1116