### PR TITLE
Deprecate CloudIO activator for removal

### DIFF
--- a/org.eclipse.zest.cloudio/.project
+++ b/org.eclipse.zest.cloudio/.project
@@ -20,9 +20,15 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.api.tools.apiAnalysisBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.zest.cloudio/src/org/eclipse/zest/cloudio/Activator.java
+++ b/org.eclipse.zest.cloudio/src/org/eclipse/zest/cloudio/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Stephan Schwiebert and others.
+ * Copyright (c) 2011, 2026 Stephan Schwiebert and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,25 +26,31 @@ import org.osgi.framework.BundleContext;
 /**
  *
  * @author sschwieb
- *
+ * @deprecated Do not use. This class will be removed after the 2028-09 release.
  */
+@Deprecated(since = "2026-09", forRemoval = true)
 public class Activator extends AbstractUIPlugin {
 
 	// The plug-in ID
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public static final String PLUGIN_ID = "org.schwiebert.eclipsetagcloud"; //$NON-NLS-1$
 
 	// The shared instance
 	private static Activator plugin;
 
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public static final String ADD = "add.gif"; //$NON-NLS-1$
 
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public static final String REMOVE = "remove.gif"; //$NON-NLS-1$
 
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public static final String TOGGLE_COLORS = "toggle_colors.gif"; //$NON-NLS-1$
 
 	/**
 	 * The constructor
 	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Activator() {
 	}
 
@@ -54,6 +60,7 @@ public class Activator extends AbstractUIPlugin {
 	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.
 	 * BundleContext)
 	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
@@ -77,6 +84,7 @@ public class Activator extends AbstractUIPlugin {
 	 * @see
 	 * org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
 	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	@Override
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
@@ -88,6 +96,7 @@ public class Activator extends AbstractUIPlugin {
 	 *
 	 * @return the shared instance
 	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public static Activator getDefault() {
 		return plugin;
 	}

--- a/org.eclipse.zest.cloudio/src/org/eclipse/zest/cloudio/CloudOptionsComposite.java
+++ b/org.eclipse.zest.cloudio/src/org/eclipse/zest/cloudio/CloudOptionsComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Stephan Schwiebert and others.
+ * Copyright (c) 2011, 2026 Stephan Schwiebert and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -40,6 +40,9 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.ITreeContentProvider;
@@ -54,6 +57,14 @@ import org.eclipse.jface.viewers.Viewer;
  *
  */
 public class CloudOptionsComposite extends Composite {
+	private static final ImageDescriptor ADD = ImageDescriptor.createFromFile(CloudOptionsComposite.class,
+			"/img/add.gif"); //$NON-NLS-1$
+	private static final ImageDescriptor REMOVE = ImageDescriptor.createFromFile(CloudOptionsComposite.class,
+			"/img/remove.gif"); //$NON-NLS-1$
+	private static final ImageDescriptor TOGGLE_COLORS = ImageDescriptor.createFromFile(CloudOptionsComposite.class,
+			"/img/toggle_colors.gif"); //$NON-NLS-1$
+
+	private final ResourceManager resourceManager;
 
 	protected TagCloudViewer viewer;
 
@@ -101,6 +112,7 @@ public class CloudOptionsComposite extends Composite {
 		Assert.isLegal(viewer.getLabelProvider() instanceof IEditableCloudLabelProvider,
 				"Cloud label provider must be of type " + IEditableCloudLabelProvider.class); //$NON-NLS-1$
 		this.viewer = viewer;
+		this.resourceManager = JFaceResources.managerFor(this);
 		setLayout(new GridLayout());
 		addGroups();
 	}
@@ -184,7 +196,7 @@ public class CloudOptionsComposite extends Composite {
 		fonts.add(getFont().getFontData()[0]);
 		tv.setInput(fonts);
 		Button add = new Button(comp, SWT.FLAT);
-		add.setImage(Activator.getDefault().getImageRegistry().get(Activator.ADD));
+		add.setImage(resourceManager.create(ADD));
 		add.setToolTipText(Messages.CloudOptionsComposite_AddFonts);
 		add.addSelectionListener(new SelectionListener() {
 
@@ -219,7 +231,7 @@ public class CloudOptionsComposite extends Composite {
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
 		});
-		remove.setImage(Activator.getDefault().getImageRegistry().get(Activator.REMOVE));
+		remove.setImage(resourceManager.create(REMOVE));
 		return buttons;
 	}
 
@@ -280,7 +292,7 @@ public class CloudOptionsComposite extends Composite {
 		initColors();
 		tv.setInput(colors);
 		Button add = new Button(comp, SWT.FLAT);
-		add.setImage(Activator.getDefault().getImageRegistry().get(Activator.ADD));
+		add.setImage(resourceManager.create(ADD));
 		add.setToolTipText(Messages.CloudOptionsComposite_AddColor);
 		add.addSelectionListener(new SelectionListener() {
 
@@ -316,7 +328,7 @@ public class CloudOptionsComposite extends Composite {
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
 		});
-		remove.setImage(Activator.getDefault().getImageRegistry().get(Activator.REMOVE));
+		remove.setImage(resourceManager.create(REMOVE));
 		Button toggle = new Button(comp, SWT.FLAT);
 		toggle.setToolTipText(Messages.CloudOptionsComposite_ToggleColors);
 		toggle.addSelectionListener(new SelectionListener() {
@@ -332,7 +344,7 @@ public class CloudOptionsComposite extends Composite {
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
 		});
-		toggle.setImage(Activator.getDefault().getImageRegistry().get(Activator.TOGGLE_COLORS));
+		toggle.setImage(resourceManager.create(TOGGLE_COLORS));
 
 		comp = new Composite(buttons, SWT.NONE);
 		gd = new GridData(SWT.FILL, SWT.FILL, true, false);


### PR DESCRIPTION
The CloudIO activator is the only dependency to the Eclipse 3.x API by because it extends the AbstractUIPlugin class, which is only used to gain access to a shared `ImageRegistry`. Instead, a `ResourceManager` is used to gain access to the bundle images.