### PR TITLE
Distinguish Zest node foreground color between highlighted and not

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/GraphLabelDecorator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/GraphLabelDecorator.java
@@ -95,7 +95,8 @@ public class GraphLabelDecorator extends LabelProvider implements IGraphLabelDec
 
 			Optional.ofNullable(decorator.getBorderColor(entity)).ifPresent(node::setBorderColor);
 			Optional.ofNullable(decorator.getBorderHighlightColor(entity)).ifPresent(node::setBorderHighlightColor);
-			Optional.ofNullable(decorator.getNodeHighlightColor(entity)).ifPresent(node::setHighlightColor);
+			Optional.ofNullable(decorator.getNodeForegroundHighlightColor(entity)).ifPresent(node::setForegroundHighlightColor);
+			Optional.ofNullable(decorator.getNodeBackgroundHighlightColor(entity)).ifPresent(node::setBackgroundHighlightColor);
 			Optional.ofNullable(decorator.getBackgroundColor(entity)).ifPresent(node::setBackgroundColor);
 			Optional.ofNullable(decorator.getForegroundColor(entity)).ifPresent(node::setForegroundColor);
 			Optional.ofNullable(decorator.getBorderWidth(entity)).filter(width -> width >= 0).ifPresent(node::setBorderWidth);

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/IEntityStyleDecorator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/IEntityStyleDecorator.java
@@ -94,13 +94,22 @@ public interface IEntityStyleDecorator {
 	Color getForegroundColor(Object entity);
 
 	/**
-	 * Returns the foreground color of this entity. May return {@code null} for
-	 * defaults.
+	 * Returns the foreground highlight color of this entity. May return
+	 * {@code null} for defaults.
 	 *
 	 * @param entity the entity to be styled.
 	 * @return the foreground color of this entity.
 	 */
-	Color getNodeHighlightColor(Object entity);
+	Color getNodeForegroundHighlightColor(Object entity);
+
+	/**
+	 * Returns the background highlight color of this entity. May return
+	 * {@code null} for defaults.
+	 *
+	 * @param entity the entity to be styled.
+	 * @return the background color of this entity.
+	 */
+	Color getNodeBackgroundHighlightColor(Object entity);
 
 	/**
 	 * Returns the tool-tip for this node. If {@code null} is returned Zest will

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphContainer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphContainer.java
@@ -826,8 +826,8 @@ public class GraphContainer extends GraphNode implements IContainer2 {
 		expandGraphLabel.setFont(getFont());
 
 		if (highlighted == HIGHLIGHT_ON) {
-			expandGraphLabel.setForegroundColor(getForegroundColor());
-			expandGraphLabel.setBackgroundColor(getHighlightColor());
+			expandGraphLabel.setForegroundColor(getForegroundHighlightColor());
+			expandGraphLabel.setBackgroundColor(getBackgroundHighlightColor());
 		} else {
 			expandGraphLabel.setForegroundColor(getForegroundColor());
 			expandGraphLabel.setBackgroundColor(getBackgroundColor());

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria, BC,
- *                       Canada and others.
+ * Copyright 2005, 2026, CHISEL Group, University of Victoria, Victoria,
+ *                       BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -63,8 +63,9 @@ public class GraphNode extends GraphItem {
 	private List<GraphConnection> targetConnections;
 
 	private Color foreColor;
+	private Color foreHighlightColor;
 	private Color backColor;
-	private Color highlightColor;
+	private Color backHighlightColor;
 	private Color borderColor;
 	private Color borderHighlightColor;
 	private int borderWidth;
@@ -190,8 +191,9 @@ public class GraphNode extends GraphItem {
 		this.sourceConnections = new ArrayList<>();
 		this.targetConnections = new ArrayList<>();
 		this.foreColor = parent.getGraph().DARK_BLUE;
+		this.foreHighlightColor = null;
 		this.backColor = parent.getGraph().LIGHT_BLUE;
-		this.highlightColor = parent.getGraph().HIGHLIGHT_COLOR;
+		this.backHighlightColor = parent.getGraph().HIGHLIGHT_COLOR;
 		this.nodeStyle = SWT.NONE;
 		this.borderColor = ColorConstants.lightGray;
 		this.borderHighlightColor = ColorConstants.blue;
@@ -440,17 +442,65 @@ public class GraphNode extends GraphItem {
 	}
 
 	/**
-	 * Get the highlight colour for this node
+	 * Get the highlight background color for this node.
+	 *
+	 * @since 1.19
 	 */
+	public Color getBackgroundHighlightColor() {
+		return getHighlightColor();
+	}
+
+	/**
+	 * Set the highlight background color for this node.
+	 *
+	 * @since 1.19
+	 */
+	public void setBackgroundHighlightColor(Color c) {
+		setHighlightColor(c);
+	}
+
+	/**
+	 * Get the highlight foreground color for this node. Returns
+	 * {@link #getForegroundColor()} if no highlight color is set.
+	 *
+	 * @since 1.19
+	 */
+	public Color getForegroundHighlightColor() {
+		if (foreHighlightColor == null) {
+			return getForegroundColor();
+		}
+		return foreHighlightColor;
+	}
+
+	/**
+	 * Set the highlight foreground color for this node.
+	 *
+	 * @since 1.19
+	 */
+	public void setForegroundHighlightColor(Color c) {
+		this.foreHighlightColor = c;
+	}
+
+	/**
+	 * Get the highlight colour for this node
+	 *
+	 * @deprecated Use {@link #getBackgroundHighlightColor()} instead. This method
+	 *             will be removed after the 2028-09 release.
+	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color getHighlightColor() {
-		return highlightColor;
+		return backHighlightColor;
 	}
 
 	/**
 	 * Set the highlight colour for this node
+	 *
+	 * @deprecated Use {@link #setBackgroundHighlightColor(Color)} instead. This
+	 *             method will be removed after the 2028-09 release.
 	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	public void setHighlightColor(Color c) {
-		this.highlightColor = c;
+		this.backHighlightColor = c;
 	}
 
 	/**
@@ -779,8 +829,8 @@ public class GraphNode extends GraphItem {
 			// update styles (colors, border) for figures implementing
 			// IStyleableFigure
 			if (highlighted == HIGHLIGHT_ON) {
-				styleableFigure.setForegroundColor(getForegroundColor());
-				styleableFigure.setBackgroundColor(getHighlightColor());
+				styleableFigure.setForegroundColor(getForegroundHighlightColor());
+				styleableFigure.setBackgroundColor(getBackgroundHighlightColor());
 				styleableFigure.setBorderColor(getBorderHighlightColor());
 			} else {
 				styleableFigure.setForegroundColor(getForegroundColor());
@@ -865,8 +915,8 @@ public class GraphNode extends GraphItem {
 		// @tag TODO: Add border and foreground colours to highlight
 		// (this.borderColor)
 		if (highlighted == HIGHLIGHT_ON) {
-			label.setForegroundColor(getForegroundColor());
-			label.setBackgroundColor(getHighlightColor());
+			label.setForegroundColor(getForegroundHighlightColor());
+			label.setBackgroundColor(getBackgroundHighlightColor());
 			label.setBorderColor(getBorderHighlightColor());
 		} else {
 			label.setForegroundColor(getForegroundColor());


### PR DESCRIPTION
Depending on the foreground color used for Zest nodes, it might be hard to read any displayed text when they are selected. For example if the text is shown in white and the highlight color is bright.

This change splits up the foreground color into two separate fields, which can be set with the `getForegroundHighlightColor()` and the `setBackgroundHighlightColor()` (formerly the `setHighlightColor()`) methods.

To ensure backwards compatibility, the graph node will fall back to the "normal" foreground color, if no highlight color is set.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/1090