### PR TITLE
Reduce dependency in Zest Core from Platform UI to JFace

### DIFF
--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Bundle-Version: 1.19.0.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
- org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
+ org.eclipse.jface;bundle-version="[3.34.0,4.0.0)",
+ org.eclipse.ui;bundle-version="[3.2.0,4.0.0)";resolution:=optional,
  org.eclipse.draw2d;bundle-version="[3.21.0,4.0.0)";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.zest.core.viewers,


### PR DESCRIPTION
The only dependency to the Eclipse 3.x API is via the now-deprecated style provider interface (via the IDisposable) interface. This means that the full functionality of this plug-in can be used by only using JFace classes. More specifically, this allows users to use Zest in a pure Eclipse 4.x application.

Note that the dependency to `org.eclipse.ui` has to remain until the deprecated classes have been removed. But it is now marked as optional, because it is not needed _as long as_ users use non-deprecated classes.