### PR TITLE
Remove coupling of custom graph stylers to GraphLabelDecorator

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IConnectionStyleProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IConnectionStyleProvider.java
@@ -15,7 +15,7 @@ package org.eclipse.zest.core.viewers;
 import org.eclipse.swt.graphics.Color;
 
 import org.eclipse.ui.services.IDisposable;
-import org.eclipse.zest.core.viewers.decorators.ConnectionStyleDecorator;
+import org.eclipse.zest.core.viewers.decorators.IConnectionStyleDecorator;
 
 import org.eclipse.draw2d.IFigure;
 
@@ -26,7 +26,7 @@ import org.eclipse.draw2d.IFigure;
  * @author Del Myers
  * @see IGraphContentProvider
  * @see IEntityStyleProvider
- * @deprecated Use {@link ConnectionStyleDecorator} instead. This interface will
+ * @deprecated Use {@link IConnectionStyleDecorator} instead. This interface will
  *             be removed after the 2028-09 release.
  */
 //@tag bug(151327-Styles) : created to solve this bug

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IConnectionStyleProvider2.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IConnectionStyleProvider2.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.zest.core.viewers;
 
-import org.eclipse.zest.core.viewers.decorators.ConnectionStyleDecorator;
+import org.eclipse.zest.core.viewers.decorators.IConnectionStyleDecorator;
 
 import org.eclipse.draw2d.ConnectionRouter;
 
@@ -27,7 +27,7 @@ import org.eclipse.draw2d.ConnectionRouter;
  * @see IEntityStyleProvider
  * @since 1.12
  * @noreference This interface is not intended to be referenced by clients.
- * @deprecated Use {@link ConnectionStyleDecorator} instead. This interface will
+ * @deprecated Use {@link IConnectionStyleDecorator} instead. This interface will
  *             be removed after the 2028-09 release.
  */
 //@tag bug(151327-Styles) : created to solve this bug

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityConnectionStyleProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityConnectionStyleProvider.java
@@ -15,7 +15,7 @@ package org.eclipse.zest.core.viewers;
 import org.eclipse.swt.graphics.Color;
 
 import org.eclipse.ui.services.IDisposable;
-import org.eclipse.zest.core.viewers.decorators.EntityConnectionStyleDecorator;
+import org.eclipse.zest.core.viewers.decorators.IEntityConnectionStyleDecorator;
 
 import org.eclipse.draw2d.IFigure;
 
@@ -24,7 +24,7 @@ import org.eclipse.draw2d.IFigure;
  * connections that are based on entity end points.
  *
  * @author Del Myers
- * @deprecated Use {@link EntityConnectionStyleDecorator} instead. This
+ * @deprecated Use {@link IEntityConnectionStyleDecorator} instead. This
  *             interface will be removed after the 2028-09 release.
  */
 //@tag bug(151327-Styles) : fix

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityConnectionStyleProvider2.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityConnectionStyleProvider2.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.zest.core.viewers;
 
-import org.eclipse.zest.core.viewers.decorators.EntityConnectionStyleDecorator;
+import org.eclipse.zest.core.viewers.decorators.IEntityConnectionStyleDecorator;
 
 import org.eclipse.draw2d.ConnectionRouter;
 import org.eclipse.draw2d.IFigure;
@@ -26,7 +26,7 @@ import org.eclipse.draw2d.IFigure;
  * @author Del Myers
  * @since 1.12
  * @noreference This interface is not intended to be referenced by clients.
- * @deprecated Use {@link EntityConnectionStyleDecorator} instead. This
+ * @deprecated Use {@link IEntityConnectionStyleDecorator} instead. This
  *             interface will be removed after the 2028-09 release.
  */
 // TODO Zest 2.x - Integrate into IEntityConnectionStyleProvider

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityStyleProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityStyleProvider.java
@@ -15,7 +15,7 @@ package org.eclipse.zest.core.viewers;
 import org.eclipse.swt.graphics.Color;
 
 import org.eclipse.ui.services.IDisposable;
-import org.eclipse.zest.core.viewers.decorators.EntityStyleDecorator;
+import org.eclipse.zest.core.viewers.decorators.IEntityStyleDecorator;
 
 import org.eclipse.draw2d.IFigure;
 
@@ -38,7 +38,7 @@ import org.eclipse.draw2d.IFigure;
  * @author Del Myers
  * @see org.eclipse.jface.viewers.IColorProvider
  * @tag bug(151327-Styles) : created to solve this bug
