### PR TITLE
Make Zest graph styling configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## Zest
 
+- Node styling is node done via the `GraphColorProvider`, as opposed to the `IEntityStyleProvider`. This allows
+  consumers to easily style graph items without relying on JFace classes. The corresponding methods in the
+  `IEntityStyleProvider` have been deprecated for removal.
+
 ## General
 
 

--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.core;singleton:=true
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.18.100.qualifier
+Bundle-Version: 1.19.0.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.draw2d;bundle-version="[3.21.0,4.0.0)";visibility:=reexport

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IConnectionStyleProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IConnectionStyleProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2006, 2024 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2026 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -15,6 +15,8 @@ package org.eclipse.zest.core.viewers;
 import org.eclipse.swt.graphics.Color;
 
 import org.eclipse.ui.services.IDisposable;
+import org.eclipse.zest.core.widgets.Graph;
+import org.eclipse.zest.core.widgets.GraphColorProvider;
 
 import org.eclipse.draw2d.IFigure;
 
@@ -41,24 +43,34 @@ public interface IConnectionStyleProvider extends IDisposable {
 	public int getConnectionStyle(Object rel);
 
 	/**
-	 * Returns the color for the connection. Null for default. Any resources created
-	 * by this class must be disposed by this class.
+	 * Returns the color for the connection. Null for default.
 	 *
 	 * @param rel the relationship represented by this connection.
 	 * @return the color.
-	 * @see #dispose()
+	 * @see GraphColorProvider#getForegroundColor(Object)
+	 * @deprecated Call {@link Graph#setColorProvider} with a custom
+	 *             {@link GraphColorProvider} instead. This method will be removed
+	 *             after the 2028-09 release.
 	 */
-	public Color getColor(Object rel);
+	@Deprecated(since = "2026-09", forRemoval = true)
+	default Color getColor(Object rel) {
+		return null;
+	}
 
 	/**
-	 * Returns the highlighted color for this connection. Null for default. Any
-	 * resources created by this class must be disposed by this class.
+	 * Returns the highlighted color for this connection. Null for default.
 	 *
 	 * @param rel the relationship represented by this connection.
 	 * @return the highlighted color. Null for default.
-	 * @see #dispose()
+	 * @see GraphColorProvider#getForegroundHighlightColor(Object)
+	 * @deprecated Call {@link Graph#setColorProvider} with a custom
+	 *             {@link GraphColorProvider} instead. This method will be removed
+	 *             after the 2028-09 release.
 	 */
-	public Color getHighlightColor(Object rel);
+	@Deprecated(since = "2026-09", forRemoval = true)
+	default Color getHighlightColor(Object rel) {
+		return null;
+	}
 
 	/**
 	 * Returns the line width of the connection. -1 for default.

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityConnectionStyleProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityConnectionStyleProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2006, 2024 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2026 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -15,6 +15,8 @@ package org.eclipse.zest.core.viewers;
 import org.eclipse.swt.graphics.Color;
 
 import org.eclipse.ui.services.IDisposable;
+import org.eclipse.zest.core.widgets.Graph;
+import org.eclipse.zest.core.widgets.GraphColorProvider;
 
 import org.eclipse.draw2d.IFigure;
 
@@ -47,9 +49,15 @@ public interface IEntityConnectionStyleProvider extends IDisposable {
 	 *             disposed by this class.
 	 * @param dest the destination entity.
 	 * @return the color.
-	 * @see #dispose()
+	 * @see GraphColorProvider#getForegroundColor(Object)
+	 * @deprecated Call {@link Graph#setColorProvider} with a custom
+	 *             {@link GraphColorProvider} instead. This method will be removed
+	 *             after the 2028-09 release.
 	 */
-	public Color getColor(Object src, Object dest);
+	@Deprecated(since = "2026-09", forRemoval = true)
+	default Color getColor(Object src, Object dest) {
+		return null;
+	}
 
 	/**
 	 * Returns the highlighted color for this connection. Null for default.
@@ -58,9 +66,15 @@ public interface IEntityConnectionStyleProvider extends IDisposable {
 	 *             disposed by this class.
 	 * @param dest the destination entity.
 	 * @return the highlighted color. Null for default.
-	 * @see #dispose()
+	 * @see GraphColorProvider#getForegroundHighlightColor(Object)
+	 * @deprecated Call {@link Graph#setColorProvider} with a custom
+	 *             {@link GraphColorProvider} instead. This method will be removed
+	 *             after the 2028-09 release.
 	 */
-	public Color getHighlightColor(Object src, Object dest);
+	@Deprecated(since = "2026-09", forRemoval = true)
+	default Color getHighlightColor(Object src, Object dest) {
+		return null;
+	}
 
 	/**
 	 * Returns the line width of the connection. -1 for default.

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityStyleProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityStyleProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2006, 2024 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2026 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -15,6 +15,8 @@ package org.eclipse.zest.core.viewers;
 import org.eclipse.swt.graphics.Color;
 
 import org.eclipse.ui.services.IDisposable;
+import org.eclipse.zest.core.widgets.Graph;
+import org.eclipse.zest.core.widgets.GraphColorProvider;
 
 import org.eclipse.draw2d.IFigure;
 
@@ -41,34 +43,51 @@ import org.eclipse.draw2d.IFigure;
 public interface IEntityStyleProvider extends IDisposable {
 
 	/**
-	 * Returns the forground colour of this entity. May return null for defaults.
-	 * Any resources created by this class must be disposed by this class.
+	 * Returns the highlight colour of this entity. May return null for defaults.
 	 *
 	 * @param entity the entity to be styled.
-	 * @return the forground colour of this entity.
-	 * @see #dispose()
+	 * @return the highlight colour of this entity.
+	 * @see GraphColorProvider#getForegroundHighlightColor(Object)
+	 * @see GraphColorProvider#getBackgroundHighlightColor(Object)
+	 * @deprecated Call {@link Graph#setColorProvider} with a custom
+	 *             {@link GraphColorProvider} instead. This method will be removed
+	 *             after the 2028-09 release.
 	 */
-	public Color getNodeHighlightColor(Object entity);
+	@Deprecated(since = "2026-09", forRemoval = true)
+	default Color getNodeHighlightColor(Object entity) {
+		return null;
+	}
 
 	/**
 	 * Returns the background colour for this entity. May return null for defaults.
-	 * Any resources created by this class must be disposed by this class.
 	 *
 	 * @param entity the entity to be styled.
 	 * @return the background colour for this entity.
-	 * @see #dispose()
+	 * @see GraphColorProvider#getBorderColor(Object)
+	 * @deprecated Call {@link Graph#setColorProvider} with a custom
+	 *             {@link GraphColorProvider} instead. This method will be removed
+	 *             after the 2028-09 release.
 	 */
-	public Color getBorderColor(Object entity);
+	@Deprecated(since = "2026-09", forRemoval = true)
+	default Color getBorderColor(Object entity) {
+		return null;
+	}
 
 	/**
 	 * Returns the border highlight colour for this entity. May return null for
-	 * defaults. Any resources created by this class must be disposed by this class.
+	 * defaults.
 	 *
 	 * @param entity the entity to be styled.
 	 * @return the border highlight colour for this entity.
-	 * @see #dispose()
+	 * @see GraphColorProvider#getBorderHighlightColor(Object)
+	 * @deprecated Call {@link Graph#setColorProvider} with a custom
+	 *             {@link GraphColorProvider} instead. This method will be removed
+	 *             after the 2028-09 release.
 	 */
-	public Color getBorderHighlightColor(Object entity);
+	@Deprecated(since = "2026-09", forRemoval = true)
+	default Color getBorderHighlightColor(Object entity) {
+		return null;
+	}
 
 	/**
 	 * Returns the border width for this entity. May return -1 for defaults.
@@ -102,17 +121,36 @@ public interface IEntityStyleProvider extends IDisposable {
 	// @tag ADJACENT : Removed highlight adjacent
 	// public Color getAdjacentEntityHighlightColor(Object entity);
 	/**
-	 * Returns the colour that this node should be coloured. This will be ignored if
-	 * getNodeColour returns null. Any resources created by this class must be
-	 * diposed by this class.
+	 * Returns the background colour that this node should be coloured. This will be
+	 * ignored if getNodeColour returns null.
 	 *
 	 * @param entity The entity to be styled
 	 * @return The colour for the node
-	 * @see #dispose()
+	 * @see GraphColorProvider#getBackgroundColor(Object)
+	 * @deprecated Call {@link Graph#setColorProvider} with a custom
+	 *             {@link GraphColorProvider} instead. This method will be removed
+	 *             after the 2028-09 release.
 	 */
-	public Color getBackgroundColour(Object entity);
+	@Deprecated(since = "2026-09", forRemoval = true)
+	default Color getBackgroundColour(Object entity) {
+		return null;
+	}
 
-	public Color getForegroundColour(Object entity);
+	/**
+	 * Returns the foreground colour that this node should be coloured. This will be
+	 * ignored if getNodeColour returns null.
+	 *
+	 * @param entity The entity to be styled
+	 * @return The colour for the node
+	 * @see GraphColorProvider#getForegroundColor(Object)
+	 * @deprecated Call {@link Graph#setColorProvider} with a custom
+	 *             {@link GraphColorProvider} instead. This method will be removed
+	 *             after the 2028-09 release.
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
+	default Color getForegroundColour(Object entity) {
+		return null;
+	}
 
 	/**
 	 * Returns the tooltop for this node. If null is returned Zest will simply use

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -106,14 +107,62 @@ public class Graph extends FigureCanvas implements IContainer2 {
 
 	// @tag CGraph.Colors : These are the colour constants for the graph, they
 	// are disposed on clean-up
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-09 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color LIGHT_BLUE = null;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-09 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color LIGHT_BLUE_CYAN = null;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-09 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color GREY_BLUE = null;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-09 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color DARK_BLUE = null;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-09 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color LIGHT_YELLOW = null;
 
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-09 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color HIGHLIGHT_COLOR = ColorConstants.yellow;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-09 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color HIGHLIGHT_ADJACENT_COLOR = ColorConstants.orange;
+	/**
+	 * @deprecated Use {@link GraphColorProvider} instead. This field will be
+	 *             removed after the 2028-09 release.
+	 * @see #setColorProvider(GraphColorProvider)
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color DEFAULT_NODE_COLOR = LIGHT_BLUE;
 
 	/**
@@ -154,6 +203,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 
 	private final ZoomGestureListener zoomListener;
 	private final RotateGestureListener rotateListener;
+	private GraphColorProvider colorProvider = new GraphColorProvider();
 
 	/**
 	 * Constructor for a Graph. This widget represents the root of the graph, and
@@ -1780,5 +1830,27 @@ public class Graph extends FigureCanvas implements IContainer2 {
 			zoomManager = new ZoomManager(getRootLayer(), getViewport());
 		}
 		return zoomManager;
+	}
+
+	/**
+	 * Sets the color provider used by this graph and its items. A color provider
+	 * defines the palette used for e.g. the fore- and background of all elements
+	 * and ensures a uniform look-and-feel. This method should be called
+	 * <i>before</i> adding elements to this graph.
+	 *
+	 * @param colorProvider The color provider used for this graph. Must not be
+	 *                      {@code null}.
+	 * @throws NullPointerException if {@code colorProvider} is {@code null}.
+	 * @since 1.19
+	 */
+	public void setColorProvider(GraphColorProvider colorProvider) throws NullPointerException {
+		this.colorProvider = Objects.requireNonNull(colorProvider);
+	}
+
+	/**
+	 * Used by the {@link GraphItem} subclasses to get the current color provider.
+	 */
+	/* package */ GraphColorProvider getColorProvider() {
+		return colorProvider;
 	}
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphColorProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphColorProvider.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.zest.core.widgets;
+
+import org.eclipse.swt.graphics.Color;
+
+import org.eclipse.draw2d.BasicColorProvider;
+import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.ColorProvider;
+
+/**
+ * Default implementation of the {@link ColorProvider} used by the Zest
+ * {@link Graph}. This provider is defines the color of e.g. all
+ * {@link GraphNode}s. May be extended to provide custom colors.
+ * <p>
+ * Additional methods may be added in the future.
+ * </p>
+ *
+ * @since 1.19
+ * @see Graph#setColorProvider(GraphColorProvider)
+ */
+public class GraphColorProvider extends BasicColorProvider {
+	/**
+	 * Provides a background color for the given element.
+	 *
+	 * @param element the element
+	 * @return the background color for the element, or {@code null} to use the
+	 *         default background color
+	 */
+	@SuppressWarnings({ "removal", "static-method" })
+	public Color getBackgroundColor(Object element) {
+		if (element instanceof GraphNode node) {
+			return node.getGraphModel().LIGHT_BLUE;
+		}
+		return null;
+	}
+
+	/**
+	 * Provides a highlight background color for the given element.
+	 *
+	 * @param element the element
+	 * @return the highlight background color for the element, or {@code null} to
+	 *         use the default highlight background color
+	 */
+	@SuppressWarnings({ "static-method", "removal" })
+	public Color getBackgroundHighlightColor(Object element) {
+		if (element instanceof GraphNode node) {
+			return node.getGraphModel().HIGHLIGHT_COLOR;
+		}
+		return null;
+	}
+
+	/**
+	 * Provides a border color for the given element.
+	 *
+	 * @param element the element
+	 * @return the border color for the element, or {@code null} to use the default
+	 *         border color
+	 */
+	@SuppressWarnings("static-method")
+	public Color getBorderColor(Object element) {
+		if (element instanceof GraphNode) {
+			return ColorConstants.lightGray;
+		}
+		return null;
+	}
+
+	/**
+	 * Provides a border highlight color for the given element.
+	 *
+	 * @param element the element
+	 * @return the border highlight color for the element, or {@code null} to use
+	 *         the default border highlight color
+	 */
+	@SuppressWarnings("static-method")
+	public Color getBorderHighlightColor(Object element) {
+		if (element instanceof GraphNode) {
+			return ColorConstants.blue;
+		}
+		return null;
+	}
+
+	/**
+	 * Provides a foreground color for the given element.
+	 *
+	 * @param element the element
+	 * @return the foreground color for the element, or {@code null} to use the
+	 *         default foreground color
+	 */
+	@SuppressWarnings({ "static-method", "removal" })
+	public Color getForegroundColor(Object element) {
+		if (element instanceof GraphNode node) {
+			return node.getGraphModel().DARK_BLUE;
+		}
+		return null;
+	}
+
+	/**
+	 * Provides a highlight foreground color for the given element.
+	 *
+	 * @param element the element
+	 * @return the highlight foreground color for the element, or {@code null} to
+	 *         use the default highlight foreground color
+	 */
+	@SuppressWarnings({ "static-method", "removal" })
+	public Color getForegroundHighlightColor(Object element) {
+		if (element instanceof GraphConnection conn) {
+			return conn.getGraphModel().DARK_BLUE;
+		}
+		return null;
+	}
+}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2025, CHISEL Group, University of Victoria, Victoria,
- *                            BC, Canada and others.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria, BC,
+ *                       Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -107,11 +107,11 @@ public class GraphConnection extends GraphItem {
 		this.visible = true;
 		this.color = ColorConstants.lightGray;
 		this.foreground = ColorConstants.lightGray;
-		this.highlightColor = graphModel.DARK_BLUE;
+		this.graphModel = graphModel;
+		this.highlightColor = getGraphModel().getColorProvider().getForegroundHighlightColor(this);
 		this.lineWidth = 1;
 		this.lineStyle = Graphics.LINE_SOLID;
 		setWeight(weight);
-		this.graphModel = graphModel;
 		this.curveDepth = 0;
 		this.layoutConnection = new GraphLayoutConnection();
 		this.font = Display.getDefault().getSystemFont();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2025, CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria, BC, Canada.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,7 +30,6 @@ import org.eclipse.zest.layouts.LayoutEntity;
 import org.eclipse.zest.layouts.constraints.LayoutConstraint;
 
 import org.eclipse.draw2d.Animation;
-import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.FigureListener;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
@@ -191,19 +190,19 @@ public class GraphNode extends GraphItem {
 		this.parent = parent;
 		this.sourceConnections = new ArrayList<>();
 		this.targetConnections = new ArrayList<>();
-		this.foreColor = parent.getGraph().DARK_BLUE;
-		this.backColor = parent.getGraph().LIGHT_BLUE;
-		this.highlightColor = parent.getGraph().HIGHLIGHT_COLOR;
+		this.graph = parent.getGraph();
+		this.foreColor = getGraphModel().getColorProvider().getForegroundColor(this);
+		this.backColor = getGraphModel().getColorProvider().getBackgroundColor(this);
+		this.highlightColor = getGraphModel().getColorProvider().getBackgroundHighlightColor(this);
 		// @tag ADJACENT : Removed highlight adjacent
 		// this.highlightAdjacentColor = ColorConstants.orange;
 		this.nodeStyle = SWT.NONE;
-		this.borderColor = ColorConstants.lightGray;
-		this.borderHighlightColor = ColorConstants.blue;
+		this.borderColor = getGraphModel().getColorProvider().getBorderColor(this);
+		this.borderHighlightColor = getGraphModel().getColorProvider().getBorderHighlightColor(this);
 		this.borderWidth = 1;
 		this.currentLocation = new PrecisionPoint(0, 0);
 		this.size = new Dimension(-1, -1);
 		this.font = Display.getDefault().getSystemFont();
-		this.graph = parent.getGraph();
 		this.cacheLabel = false;
 		this.setText(text);
 		this.layoutEntity = new LayoutGraphNode();


### PR DESCRIPTION
Consumers can already customize the styling of a Zest `Graph` by implementing a custom `IEntityStyleProvider`. However, this is only possible in combination with a JFace viewer and not pure SWT-based graph.

Additionally, this provider implements the `IDisposable` interface, which means that it also can't be used in a pure E4 application. With this change, the corresponding methods in the `IEntityStyleProvider` have been marked for removal and now provide a default implementation.

Instead of this provider, consumers can now use the `GraphColorProvider` to specify the colors used when creating the graph items and which can be set by calling `setColorProvider()` on the `Graph` widget.

The public `Color` fields have been marked for removal in favor of this new color provider.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/1090