### PR TITLE
Fix NPE if `ResizeTracker` is used with a `null` edit part

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ResizeTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ResizeTracker.java
@@ -210,7 +210,10 @@ public class ResizeTracker extends SimpleDragTracker {
 	 */
 	@Override
 	protected Cursor getDefaultCursor() {
-		return Cursors.getDirectionalCursor(direction, getTargetEditPart().getFigure().isMirrored());
+		if (getTargetEditPart() != null) {
+			return Cursors.getDirectionalCursor(direction, getTargetEditPart().getFigure().isMirrored());
+		}
+		return Cursors.getDirectionalCursor(direction);
 	}
 
 	/**
@@ -243,9 +246,7 @@ public class ResizeTracker extends SimpleDragTracker {
 	/**
 	 * The TargetEditPart is the parent of the EditPart being resized.
 	 *
-	 * @return The target EditPart; may be <code>null</code> in 2.1 applications
-	 *         that use the now deprecated {@link ResizeTracker#ResizeTracker(int)
-	 *         constructor}.
+	 * @return The target EditPart; may be <code>null</code>.
 	 */
 	protected GraphicalEditPart getTargetEditPart() {
 		if (owner != null) {


### PR DESCRIPTION
Even if not recommended, it is perfectly valid to create a `ResizeTracker` without a graphical edit part. This tracker will throw a `NullPointerException` when calculating the default cursor, as the figure of the edit part is used to determine, whether the cursor should be mirrored.

This change adds the same null check that is used in other methods where the edit part is referenced.