### PR TITLE
Reduce coupling to `ScaledGraphics` in `ScaledGraphicsTest

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@
 package org.eclipse.draw2d.test;
 
 import org.eclipse.draw2d.graph.test.DirectedGraphLayoutTest;
+import org.eclipse.draw2d.test.GraphicsTest.ScaledGraphicsTest;
 import org.eclipse.draw2d.test.colors.HSLTest;
 
 import org.junit.platform.suite.api.SelectClasses;

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/GraphicsTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/GraphicsTest.java
@@ -27,6 +27,7 @@ import org.eclipse.swt.graphics.Path;
 import org.eclipse.swt.graphics.PathData;
 import org.eclipse.swt.widgets.Display;
 
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.SWTGraphics;
 import org.eclipse.draw2d.ScaledGraphics;
 import org.eclipse.draw2d.geometry.Point;
@@ -38,8 +39,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@SuppressWarnings("removal")
-public class ScaledGraphicsTest {
+public abstract class GraphicsTest {
 
 	static Stream<Arguments> singleValueTestCombinations() {
 		int[] inputs = { 5, 7, 10, 17, 20 };
@@ -52,342 +52,298 @@ public class ScaledGraphicsTest {
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testTranlsationWithMulipleScaledLayers() {
 		Display display = Display.getDefault();
 		Image image = new Image(display, 100, 100);
 		GC gc = new GC(image);
-		RecordingSwtGraphics graphics = new RecordingSwtGraphics(gc);
-		ScaledGraphics scaledGraphics = new ScaledGraphics(graphics);
-		scaledGraphics.scale(1.5);
-		scaledGraphics.translate(1f, 1f);
-		ScaledGraphics scaledGraphics2 = new ScaledGraphics(scaledGraphics);
-		scaledGraphics2.scale(2.5);
-		scaledGraphics2.translate(1f, 1f);
+		RecordingSwtGraphics recorder = new RecordingSwtGraphics(gc);
+		Graphics graphics = createGraphics(recorder);
+		graphics.scale(1.5);
+		graphics.translate(1f, 1f);
+		Graphics graphics2 = createGraphics(graphics);
+		graphics2.scale(2.5);
+		graphics2.translate(1f, 1f);
 
-		scaledGraphics2.drawRectangle(0, 0, 10, 10);
-		assertEquals(5, graphics.translation.x);
-		assertEquals(5, graphics.translation.y);
+		graphics2.drawRectangle(0, 0, 10, 10);
+		assertEquals(5, recorder.translation.x);
+		assertEquals(5, recorder.translation.y);
 
-		validateDrawRectangle(graphics, new Rectangle(5, 5, 37, 37));
-		scaledGraphics2.dispose();
-		scaledGraphics.dispose();
+		validateDrawRectangle(recorder, new Rectangle(5, 5, 37, 37));
+		graphics2.dispose();
 		graphics.dispose();
+		recorder.dispose();
 		gc.dispose();
 		image.dispose();
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testDrawLineForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawLine(new Point(5, 5), new Point(5, 5 + 20)));
+				graphics -> graphics.drawLine(new Point(5, 5), new Point(5, 5 + 20)));
 		validateDrawLine(swtGraphics, new Point(30, 30));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawLineWithInt(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.drawLine(source, source, source, source + 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawLine(source, source, source, source + 5));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawLineWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics.drawLine(source, source, source, source + 10));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.drawLine(source, source, source, source + 10));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawLineWithPoint(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(
-				scaledGraphics -> scaledGraphics.drawLine(new Point(source, source), new Point(source, source + 15)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawLine(new Point(source, source), new Point(source, source + 15)));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawLineWithPointTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
 		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.drawLine(new Point(source, source), new Point(source, source + 20)));
+				graphics -> graphics.drawLine(new Point(source, source), new Point(source, source + 20)));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testDrawOvalForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawOval(5, 7, 9, 25));
+				graphics -> graphics.drawOval(5, 7, 9, 25));
 		validateDrawOval(swtGraphics, new Rectangle(30, 40, 45, 125));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawOvalWithInt(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.drawOval(source, source, source, source + 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawOval(source, source, source, source + 5));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawOvalWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics.drawOval(source, source, source, source + 10));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.drawOval(source, source, source, source + 10));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawOvalWithRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation
-				.execute(scaledGraphics -> scaledGraphics.drawOval(new Rectangle(source, source, source, source + 15)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawOval(new Rectangle(source, source, source, source + 15)));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawOvalWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.drawOval(new Rectangle(source, source, source, source + 20)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.drawOval(new Rectangle(source, source, source, source + 20)));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testDrawPointForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawPoint(5, 5));
+				graphics -> graphics.drawPoint(5, 5));
 		validateDrawPoint(swtGraphics, new Point(30, 30));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawPoint(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.drawPoint(source, source + 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawPoint(source, source + 5));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawPointTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics.drawPoint(source, source + 10));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.drawPoint(source, source + 10));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testDrawArcForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawArc(5, 7, 9, 25, 12, 18));
+				graphics -> graphics.drawArc(5, 7, 9, 25, 12, 18));
 		validateDrawArc(swtGraphics, new Rectangle(30, 40, 45, 125));
 
-		swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawArc(0, 0, 0, 0, 12, 18));
+		swtGraphics = executeTranslatedWithOneLayer(200, 250, graphics -> graphics.drawArc(0, 0, 0, 0, 12, 18));
 		validateDrawArc(swtGraphics, new Rectangle(0, 0, 0, 0));
 
-		swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawArc(5, 7, 9, 25, 12, 0));
+		swtGraphics = executeTranslatedWithOneLayer(200, 250, graphics -> graphics.drawArc(5, 7, 9, 25, 12, 0));
 		validateDrawArc(swtGraphics, new Rectangle(0, 0, 0, 0));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawArcWithInt(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation
-				.execute(scaledGraphics -> scaledGraphics.drawArc(source, source, source, source + 5, source, source));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawArc(source, source, source, source + 5, source, source));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawArcWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.drawArc(source, source, source, source + 10, source, source));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.drawArc(source, source, source, source + 10, source, source));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawArcWithRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.drawArc(new Rectangle(source, source, source, source + 15),
-				source, source));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(
+				graphics -> graphics.drawArc(new Rectangle(source, source, source, source + 15), source, source));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawArcWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics
-				.drawArc(new Rectangle(source, source, source, source + 20), source, source));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(
+				graphics -> graphics.drawArc(new Rectangle(source, source, source, source + 20), source, source));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testDrawFocusForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawFocus(5, 7, 9, 25));
+				graphics -> graphics.drawFocus(5, 7, 9, 25));
 		validateDrawFocus(swtGraphics, new Rectangle(30, 40, 45, 125));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawFocusWithInt(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.drawFocus(source, source, source, source + 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawFocus(source, source, source, source + 5));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawFocusWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics.drawFocus(source, source, source, source + 10));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.drawFocus(source, source, source, source + 10));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawFocusWithRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(
-				scaledGraphics -> scaledGraphics.drawFocus(new Rectangle(source, source, source, source + 15)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawFocus(new Rectangle(source, source, source, source + 15)));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawFocusWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.drawFocus(new Rectangle(source, source, source, source + 20)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation
+				.executeTranslated(graphics -> graphics.drawFocus(new Rectangle(source, source, source, source + 20)));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testDrawFullImageForRegression() {
 		Image image = new Image(Display.getDefault(), 9, 25);
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawImage(image, 5, 7));
+				graphics -> graphics.drawImage(image, 5, 7));
 		validateDrawImage(swtGraphics, new Rectangle(30, 40, 45, 125));
 		image.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawFullImageWithInt(int source, int monitorZoom, int diagramZoom) {
 		Image image = new Image(Display.getDefault(), source, source + 5);
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.drawImage(image, source, source + 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawImage(image, source, source + 5));
 		image.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawFullImageWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
 		Image image = new Image(Display.getDefault(), source, source + 10);
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics.drawImage(image, new Point(source, source + 10)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.drawImage(image, new Point(source, source + 10)));
 		image.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawFullImageWithPoint(int source, int monitorZoom, int diagramZoom) {
 		Image image = new Image(Display.getDefault(), source, source + 20);
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.drawImage(image, new Point(source, source + 20)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawImage(image, new Point(source, source + 20)));
 		image.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawFullImageWithPointTranslated(int source, int monitorZoom, int diagramZoom) {
 		Image image = new Image(Display.getDefault(), source, source + 15);
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics.drawImage(image, new Point(source, source + 15)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.drawImage(image, new Point(source, source + 15)));
 		image.dispose();
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testDrawImageForRegression() {
 		Image image = new Image(Display.getDefault(), 5, 5);
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawImage(image, 5, 5, 5, 5, 5, 7, 9, 25));
+				graphics -> graphics.drawImage(image, 5, 5, 5, 5, 5, 7, 9, 25));
 		validateDrawImage(swtGraphics, new Rectangle(30, 40, 45, 125));
 		image.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawImageWithInt(int source, int monitorZoom, int diagramZoom) {
 		Image image = new Image(Display.getDefault(), 5, 5);
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(
-				scaledGraphics -> scaledGraphics.drawImage(image, 5, 5, 5, 5, source, source, source, source + 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawImage(image, 5, 5, 5, 5, source, source, source, source + 5));
 		image.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawImageWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
 		Image image = new Image(Display.getDefault(), 5, 5);
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
 		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.drawImage(image, 5, 5, 5, 5, source, source, source, source + 10));
+				graphics -> graphics.drawImage(image, 5, 5, 5, 5, source, source, source, source + 10));
 		image.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawImageWithRectangle(int source, int monitorZoom, int diagramZoom) {
 		Image image = new Image(Display.getDefault(), 5, 5);
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.drawImage(image, new Rectangle(5, 5, 5, 5),
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawImage(image, new Rectangle(5, 5, 5, 5),
 				new Rectangle(source, source, source, source + 15)));
 		image.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawImageWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
 		Image image = new Image(Display.getDefault(), 5, 5);
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics.drawImage(image, new Rectangle(5, 5, 5, 5),
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.drawImage(image, new Rectangle(5, 5, 5, 5),
 				new Rectangle(source, source, source, source + 20)));
 		image.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawPath(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
 
 		PathData data = new PathData();
 		float[] points = new float[18];
@@ -420,15 +376,14 @@ public class ScaledGraphicsTest {
 		data.points = points;
 		data.types = types;
 		Path path = new Path(Display.getDefault(), data);
-		validation.execute(scaledGraphics -> scaledGraphics.drawPath(path));
+		validation.execute(graphics -> graphics.drawPath(path));
 		path.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawPolygon(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
 		int[] points = new int[8];
 		points[0] = source * 1 + 1;
 		points[1] = source * 2 + 2;
@@ -438,221 +393,187 @@ public class ScaledGraphicsTest {
 		points[5] = source * 6 + 6;
 		points[6] = source * 7 + 7;
 		points[7] = source * 8 + 8;
-		validation.execute(scaledGraphics -> scaledGraphics.drawPolygon(points));
-		validation.execute(scaledGraphics -> scaledGraphics.drawPolygon(new PointList(points)));
+		validation.execute(graphics -> graphics.drawPolygon(points));
+		validation.execute(graphics -> graphics.drawPolygon(new PointList(points)));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testDrawRectangleForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawRectangle(5, 7, 9, 25));
+				graphics -> graphics.drawRectangle(5, 7, 9, 25));
 		validateDrawRectangle(swtGraphics, new Rectangle(30, 40, 45, 125));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawRectangleWithInt(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.drawRectangle(source, source, source, source + 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawRectangle(source, source, source, source + 5));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawRectangleWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation
-				.executeTranslated(scaledGraphics -> scaledGraphics.drawRectangle(source, source, source, source + 10));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.drawRectangle(source, source, source, source + 10));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawRectangleWithRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(
-				scaledGraphics -> scaledGraphics.drawRectangle(new Rectangle(source, source, source, source + 15)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.drawRectangle(new Rectangle(source, source, source, source + 15)));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawRectangleWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
 		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.drawRectangle(new Rectangle(source, source, source, source + 20)));
+				graphics -> graphics.drawRectangle(new Rectangle(source, source, source, source + 20)));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testDrawRoundRectangleForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.drawRoundRectangle(new Rectangle(5, 7, 9, 25), 5, 5));
+				graphics -> graphics.drawRoundRectangle(new Rectangle(5, 7, 9, 25), 5, 5));
 		validateDrawRoundRectangle(swtGraphics, new Rectangle(30, 40, 45, 125), new Point(25, 25));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawRoundRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics
-				.drawRoundRectangle(new Rectangle(source, source, source, source + 15), 5, 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(
+				graphics -> graphics.drawRoundRectangle(new Rectangle(source, source, source, source + 15), 5, 5));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testDrawRoundRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics
-				.drawRoundRectangle(new Rectangle(source, source, source, source + 20), 5, 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(
+				graphics -> graphics.drawRoundRectangle(new Rectangle(source, source, source, source + 20), 5, 5));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testFillOvalForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.fillOval(5, 7, 9, 25));
+				graphics -> graphics.fillOval(5, 7, 9, 25));
 		validateFillOval(swtGraphics, new Rectangle(30, 40, 41, 121));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillOvalWithInt(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.fillOval(source, source, source, source + 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.fillOval(source, source, source, source + 5));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillOvalWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics.fillOval(source, source, source, source + 10));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.fillOval(source, source, source, source + 10));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillOvalWithRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation
-				.execute(scaledGraphics -> scaledGraphics.fillOval(new Rectangle(source, source, source, source + 15)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.fillOval(new Rectangle(source, source, source, source + 15)));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillOvalWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.fillOval(new Rectangle(source, source, source, source + 20)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.fillOval(new Rectangle(source, source, source, source + 20)));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testFillArcForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.fillArc(5, 7, 9, 25, 12, 18));
+				graphics -> graphics.fillArc(5, 7, 9, 25, 12, 18));
 		validateFillArc(swtGraphics, new Rectangle(30, 40, 41, 121));
 
-		swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.fillArc(0, 0, 0, 0, 12, 18));
+		swtGraphics = executeTranslatedWithOneLayer(200, 250, graphics -> graphics.fillArc(0, 0, 0, 0, 12, 18));
 		validateFillArc(swtGraphics, new Rectangle(0, 0, 0, 0));
 
-		swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.fillArc(5, 7, 9, 25, 12, 0));
+		swtGraphics = executeTranslatedWithOneLayer(200, 250, graphics -> graphics.fillArc(5, 7, 9, 25, 12, 0));
 		validateFillArc(swtGraphics, new Rectangle(0, 0, 0, 0));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillArcWithInt(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation
-				.execute(scaledGraphics -> scaledGraphics.fillArc(source, source, source, source + 5, source, source));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.fillArc(source, source, source, source + 5, source, source));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillArcWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.fillArc(source, source, source, source + 10, source, source));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.fillArc(source, source, source, source + 10, source, source));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillArcWithRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.fillArc(new Rectangle(source, source, source, source + 15),
-				source, source));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(
+				graphics -> graphics.fillArc(new Rectangle(source, source, source, source + 15), source, source));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillArcWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics
-				.fillArc(new Rectangle(source, source, source, source + 20), source, source));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(
+				graphics -> graphics.fillArc(new Rectangle(source, source, source, source + 20), source, source));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testFillGradientForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.fillGradient(5, 7, 9, 25, true));
+				graphics -> graphics.fillGradient(5, 7, 9, 25, true));
 		validateFillGradient(swtGraphics, new Rectangle(30, 40, 41, 121));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillGradientWithInt(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.fillGradient(source, source, source, source + 5, true));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.fillGradient(source, source, source, source + 5, true));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillGradientWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.fillGradient(source, source, source, source + 10, true));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.fillGradient(source, source, source, source + 10, true));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillGradientWithRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics
-				.fillGradient(new Rectangle(source, source, source, source + 15), true));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.fillGradient(new Rectangle(source, source, source, source + 15), true));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillGradientWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics
-				.fillGradient(new Rectangle(source, source, source, source + 20), true));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(
+				graphics -> graphics.fillGradient(new Rectangle(source, source, source, source + 20), true));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillPath(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
 
 		PathData data = new PathData();
 		float[] points = new float[18];
@@ -685,15 +606,14 @@ public class ScaledGraphicsTest {
 		data.points = points;
 		data.types = types;
 		Path path = new Path(Display.getDefault(), data);
-		validation.execute(scaledGraphics -> scaledGraphics.fillPath(path));
+		validation.execute(graphics -> graphics.fillPath(path));
 		path.dispose();
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillPolygon(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
 		int[] points = new int[8];
 		points[0] = source * 1 + 1;
 		points[1] = source * 2 + 2;
@@ -703,186 +623,163 @@ public class ScaledGraphicsTest {
 		points[5] = source * 6 + 6;
 		points[6] = source * 7 + 7;
 		points[7] = source * 8 + 8;
-		validation.execute(scaledGraphics -> scaledGraphics.fillPolygon(points));
-		validation.execute(scaledGraphics -> scaledGraphics.fillPolygon(new PointList(points)));
+		validation.execute(graphics -> graphics.fillPolygon(points));
+		validation.execute(graphics -> graphics.fillPolygon(new PointList(points)));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testFillRectangleForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.fillRectangle(5, 7, 9, 25));
+				graphics -> graphics.fillRectangle(5, 7, 9, 25));
 		validateFillRectangle(swtGraphics, new Rectangle(30, 40, 41, 121));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillRectangleWithInt(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics.fillRectangle(source, source, source, source + 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.fillRectangle(source, source, source, source + 5));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillRectangleWithIntTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation
-				.executeTranslated(scaledGraphics -> scaledGraphics.fillRectangle(source, source, source, source + 10));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.fillRectangle(source, source, source, source + 10));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillRectangleWithRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(
-				scaledGraphics -> scaledGraphics.fillRectangle(new Rectangle(source, source, source, source + 15)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.fillRectangle(new Rectangle(source, source, source, source + 15)));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillRectangleWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
 		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.fillRectangle(new Rectangle(source, source, source, source + 20)));
+				graphics -> graphics.fillRectangle(new Rectangle(source, source, source, source + 20)));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testFillRoundRectangleForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.fillRoundRectangle(new Rectangle(5, 7, 9, 25), 5, 5));
+				graphics -> graphics.fillRoundRectangle(new Rectangle(5, 7, 9, 25), 5, 5));
 		validateFillRoundRectangle(swtGraphics, new Rectangle(30, 40, 41, 121), new Point(25, 25));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillRoundRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.execute(scaledGraphics -> scaledGraphics
-				.fillRoundRectangle(new Rectangle(source, source, source, source + 15), 5, 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(
+				graphics -> graphics.fillRoundRectangle(new Rectangle(source, source, source, source + 15), 5, 5));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testFillRoundRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(scaledGraphics -> scaledGraphics
-				.fillRoundRectangle(new Rectangle(source, source, source, source + 20), 5, 5));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(
+				graphics -> graphics.fillRoundRectangle(new Rectangle(source, source, source, source + 20), 5, 5));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testClipRectForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.clipRect(new Rectangle(5, 7, 9, 25)));
+				graphics -> graphics.clipRect(new Rectangle(5, 7, 9, 25)));
 		validateClipRect(swtGraphics, new Rectangle(30, 40, 45, 125));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testClipRectWithRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation
-				.execute(scaledGraphics -> scaledGraphics.clipRect(new Rectangle(source, source, source, source + 15)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.clipRect(new Rectangle(source, source, source, source + 15)));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testClipRectWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.clipRect(new Rectangle(source, source, source, source + 20)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.clipRect(new Rectangle(source, source, source, source + 20)));
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testGetClipRectForRegression() {
 		Rectangle clipRect = new Rectangle();
-		executeTranslatedWithOneLayer(200, 250, scaledGraphics -> scaledGraphics.getClip(clipRect),
+		executeTranslatedWithOneLayer(200, 250, graphics -> graphics.getClip(clipRect),
 				graphics -> graphics.clipRect = new Rectangle(25, 35, 45, 125));
 		validateRect(clipRect, new Rectangle(5, 7, 9, 25));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testGetClipRectWithRectangle(int source, int monitorZoom, int diagramZoom) {
 		Rectangle clipRectOne = new Rectangle();
-		executeWithOneLayer(monitorZoom, diagramZoom, scaledGraphics -> scaledGraphics.getClip(clipRectOne),
+		executeWithOneLayer(monitorZoom, diagramZoom, graphics -> graphics.getClip(clipRectOne),
 				graphics -> graphics.clipRect = new Rectangle(source * 10, source * 10, source * 10, source * 10 + 15));
 
 		Rectangle clipRectTwo = new Rectangle();
-		executeWithTwoLayers(monitorZoom, diagramZoom, scaledGraphics -> scaledGraphics.getClip(clipRectTwo),
+		executeWithTwoLayers(monitorZoom, diagramZoom, graphics -> graphics.getClip(clipRectTwo),
 				graphics -> graphics.clipRect = new Rectangle(source * 10, source * 10, source * 10, source * 10 + 15));
 		validateRect(clipRectTwo, clipRectOne);
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testGetClipRectWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
 		Rectangle clipRectOne = new Rectangle();
-		executeTranslatedWithOneLayer(monitorZoom, diagramZoom, scaledGraphics -> scaledGraphics.getClip(clipRectOne),
+		executeTranslatedWithOneLayer(monitorZoom, diagramZoom, graphics -> graphics.getClip(clipRectOne),
 				graphics -> graphics.clipRect = new Rectangle(source * 10, source * 10, source * 10, source * 10 + 15));
 
 		Rectangle clipRectTwo = new Rectangle();
-		executeTranslatedWithTwoLayers(monitorZoom, diagramZoom, scaledGraphics -> scaledGraphics.getClip(clipRectTwo),
+		executeTranslatedWithTwoLayers(monitorZoom, diagramZoom, graphics -> graphics.getClip(clipRectTwo),
 				graphics -> graphics.clipRect = new Rectangle(source * 10, source * 10, source * 10, source * 10 + 15));
 		validateRect(clipRectTwo, clipRectOne);
 	}
 
 	@Test
-	@SuppressWarnings("static-method")
 	public void testSetClipRectForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
-				scaledGraphics -> scaledGraphics.setClip(new Rectangle(5, 7, 9, 25)));
+				graphics -> graphics.setClip(new Rectangle(5, 7, 9, 25)));
 		validateSetClipRect(swtGraphics, new Rectangle(30, 40, 45, 125));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testSetClipRectWithRectangle(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation
-				.execute(scaledGraphics -> scaledGraphics.setClip(new Rectangle(source, source, source, source + 15)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.execute(graphics -> graphics.setClip(new Rectangle(source, source, source, source + 15)));
 	}
 
 	@ParameterizedTest
 	@MethodSource("singleValueTestCombinations")
-	@SuppressWarnings("static-method")
 	public void testSetClipRectWithRectangleTranslated(int source, int monitorZoom, int diagramZoom) {
-		ScaledGraphicsValidation validation = new ScaledGraphicsValidation(monitorZoom, diagramZoom);
-		validation.executeTranslated(
-				scaledGraphics -> scaledGraphics.setClip(new Rectangle(source, source, source, source + 20)));
+		GraphicsValidation validation = new GraphicsValidation(monitorZoom, diagramZoom);
+		validation.executeTranslated(graphics -> graphics.setClip(new Rectangle(source, source, source, source + 20)));
 	}
 
-	private static class ScaledGraphicsValidation {
+	private class GraphicsValidation {
 
 		private final int monitorZoom;
 		private final int diagramZoom;
 
-		public ScaledGraphicsValidation(int monitorZoom, int diagramZoom) {
+		public GraphicsValidation(int monitorZoom, int diagramZoom) {
 			this.monitorZoom = monitorZoom;
 			this.diagramZoom = diagramZoom;
 		}
 
-		public void execute(Consumer<ScaledGraphics> graphicsCall) {
+		public void execute(Consumer<Graphics> graphicsCall) {
 			RecordingSwtGraphics graphics1 = executeWithOneLayer(monitorZoom, diagramZoom, graphicsCall);
 			RecordingSwtGraphics graphics2 = executeWithTwoLayers(monitorZoom, diagramZoom, graphicsCall);
 
 			validate(graphics1, graphics2);
 		}
 
-		public void executeTranslated(Consumer<ScaledGraphics> graphicsCall) {
+		public void executeTranslated(Consumer<Graphics> graphicsCall) {
 			RecordingSwtGraphics graphics1 = executeTranslatedWithOneLayer(monitorZoom, diagramZoom, graphicsCall);
 			RecordingSwtGraphics graphics2 = executeTranslatedWithTwoLayers(monitorZoom, diagramZoom, graphicsCall);
 
@@ -913,17 +810,17 @@ public class ScaledGraphicsTest {
 	}
 
 	private static void validateRect(Rectangle actual, Rectangle expected) {
-		assertEquals(expected.x, actual.x, String.format("Scaled value for x must match value %s", expected.x)); //$NON-NLS-1$
-		assertEquals(expected.y, actual.y, String.format("Scaled value for y must match value %s", expected.y)); //$NON-NLS-1$
+		assertEquals(expected.x, actual.x, String.format("Actual value for x must match value %s", expected.x)); //$NON-NLS-1$
+		assertEquals(expected.y, actual.y, String.format("Actual value for y must match value %s", expected.y)); //$NON-NLS-1$
 		assertEquals(expected.width, actual.width,
-				String.format("Scaled value for width must match value %s", expected.width)); //$NON-NLS-1$
+				String.format("Actual value for width must match value %s", expected.width)); //$NON-NLS-1$
 		assertEquals(expected.height, actual.height,
-				String.format("Scaled value for height must match value %s", expected.height)); //$NON-NLS-1$
+				String.format("Actual value for height must match value %s", expected.height)); //$NON-NLS-1$
 	}
 
 	private static void validatePoint(Point actual, Point expected) {
-		assertEquals(expected.x, actual.x, String.format("Scaled value for x1 must match value %s", expected.x)); //$NON-NLS-1$
-		assertEquals(expected.y, actual.y, String.format("Scaled value for y1 must match value %s", expected.y)); //$NON-NLS-1$
+		assertEquals(expected.x, actual.x, String.format("Actual value for x1 must match value %s", expected.x)); //$NON-NLS-1$
+		assertEquals(expected.y, actual.y, String.format("Actual value for y1 must match value %s", expected.y)); //$NON-NLS-1$
 	}
 
 	private static void validateClipRect(RecordingSwtGraphics graphics, Rectangle expected) {
@@ -1018,105 +915,110 @@ public class ScaledGraphicsTest {
 				String.format("fillRoundRectangle: Scaled value for arc height must match value %s", expectedArc.y)); //$NON-NLS-1$
 	}
 
-	private static RecordingSwtGraphics executeWithOneLayer(int monitorZoom, int diagramZoom,
-			Consumer<ScaledGraphics> graphicsCall) {
+	private RecordingSwtGraphics executeWithOneLayer(int monitorZoom, int diagramZoom,
+			Consumer<Graphics> graphicsCall) {
 		return executeWithOneLayer(monitorZoom, diagramZoom, graphicsCall, graphics -> {
 		});
 	}
 
-	private static RecordingSwtGraphics executeWithOneLayer(int monitorZoom, int diagramZoom,
-			Consumer<ScaledGraphics> graphicsCall, Consumer<RecordingSwtGraphics> initializeGraphics) {
+	private RecordingSwtGraphics executeWithOneLayer(int monitorZoom, int diagramZoom, Consumer<Graphics> graphicsCall,
+			Consumer<RecordingSwtGraphics> initializeGraphics) {
 		Display display = Display.getDefault();
 		Image image = new Image(display, 100, 100);
 		GC gc = new GC(image);
-		RecordingSwtGraphics graphics = new RecordingSwtGraphics(gc);
-		initializeGraphics.accept(graphics);
-		ScaledGraphics scaledGraphics = new ScaledGraphics(graphics);
-		scaledGraphics.scale(monitorZoom / 100d * diagramZoom / 100d);
-		graphicsCall.accept(scaledGraphics);
-		scaledGraphics.dispose();
+		RecordingSwtGraphics recorder = new RecordingSwtGraphics(gc);
+		initializeGraphics.accept(recorder);
+		Graphics graphics = createGraphics(recorder);
+		graphics.scale(monitorZoom / 100d * diagramZoom / 100d);
+		graphicsCall.accept(graphics);
 		graphics.dispose();
+		recorder.dispose();
 		gc.dispose();
 		image.dispose();
-		return graphics;
+		return recorder;
 	}
 
-	private static RecordingSwtGraphics executeTranslatedWithOneLayer(int monitorZoom, int diagramZoom,
-			Consumer<ScaledGraphics> graphicsCall) {
+	private RecordingSwtGraphics executeTranslatedWithOneLayer(int monitorZoom, int diagramZoom,
+			Consumer<Graphics> graphicsCall) {
 		return executeTranslatedWithOneLayer(monitorZoom, diagramZoom, graphicsCall, graphics -> {
 		});
 	}
 
-	private static RecordingSwtGraphics executeTranslatedWithOneLayer(int monitorZoom, int diagramZoom,
-			Consumer<ScaledGraphics> graphicsCall, Consumer<RecordingSwtGraphics> initializeGraphics) {
+	private RecordingSwtGraphics executeTranslatedWithOneLayer(int monitorZoom, int diagramZoom,
+			Consumer<Graphics> graphicsCall, Consumer<RecordingSwtGraphics> initializeGraphics) {
 		Display display = Display.getDefault();
 		Image image = new Image(display, 100, 100);
 		GC gc = new GC(image);
-		RecordingSwtGraphics graphics = new RecordingSwtGraphics(gc);
-		initializeGraphics.accept(graphics);
-		ScaledGraphics scaledGraphics = new ScaledGraphics(graphics);
-		scaledGraphics.scale(monitorZoom / 100d * diagramZoom / 100d);
-		scaledGraphics.translate(1f, 1f);
-		graphicsCall.accept(scaledGraphics);
-		scaledGraphics.dispose();
+		RecordingSwtGraphics recorder = new RecordingSwtGraphics(gc);
+		initializeGraphics.accept(recorder);
+		Graphics graphics = createGraphics(recorder);
+		graphics.scale(monitorZoom / 100d * diagramZoom / 100d);
+		graphics.translate(1f, 1f);
+		graphicsCall.accept(graphics);
 		graphics.dispose();
+		recorder.dispose();
 		gc.dispose();
 		image.dispose();
-		return graphics;
+		return recorder;
 	}
 
-	private static RecordingSwtGraphics executeWithTwoLayers(int monitorZoom, int diagramZoom,
-			Consumer<ScaledGraphics> graphicsCall) {
+	private RecordingSwtGraphics executeWithTwoLayers(int monitorZoom, int diagramZoom,
+			Consumer<Graphics> graphicsCall) {
 		return executeWithTwoLayers(monitorZoom, diagramZoom, graphicsCall, graphics -> {
 		});
 	}
 
-	private static RecordingSwtGraphics executeWithTwoLayers(int monitorZoom, int diagramZoom,
-			Consumer<ScaledGraphics> graphicsCall, Consumer<RecordingSwtGraphics> initializeGraphics) {
+	private RecordingSwtGraphics executeWithTwoLayers(int monitorZoom, int diagramZoom, Consumer<Graphics> graphicsCall,
+			Consumer<RecordingSwtGraphics> initializeGraphics) {
 		Display display = Display.getDefault();
 		Image image = new Image(display, 100, 100);
 		GC gc = new GC(image);
-		RecordingSwtGraphics graphics = new RecordingSwtGraphics(gc);
-		initializeGraphics.accept(graphics);
-		ScaledGraphics scaledGraphics = new ScaledGraphics(graphics);
-		scaledGraphics.scale(monitorZoom / 100d);
-		ScaledGraphics scaledGraphics2 = new ScaledGraphics(scaledGraphics);
-		scaledGraphics2.scale(diagramZoom / 100d);
-		graphicsCall.accept(scaledGraphics2);
-		scaledGraphics2.dispose();
-		scaledGraphics.dispose();
+		RecordingSwtGraphics recorder = new RecordingSwtGraphics(gc);
+		initializeGraphics.accept(recorder);
+		Graphics graphics = createGraphics(recorder);
+		graphics.scale(monitorZoom / 100d);
+		Graphics graphics2 = createGraphics(graphics);
+		graphics2.scale(diagramZoom / 100d);
+		graphicsCall.accept(graphics2);
+		graphics2.dispose();
 		graphics.dispose();
+		recorder.dispose();
 		gc.dispose();
 		image.dispose();
-		return graphics;
+		return recorder;
 	}
 
-	private static RecordingSwtGraphics executeTranslatedWithTwoLayers(int monitorZoom, int diagramZoom,
-			Consumer<ScaledGraphics> graphicsCall) {
+	private RecordingSwtGraphics executeTranslatedWithTwoLayers(int monitorZoom, int diagramZoom,
+			Consumer<Graphics> graphicsCall) {
 		return executeTranslatedWithTwoLayers(monitorZoom, diagramZoom, graphicsCall, graphics -> {
 		});
 	}
 
-	private static RecordingSwtGraphics executeTranslatedWithTwoLayers(int monitorZoom, int diagramZoom,
-			Consumer<ScaledGraphics> graphicsCall, Consumer<RecordingSwtGraphics> initializeGraphics) {
+	private RecordingSwtGraphics executeTranslatedWithTwoLayers(int monitorZoom, int diagramZoom,
+			Consumer<Graphics> graphicsCall, Consumer<RecordingSwtGraphics> initializeGraphics) {
 		Display display = Display.getDefault();
 		Image image = new Image(display, 100, 100);
 		GC gc = new GC(image);
-		RecordingSwtGraphics graphics = new RecordingSwtGraphics(gc);
-		initializeGraphics.accept(graphics);
-		ScaledGraphics scaledGraphics = new ScaledGraphics(graphics);
-		scaledGraphics.scale(monitorZoom / 100d);
-		ScaledGraphics scaledGraphics2 = new ScaledGraphics(scaledGraphics);
-		scaledGraphics2.scale(diagramZoom / 100d);
-		scaledGraphics2.translate(1f, 1f);
-		graphicsCall.accept(scaledGraphics2);
-		scaledGraphics2.dispose();
-		scaledGraphics.dispose();
+		RecordingSwtGraphics recorder = new RecordingSwtGraphics(gc);
+		initializeGraphics.accept(recorder);
+		Graphics graphics = createGraphics(recorder);
+		graphics.scale(monitorZoom / 100d);
+		Graphics graphics2 = createGraphics(graphics);
+		graphics2.scale(diagramZoom / 100d);
+		graphics2.translate(1f, 1f);
+		graphicsCall.accept(graphics2);
+		graphics2.dispose();
 		graphics.dispose();
+		recorder.dispose();
 		gc.dispose();
 		image.dispose();
-		return graphics;
+		return recorder;
 	}
+
+	/**
+	 * Creates and returns a new instance of the Graphics object to be tested.
+	 */
+	protected abstract Graphics createGraphics(Graphics recorder);
 
 	private static class RecordingSwtGraphics extends SWTGraphics {
 
@@ -1304,6 +1206,14 @@ public class ScaledGraphicsTest {
 			fillRoundRectangle.setHeight(r.height);
 			fillRoundRectangleArc.setX(arcWidth);
 			fillRoundRectangleArc.setY(arcHeight);
+		}
+	}
+
+	public static class ScaledGraphicsTest extends GraphicsTest {
+		@Override
+		@SuppressWarnings("removal")
+		protected Graphics createGraphics(Graphics recorder) {
+			return new ScaledGraphics(recorder);
 		}
 	}
 }


### PR DESCRIPTION
This renames the internal `ScaledGraphicsValidation` class to `GraphicsValidation` and adapts the method signatures to accept a plain `Graphics` object. Doing so allows up to eventually reuse this test when adding the Swing/SVG-based Graphics implementation.

For clarity, the `RecordingSwtGraphics` instances have been renamed to `recorder` and the `graphics` instance which is being tested to `graphics`, rather than `scaledGraphics`.

In addition the `ScaledGraphicsTest` is renamed to `GraphicsTest` and made abstract. The `ScaledGraphics`-based testing is now done via a _new_ `ScaledGraphicsTest`, which extends this abstract base class.