### PR TITLE
Fix clipping in Outline if at > 100% zoom #1135

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/parts/Thumbnail.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/parts/Thumbnail.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -126,6 +126,7 @@ public class Thumbnail extends Figure implements UpdateListener {
 		public void resetTileValues() {
 			// Keep track of source size that matches the computed tile size.
 			sourceSize = getSourceRectangle().getSize();
+			getSource().translateToAbsolute(sourceSize);
 
 			// Compute number of horizontal and vertical tiles and the size of
 			// each tile (while the last tile in horizontal and vertical


### PR DESCRIPTION
The source size of the thumbnail image needs to be in absolute coordinates, to make sure that the number of tiles encloses the entire client area of the viewer.

Closes https://github.com/eclipse-gef/gef-classic/issues/1135