### PR TITLE
Clarify JavaDoc contract in AbstractTreeEditPart.getText()

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractTreeEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractTreeEditPart.java
@@ -121,7 +121,8 @@ public abstract class AbstractTreeEditPart extends AbstractEditPart implements T
 
 	/**
 	 * Override this method to return the String to be used in this EditPart's
-	 * {@link #widget}. This method is called from {@link #refreshVisuals()}.
+	 * {@link #widget}. This method is called from {@link #refreshVisuals()} and
+	 * must <b>not</b> return {@code null}.
 	 *
 	 * @return the String to be displayed by the TreeItem
 	 */


### PR DESCRIPTION
The string returned by this method is expected to be non-null, as its is later used in the `refreshWidget()` method, which internally calls `setText()` on the underlying `TreeItem`.

SWT will throw an `ERROR_NULL_ARGUMENT` when trying to set a `null` text, so the JavaDoc should mention this restriction.