### PR TITLE
Mark public color fields in `Graph` for removal

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -106,14 +106,46 @@ public class Graph extends FigureCanvas implements IContainer2 {
 
 	// @tag CGraph.Colors : These are the colour constants for the graph, they
 	// are disposed on clean-up
+	/**
+	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color LIGHT_BLUE = null;
+	/**
+	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color LIGHT_BLUE_CYAN = null;
+	/**
+	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color GREY_BLUE = null;
+	/**
+	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color DARK_BLUE = null;
+	/**
+	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color LIGHT_YELLOW = null;
 
+	/**
+	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color HIGHLIGHT_COLOR = ColorConstants.yellow;
+	/**
+	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color HIGHLIGHT_ADJACENT_COLOR = ColorConstants.orange;
+	/**
+	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color DEFAULT_NODE_COLOR = LIGHT_BLUE;
 
 	/**

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2025, CHISEL Group, University of Victoria, Victoria,
- *                            BC, Canada and others.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria, BC,
+ *                       Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -97,6 +97,7 @@ public class GraphConnection extends GraphItem {
 
 	private ConnectionRouter router = null;
 
+	@SuppressWarnings("removal")
 	public GraphConnection(Graph graphModel, int style, GraphNode source, GraphNode destination) {
 		super(graphModel, style);
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -183,6 +183,7 @@ public class GraphNode extends GraphItem {
 
 	static int count = 0;
 
+	@SuppressWarnings("removal")
 	protected void initModel(IContainer parent, String text, Image image) {
 		this.nodeStyle |= parent.getGraph().getNodeStyle();
 		this.parent = parent;


### PR DESCRIPTION
Having public fields is an anti-pattern because it allows users to modify those fields at any point. The colors should instead be set directly via e.g. `setBackgroundColor(...)` when creating the graph items.