- * @deprecated Use {@link EntityStyleDecorator} instead. This interface will be
+ * @deprecated Use {@link IEntityStyleDecorator} instead. This interface will be
  *             removed after the 2028-09 release.
  */
 @Deprecated(since = "1.19", forRemoval = true)

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/GraphLabelDecorator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/GraphLabelDecorator.java
@@ -12,11 +12,16 @@
  *******************************************************************************/
 package org.eclipse.zest.core.viewers.decorators;
 
+import java.util.Optional;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTError;
 import org.eclipse.swt.graphics.Image;
 
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
+import org.eclipse.zest.core.widgets.ZestStyles;
 
 /**
  * Default implementation of the {@link IGraphLabelDecorator} interface. May be
@@ -40,11 +45,61 @@ public class GraphLabelDecorator extends LabelProvider implements IGraphLabelDec
 
 	@Override
 	public void decorateConnection(GraphConnection connection) {
-		// Default implementation does nothing
+		if (this instanceof IConnectionStyleDecorator decorator) {
+			Object rel = connection.getData();
+
+			int style = decorator.getConnectionStyle(rel);
+			if (!ZestStyles.validateConnectionStyle(style)) {
+				throw new SWTError(SWT.ERROR_INVALID_ARGUMENT);
+			}
+
+			if (style != ZestStyles.NONE) {
+				connection.setConnectionStyle(style);
+			}
+
+			Optional.ofNullable(decorator.getHighlightColor(rel)).ifPresent(connection::setHighlightColor);
+			Optional.ofNullable(decorator.getColor(rel)).ifPresent(connection::setLineColor);
+			Optional.ofNullable(decorator.getTooltip(rel)).ifPresent(connection::setTooltip);
+			Optional.ofNullable(decorator.getLineWidth(rel)).filter(w -> w >= 0).ifPresent(connection::setLineWidth);
+			Optional.ofNullable(decorator.getRouter(rel)).ifPresent(connection::setRouter);
+		}
+		if (this instanceof IEntityConnectionStyleDecorator decorator) {
+			Object src = connection.getSource().getData();
+			Object dest = connection.getDestination().getData();
+
+			int style = decorator.getConnectionStyle(src, dest);
+			if (!ZestStyles.validateConnectionStyle(style)) {
+				throw new SWTError(SWT.ERROR_INVALID_ARGUMENT);
+			}
+
+			if (style != ZestStyles.NONE) {
+				connection.setConnectionStyle(style);
+			}
+
+			Optional.ofNullable(decorator.getColor(src, dest)).ifPresent(connection::setLineColor);
+			Optional.ofNullable(decorator.getHighlightColor(src, dest)).ifPresent(connection::setHighlightColor);
+			Optional.ofNullable(decorator.getTooltip(src, dest)).ifPresent(connection::setTooltip);
+			Optional.ofNullable(decorator.getLineWidth(src, dest)).filter(w -> w >= 0).ifPresent(connection::setLineWidth);
+			Optional.ofNullable(decorator.getRouter(src, dest)).ifPresent(connection::setRouter);
+		}
 	}
 
 	@Override
 	public void decorateNode(GraphNode node) {
-		// Default implementation does nothing
+		if (this instanceof IEntityStyleDecorator decorator) {
+			Object entity = node.getData();
+
+			if (decorator.fisheyeNode(entity)) {
+				node.setNodeStyle(node.getNodeStyle() | ZestStyles.NODES_FISHEYE);
+			}
+
+			Optional.ofNullable(decorator.getBorderColor(entity)).ifPresent(node::setBorderColor);
+			Optional.ofNullable(decorator.getBorderHighlightColor(entity)).ifPresent(node::setBorderHighlightColor);
+			Optional.ofNullable(decorator.getNodeHighlightColor(entity)).ifPresent(node::setHighlightColor);
+			Optional.ofNullable(decorator.getBackgroundColor(entity)).ifPresent(node::setBackgroundColor);
+			Optional.ofNullable(decorator.getForegroundColor(entity)).ifPresent(node::setForegroundColor);
+			Optional.ofNullable(decorator.getBorderWidth(entity)).filter(width -> width >= 0).ifPresent(node::setBorderWidth);
+			Optional.ofNullable(decorator.getTooltip(entity)).ifPresent(node::setTooltip);
+		}
 	}
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/IConnectionStyleDecorator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/IConnectionStyleDecorator.java
@@ -12,13 +12,8 @@
  *******************************************************************************/
 package org.eclipse.zest.core.viewers.decorators;
 
