### PR TITLE
Simply print logic in `ImagePrintFigureOperation` #1146

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ImagePrintFigureOperationTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ImagePrintFigureOperationTest.java
@@ -16,6 +16,7 @@ package org.eclipse.draw2d.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.widgets.Shell;
@@ -53,6 +54,56 @@ public class ImagePrintFigureOperationTest {
 				return true;
 			}
 		});
+	}
+
+	/**
+	 * @see <a href="https://github.com/eclipse-gef/gef-classic/issues/1146">Issue
+	 *      1146</a>
+	 */
+	@Test
+	public void testPaintWithAutoScaling() {
+		figure.setSize(310, 310);
+		Image image = new ImagePrintFigureOperation(shell, figure) {
+			@Override
+			protected boolean isDraw2DAutoScalingEnabled() {
+				return true;
+			}
+		}.run();
+
+		GC gc = new GC(shell);
+		gc.drawImage(image, 0, 0, 310, 310, 0, 0, 100, 100);
+		gc.dispose();
+
+		image.dispose();
+	}
+
+	/**
+	 * SWT uses {@link Math#round(double)} for rounding, while Draw2D uses
+	 * {@link Math#floor(double)}. For a zoom < 100% this leads to a mismatch which
+	 * results in an {@link IllegalArgumentException} when trying to paint the
+	 * image, as the "scaled" image doesn't match the expected size due to an
+	 * off-by-one rounding error.
+	 *
+	 * @see <a href="https://github.com/eclipse-gef/gef-classic/issues/1146">Issue
+	 *      1146</a>
+	 */
+	@Test
+	public void testImageBoundsWithAutoScaling() {
+		figure.setSize(310, 310);
+		Image image = new ImagePrintFigureOperation(shell, figure) {
+			@Override
+			protected boolean isDraw2DAutoScalingEnabled() {
+				return true;
+			}
+		}.run();
+
+		for (int i = 1; i < 100; ++i) {
+			ImageData imageData = image.getImageData(i);
+			assertEquals(Math.round(310 * i / 100.0), imageData.width);
+			assertEquals(Math.round(310 * i / 100.0), imageData.height);
+		}
+
+		image.dispose();
 	}
 
 	@Test

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ImagePrintFigureOperation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ImagePrintFigureOperation.java
@@ -15,7 +15,6 @@ package org.eclipse.draw2d;
 
 import java.util.Objects;
 
-import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
@@ -24,7 +23,6 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.geometry.Dimension;
-import org.eclipse.draw2d.internal.ImageUtils;
 import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 /**
@@ -39,7 +37,6 @@ import org.eclipse.draw2d.internal.InternalDraw2dUtils;
  */
 public class ImagePrintFigureOperation {
 	private final Display display;
-	private final Control control;
 	private IFigure printSource;
 
 	/**
@@ -64,7 +61,6 @@ public class ImagePrintFigureOperation {
 	 */
 	protected ImagePrintFigureOperation(Control control) {
 		Objects.requireNonNull(control, "Control must not be null"); //$NON-NLS-1$
-		this.control = control;
 		this.display = control.getDisplay();
 	}
 
@@ -154,14 +150,7 @@ public class ImagePrintFigureOperation {
 	 * @return The image if Draw2D-based auto-scaling is enabled.
 	 */
 	private Image createAutoScaledImage() {
-		double scale = InternalDraw2dUtils.calculateScale(control);
-		Image image = createImageAtScale(scale);
-		try {
-			ImageData imageData = image.getImageData(100);
-			return new Image(display, new ScaledImageDataProvider(imageData, (int) (scale * 100)));
-		} finally {
-			image.dispose();
-		}
+		return new Image(display, new ScaledImageDataProvider());
 	}
 
 	/**
@@ -189,7 +178,9 @@ public class ImagePrintFigureOperation {
 
 		Dimension size = getImageSize().getCopy();
 		if (isDraw2DAutoScalingEnabled()) {
-			size.scale(scale);
+			// size.scale(scale) internally use Math.floor(), but SWT requires Math.round()
+			size.width = (int) Math.round(size.width * scale);
+			size.height = (int) Math.round(size.height * scale);
 		}
 
 		Image image = new Image(display, size.width, size.height);
@@ -218,29 +209,17 @@ public class ImagePrintFigureOperation {
 	}
 
 	/**
-	 * {@link ImageData} provider containing the image data at the current monitor
-	 * zoom and at 100% zoom (as required by SWT). This class is used if
-	 * Draw2D-based scaling to make sure that the image remains sharp.
+	 * {@link ImageData} provider calculating the image data for a given zoom level.
+	 * This class is used if Draw2D-based scaling to make sure that the image
+	 * remains sharp.
 	 */
 	private class ScaledImageDataProvider implements ImageDataProvider {
-		private final ImageData imageData;
-		private final int zoom;
-
-		public ScaledImageDataProvider(ImageData imageData, int zoom) {
-			this.imageData = imageData;
-			this.zoom = zoom;
-		}
-
 		@Override
 		public ImageData getImageData(int zoom) {
-			if (this.zoom == zoom) {
-				return imageData;
-			}
-			try {
+			if (zoom > 0) {
 				return getImageDataAtZoom(zoom);
-			} catch (SWTException e) {
-				return ImageUtils.smoothScaleTo(display, imageData, zoom * 1.0 / this.zoom);
 			}
+			return null;
 		}
 	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/ImageUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/ImageUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Patrick Ziegler and others.
+ * Copyright (c) 2025, 2026 Patrick Ziegler and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,12 +19,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ServiceConfigurationError;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
-import org.eclipse.swt.graphics.Device;
-import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageLoader;
 
 /**
@@ -78,32 +73,5 @@ public final class ImageUtils {
 			isSvgSupported = false;
 		}
 		return isSvgSupported;
-	}
-
-	/**
-	 * Scales the {@link ImageData} by the given factor using anti-alias and
-	 * interpolation.
-	 *
-	 * @param device The device to draw on.
-	 * @param data   The image data to scale.
-	 * @param scale  The factor by which the image is scaled.
-	 */
-	public static ImageData smoothScaleTo(Device device, ImageData data, double scale) {
-		int scaledWidth = Math.max(1, (int) (data.width * scale));
-		int scaledHeight = Math.max(1, (int) (data.height * scale));
-
-		Image source = new Image(device, data);
-		Image target = new Image(device, scaledWidth, scaledHeight);
-		GC gc = new GC(target);
-		try {
-			gc.setAntialias(SWT.ON);
-			gc.setInterpolation(SWT.HIGH);
-			gc.drawImage(source, 0, 0, data.width, data.height, 0, 0, scaledWidth, scaledHeight);
-			gc.dispose();
-			return target.getImageData(100);
-		} finally {
-			target.dispose();
-			source.dispose();
-		}
 	}
 }


### PR DESCRIPTION
This removes the explicit caching of the image data for the current zoom level, as the same data is already stored in the SWT image and thus redundant. Additionally, calculating the scaled image size is now done using `Math.round()` instead of `Math.floor()`, to match the size that is expected by SWT which may otherwise cause a validation error.

Closes https://github.com/eclipse-gef/gef-classic/issues/1146