-import java.util.Optional;
-
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.SWTError;
 import org.eclipse.swt.graphics.Color;
 
-import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.ZestStyles;
 
 import org.eclipse.draw2d.ConnectionRouter;
@@ -31,27 +26,7 @@ import org.eclipse.draw2d.IFigure;
  * @author Del Myers
  * @since 1.19
  */
-public abstract class ConnectionStyleDecorator extends GraphLabelDecorator {
-
-	@Override
-	public void decorateConnection(GraphConnection connection) {
-		Object rel = connection.getData();
-
-		int style = getConnectionStyle(rel);
-		if (!ZestStyles.validateConnectionStyle(style)) {
-			throw new SWTError(SWT.ERROR_INVALID_ARGUMENT);
-		}
-
-		if (style != ZestStyles.NONE) {
-			connection.setConnectionStyle(style);
-		}
-
-		Optional.ofNullable(getHighlightColor(rel)).ifPresent(connection::setHighlightColor);
-		Optional.ofNullable(getColor(rel)).ifPresent(connection::setLineColor);
-		Optional.ofNullable(getTooltip(rel)).ifPresent(connection::setTooltip);
-		Optional.ofNullable(getLineWidth(rel)).filter(w -> w >= 0).ifPresent(connection::setLineWidth);
-		Optional.ofNullable(getRouter(rel)).ifPresent(connection::setRouter);
-	}
+public interface IConnectionStyleDecorator {
 
 	/**
 	 * Returns the color for the connection. {@code null} for default.
@@ -59,7 +34,7 @@ public abstract class ConnectionStyleDecorator extends GraphLabelDecorator {
 	 * @param rel the relationship represented by this connection.
 	 * @return the color.
 	 */
-	protected abstract Color getColor(Object rel);
+	Color getColor(Object rel);
 
 	/**
 	 * Returns the style flags for this connection. Valid flags are those that begin
@@ -70,7 +45,7 @@ public abstract class ConnectionStyleDecorator extends GraphLabelDecorator {
 	 * @return the style flags for this connection.
 	 * @see ZestStyles
 	 */
-	protected abstract int getConnectionStyle(Object rel);
+	int getConnectionStyle(Object rel);
 
 	/**
 	 * Returns the highlighted color for this connection. {@code null} for default.
@@ -78,7 +53,7 @@ public abstract class ConnectionStyleDecorator extends GraphLabelDecorator {
 	 * @param rel the relationship represented by this connection.
 	 * @return the highlighted color. {@code null} for default.
 	 */
-	protected abstract Color getHighlightColor(Object rel);
+	Color getHighlightColor(Object rel);
 
 	/**
 	 * Returns the line width of the connection. {@code -1} for default.
@@ -86,7 +61,7 @@ public abstract class ConnectionStyleDecorator extends GraphLabelDecorator {
 	 * @param rel the relationship represented by this connection.
 	 * @return the line width for the connection. {@code -1} for default.
 	 */
-	protected abstract int getLineWidth(Object rel);
+	int getLineWidth(Object rel);
 
 	/**
 	 * Returns the connection router of the single relation.
@@ -94,7 +69,7 @@ public abstract class ConnectionStyleDecorator extends GraphLabelDecorator {
 	 * @param rel the relationship represented by this connection.
 	 * @return the connection router for {@code rel}. {@code null} for default.
 	 */
-	protected abstract ConnectionRouter getRouter(Object rel);
+	ConnectionRouter getRouter(Object rel);
 
 	/**
 	 * Returns the tool-tip for this node. If {@code null} is returned Zest will
@@ -102,5 +77,5 @@ public abstract class ConnectionStyleDecorator extends GraphLabelDecorator {
 	 *
 	 * @param entity
 	 */
-	protected abstract IFigure getTooltip(Object entity);
+	IFigure getTooltip(Object entity);
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/IEntityConnectionStyleDecorator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/IEntityConnectionStyleDecorator.java
@@ -12,13 +12,8 @@
  *******************************************************************************/
 package org.eclipse.zest.core.viewers.decorators;
 
-import java.util.Optional;
-
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.SWTError;
 import org.eclipse.swt.graphics.Color;
 
-import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.ZestStyles;
 
 import org.eclipse.draw2d.ConnectionRouter;
@@ -31,28 +26,7 @@ import org.eclipse.draw2d.IFigure;
  * @author Del Myers
  * @since 1.19
  */
-public abstract class EntityConnectionStyleDecorator extends GraphLabelDecorator {
-
-	@Override
-	public void decorateConnection(GraphConnection connection) {
-		Object src = connection.getSource().getData();
-		Object dest = connection.getDestination().getData();
-
-		int style = getConnectionStyle(src, dest);
-		if (!ZestStyles.validateConnectionStyle(style)) {
-			throw new SWTError(SWT.ERROR_INVALID_ARGUMENT);
-		}
-
-		if (style != ZestStyles.NONE) {
-			connection.setConnectionStyle(style);
-		}
-
-		Optional.ofNullable(getColor(src, dest)).ifPresent(connection::setLineColor);
-		Optional.ofNullable(getHighlightColor(src, dest)).ifPresent(connection::setHighlightColor);
-		Optional.ofNullable(getTooltip(src, dest)).ifPresent(connection::setTooltip);
-		Optional.ofNullable(getLineWidth(src, dest)).filter(w -> w >= 0).ifPresent(connection::setLineWidth);
-		Optional.ofNullable(getRouter(src, dest)).ifPresent(connection::setRouter);
-	}
+public interface IEntityConnectionStyleDecorator {
 
 	/**
 	 * Returns the color for the connection. {@code null} for default.
@@ -61,7 +35,7 @@ public abstract class EntityConnectionStyleDecorator extends GraphLabelDecorator
 	 * @param dest the destination entity.
 	 * @return the color.
 	 */
-	protected abstract Color getColor(Object src, Object dest);
+	Color getColor(Object src, Object dest);
 
 	/**
 	 * Returns the style flags for this connection. Valid flags are those that begin
@@ -73,7 +47,7 @@ public abstract class EntityConnectionStyleDecorator extends GraphLabelDecorator
 	 * @return the style flags for this connection.
 	 * @see ZestStyles
 	 */
-	protected abstract int getConnectionStyle(Object src, Object dest);
+	int getConnectionStyle(Object src, Object dest);
 
 	/**
 	 * Returns the highlighted color for this connection. {@code null} for default.
@@ -82,7 +56,7 @@ public abstract class EntityConnectionStyleDecorator extends GraphLabelDecorator
 	 * @param dest the destination entity.
 	 * @return the highlighted color. {@code null} for default.
 	 */
-	protected abstract Color getHighlightColor(Object src, Object dest);
+	Color getHighlightColor(Object src, Object dest);
 
 	/**
 	 * Returns the line width of the connection. {@code -1} for default.
@@ -91,7 +65,7 @@ public abstract class EntityConnectionStyleDecorator extends GraphLabelDecorator
 	 * @param dest the destination entity.
 	 * @return the line width for the connection. {@code -1} for default.
 	 */
-	protected abstract int getLineWidth(Object src, Object dest);
+	int getLineWidth(Object src, Object dest);
 
 	/**
 	 * Returns the connection router of the single relation.
@@ -100,7 +74,7 @@ public abstract class EntityConnectionStyleDecorator extends GraphLabelDecorator
 	 * @param dest the destination entity.
 	 * @return the router for the connection. {@code null} for default.
 	 */
-	protected abstract ConnectionRouter getRouter(Object src, Object dest);
+	ConnectionRouter getRouter(Object src, Object dest);
 
 	/**
 	 * Returns the tool-tip for the connection.
@@ -109,5 +83,5 @@ public abstract class EntityConnectionStyleDecorator extends GraphLabelDecorator
 	 * @param dest the destination entity.
 	 * @return the tool-tip for the connection. {@code null} for default.
 	 */
-	protected abstract IFigure getTooltip(Object src, Object dest);
+	IFigure getTooltip(Object src, Object dest);
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/IEntityStyleDecorator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/IEntityStyleDecorator.java
@@ -12,12 +12,7 @@
  ******************************************************************************/
 package org.eclipse.zest.core.viewers.decorators;
 
-import java.util.Optional;
-
 import org.eclipse.swt.graphics.Color;
-
-import org.eclipse.zest.core.widgets.GraphNode;
-import org.eclipse.zest.core.widgets.ZestStyles;
 
 import org.eclipse.draw2d.IFigure;
 
@@ -38,31 +33,12 @@ import org.eclipse.draw2d.IFigure;
  * Any method may return {@code null} if the Zest defaults are preferred.
  *
  * NOTE: It is up to the implementors of this interface to dispose of any Fonts
- * that are created by this class. The {@link #dispose()} method will be called
- * at the end of the entity's life-cycle so that this class may dispose of its
- * resources.
+ * that are created by this class.
  *
  * @author Del Myers
  * @since 1.19
  */
-public abstract class EntityStyleDecorator extends GraphLabelDecorator {
-
-	@Override
-	public void decorateNode(GraphNode node) {
-		Object entity = node.getData();
-
-		if (fisheyeNode(entity)) {
-			node.setNodeStyle(node.getNodeStyle() | ZestStyles.NODES_FISHEYE);
-		}
-
-		Optional.ofNullable(getBorderColor(entity)).ifPresent(node::setBorderColor);
-		Optional.ofNullable(getBorderHighlightColor(entity)).ifPresent(node::setBorderHighlightColor);
-		Optional.ofNullable(getNodeHighlightColor(entity)).ifPresent(node::setHighlightColor);
-		Optional.ofNullable(getBackgroundColor(entity)).ifPresent(node::setBackgroundColor);
-		Optional.ofNullable(getForegroundColor(entity)).ifPresent(node::setForegroundColor);
-		Optional.ofNullable(getBorderWidth(entity)).filter(width -> width >= 0).ifPresent(node::setBorderWidth);
-		Optional.ofNullable(getTooltip(entity)).ifPresent(node::setTooltip);
-	}
+public interface IEntityStyleDecorator {
 
 	/**
 	 * Returns {@code true} if the node should be displayed with a fish-eye effect.
@@ -71,7 +47,7 @@ public abstract class EntityStyleDecorator extends GraphLabelDecorator {
 	 * @return {@code true} if the node should be displayed with a fish-eye effect,
 	 *         {@code false} otherwise.
 	 */
-	protected abstract boolean fisheyeNode(Object entity);
+	boolean fisheyeNode(Object entity);
 
 	/**
 	 * Returns the background color that this node should be colored. This will be
@@ -80,7 +56,7 @@ public abstract class EntityStyleDecorator extends GraphLabelDecorator {
 	 * @param entity The entity to be styled
 	 * @return The color for the node
 	 */
-	protected abstract Color getBackgroundColor(Object entity);
+	Color getBackgroundColor(Object entity);
 
 	/**
 	 * Returns the background color for this entity. May return {@code null} for
@@ -89,7 +65,7 @@ public abstract class EntityStyleDecorator extends GraphLabelDecorator {
 	 * @param entity the entity to be styled.
 	 * @return the background color for this entity.
 	 */
-	protected abstract Color getBorderColor(Object entity);
+	Color getBorderColor(Object entity);
 
 	/**
 	 * Returns the border highlight color for this entity. May return {@code null}
@@ -98,7 +74,7 @@ public abstract class EntityStyleDecorator extends GraphLabelDecorator {
 	 * @param entity the entity to be styled.
 	 * @return the border highlight color for this entity.
 	 */
-	protected abstract Color getBorderHighlightColor(Object entity);
+	Color getBorderHighlightColor(Object entity);
 
 	/**
 	 * Returns the border width for this entity. May return {@code -1} for defaults.
@@ -106,7 +82,7 @@ public abstract class EntityStyleDecorator extends GraphLabelDecorator {
 	 * @param entity the entity to be styled.
 	 * @return the border width, or {@code -1} for defaults.
 	 */
-	protected abstract int getBorderWidth(Object entity);
+	int getBorderWidth(Object entity);
 
 	/**
 	 * Returns the foreground color that this node should be colored. This will be
@@ -115,7 +91,7 @@ public abstract class EntityStyleDecorator extends GraphLabelDecorator {
 	 * @param entity The entity to be styled
 	 * @return The color for the node
 	 */
-	protected abstract Color getForegroundColor(Object entity);
+	Color getForegroundColor(Object entity);
 
 	/**
 	 * Returns the foreground color of this entity. May return {@code null} for
@@ -123,9 +99,8 @@ public abstract class EntityStyleDecorator extends GraphLabelDecorator {
 	 *
 	 * @param entity the entity to be styled.
 	 * @return the foreground color of this entity.
-	 * @see #dispose()
 	 */
-	protected abstract Color getNodeHighlightColor(Object entity);
+	Color getNodeHighlightColor(Object entity);
 
 	/**
 	 * Returns the tool-tip for this node. If {@code null} is returned Zest will
@@ -134,5 +109,5 @@ public abstract class EntityStyleDecorator extends GraphLabelDecorator {
 	 * @param entity The entity to be styled
 	 * @return The tool-tip for the node
 	 */
-	protected abstract IFigure getTooltip(Object entity);
+	IFigure getTooltip(Object entity);
 }

--- a/org.eclipse.zest.doc.isv/guide-src/migration-guide.adoc
+++ b/org.eclipse.zest.doc.isv/guide-src/migration-guide.adoc
@@ -14,16 +14,42 @@ The styler API underwent a major refactoring, with several interfaces being
 deprecated for removal. Following interfaces are affected:
 
 - `IConnectionStyleProvider`, `IConnectionStyleProvider2`
-  ⇒ Replaced by `ConnectionStyleDecorator`.
+  ⇒ Replaced by `IConnectionStyleDecorator`.
 
 - `IEntityConnectionStyleProvider`, `IEntityConnectionStyleProvider2`
-  ⇒ Replaced by `EntityConnectionStyleDecorator`.
+  ⇒ Replaced by `IEntityConnectionStyleDecorator`.
 
 - `IEntityStyleProvider`
-  ⇒ Replaced by `EntityStyleDecorator`.
+  ⇒ Replaced by `IEntityStyleDecorator`.
 
 - `ISelfStyleProvider`
-  ⇒ Replaced by `GraphDecorator`.
+  ⇒ Replaced by `GraphLabelDecorator`.
+
+In order to use the `IConnectionStyleDecorator`, `IEntityStyleDecorator` or
+`IEntityConnectionStyleDecorator`, extend the `GraphLabelDecorator` and
+implement the desired interfaces. The default implementation of this decorator
+will detect those interfaces and style the nodes and connections accordingly.
+
+Example:
+
+```java
+class MyGraphLabelDecorator extends GraphLabelDecorator implements IConnectionStyleDecorator, IEntityStyleDecorator {
+	// ConnectionStyleDecorator
+	public Color getColor(Object rel) {
+		...
+	}
+	...
+
+	// EntityStyleDecorator
+	public boolean fisheyeNode(Object entity) {
+		...
+	}
+	...
+}
+```
+
+Note that implementing both the `IEntityConnectionStyleDecorator` and
+`IConnectionStyleDecorator` results in undefined behavior.
 
 The decorator class can be used directly as label provider for the
 `GraphViewer` or used together with a dedicated `ILabelProvider` in the

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/ManhattanLayoutJFaceSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/ManhattanLayoutJFaceSnippet.java
@@ -31,7 +31,8 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.zest.core.viewers.GraphViewer;
 import org.eclipse.zest.core.viewers.IGraphContentProvider;
-import org.eclipse.zest.core.viewers.decorators.ConnectionStyleDecorator;
+import org.eclipse.zest.core.viewers.decorators.IConnectionStyleDecorator;
+import org.eclipse.zest.core.viewers.decorators.GraphLabelDecorator;
 import org.eclipse.zest.examples.Messages;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
@@ -40,7 +41,7 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.ManhattanConnectionRouter;
 
 /**
- * This snippet shows how to use the {@link ConnectionStyleDecorator} class
+ * This snippet shows how to use the {@link IConnectionStyleDecorator} class
  * to set the connection router for some references.
  *
  * Based on {@link GraphJFaceSnippet4}.
@@ -96,7 +97,7 @@ public class ManhattanLayoutJFaceSnippet {
 
 	}
 
-	static class MyConnectionStyleDecorator extends ConnectionStyleDecorator {
+	static class MyConnectionStyleDecorator extends GraphLabelDecorator implements IConnectionStyleDecorator {
 
 		@Override
 		public ConnectionRouter getRouter(Object rel) {


### PR DESCRIPTION
This changes the `IConnectionStyleDecorator`, `IEntityStyleDecorator` and the `IEntityConnectionStyleDecorator` from abstract classes to interfaces and moves the default implementation to the `GraphLabelProvider`.

Problem with the current implementation is that consumers who implement more than one of the now-deprecated style providers can't easily migrate to the new decorators, as Java doesn't allow sub-classing.

By decoupling those extensions from the `IGraphLabelDecorator` interface, we remove this limitation while at the same time preserving the ability to add new methods to mentioned interface, without breaking backwards compatibility.