### PR TITLE
Make Graph colors configurable using the `IGraphDecorator` interface

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/GraphLabelDecorator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/decorators/GraphLabelDecorator.java
@@ -19,6 +19,7 @@ import org.eclipse.swt.SWTError;
 import org.eclipse.swt.graphics.Image;
 
 import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
@@ -102,5 +103,10 @@ public class GraphLabelDecorator extends LabelProvider implements IGraphLabelDec
 			Optional.ofNullable(decorator.getBorderWidth(entity)).filter(width -> width >= 0).ifPresent(node::setBorderWidth);
 			Optional.ofNullable(decorator.getTooltip(entity)).ifPresent(node::setTooltip);
 		}
+	}
+
+	@Override
+	public void decorateGraph(Graph graph) {
+		// Default implementation does nothing
 	}
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -40,8 +40,10 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.zest.core.viewers.internal.ZoomManager;
+import org.eclipse.zest.core.widgets.decorators.IGraphDecorator;
 import org.eclipse.zest.core.widgets.gestures.RotateGestureListener;
 import org.eclipse.zest.core.widgets.gestures.ZoomGestureListener;
+import org.eclipse.zest.core.widgets.internal.BasicGraphDecorator;
 import org.eclipse.zest.core.widgets.internal.ContainerFigure;
 import org.eclipse.zest.core.widgets.internal.ZestRootLayer;
 import org.eclipse.zest.layouts.InvalidLayoutConfiguration;
@@ -107,43 +109,80 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	// @tag CGraph.Colors : These are the colour constants for the graph, they
 	// are disposed on clean-up
 	/**
-	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 * Colors don't consume system resources anymore and should be maintained by the
+	 * client. Use {@link #setGraphDecorator(IGraphDecorator)} if styling is
+	 * required. This field is initialized with {@code new Color(216, 228, 248)}.
+	 *
+	 * @deprecated Use {@link ColorConstants#lightBlue} instead. This field will be
+	 *             removed after the 2028-09 release.
 	 */
 	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color LIGHT_BLUE = null;
 	/**
+	 * Colors don't consume system resources anymore and should be maintained by the
+	 * client. Use {@link #setGraphDecorator(IGraphDecorator)} if styling is
+	 * required. This field is initialized with {@code new Color(213, 243, 255)}.
+	 *
 	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
 	 */
 	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color LIGHT_BLUE_CYAN = null;
 	/**
+	 * Colors don't consume system resources anymore and should be maintained by the
+	 * client. Use {@link #setGraphDecorator(IGraphDecorator)} if styling is
+	 * required. This field is initialized with {@code new Color(139, 150, 171)}.
+	 *
 	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
 	 */
 	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color GREY_BLUE = null;
 	/**
-	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 * Colors don't consume system resources anymore and should be maintained by the
+	 * client. Use {@link #setGraphDecorator(IGraphDecorator)} if styling is
+	 * required. This field is initialized with {@code new Color(1, 70, 122)}.
+	 *
+	 * @deprecated Use {@link ColorConstants#darkBlue} instead. This field will be
+	 *             removed after the 2028-09 release.
 	 */
 	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color DARK_BLUE = null;
 	/**
+	 * Colors don't consume system resources anymore and should be maintained by the
+	 * client. Use {@link #setGraphDecorator(IGraphDecorator)} if styling is
+	 * required. This field is initialized with {@code new Color(255, 255, 206)}.
+	 *
 	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
 	 */
 	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color LIGHT_YELLOW = null;
 
 	/**
-	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 * Colors don't consume system resources anymore and should be maintained by the
+	 * client. Use {@link #setGraphDecorator(IGraphDecorator)} if styling is
+	 * required. This field is initialized with {@link ColorConstants#yellow}.
+	 *
+	 * @deprecated Use {@link ColorConstants#yellow} instead. This field will be
+	 *             removed after the 2028-09 release.
 	 */
 	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color HIGHLIGHT_COLOR = ColorConstants.yellow;
 	/**
-	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 * Colors don't consume system resources anymore and should be maintained by the
+	 * client. Use {@link #setGraphDecorator(IGraphDecorator)} if styling is
+	 * required. This field is initialized with {@link ColorConstants#orange}.
+	 *
+	 * @deprecated Use {@link ColorConstants#orange} instead. This field will be
+	 *             removed after the 2028-09 release.
 	 */
 	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color HIGHLIGHT_ADJACENT_COLOR = ColorConstants.orange;
 	/**
-	 * @deprecated Do not use. This field will be removed after the 2028-09 release.
+	 * Colors don't consume system resources anymore and should be maintained by the
+	 * client. Use {@link #setGraphDecorator(IGraphDecorator)} if styling is
+	 * required. This field is initialized with {@code new Color(216, 228, 248)}.
+	 *
+	 * @deprecated Use {@link ColorConstants#lightBlue} instead. This field will be
+	 *             removed after the 2028-09 release.
 	 */
 	@Deprecated(since = "2026-09", forRemoval = true)
 	public Color DEFAULT_NODE_COLOR = LIGHT_BLUE;
@@ -160,6 +199,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	IFigure fisheyedFigure = null;
 	private final List<FisheyeListener> fisheyeListeners = new CopyOnWriteArrayList<>();
 	private List<SelectionListener> selectionListeners = null;
+	private IGraphDecorator graphDecorator = BasicGraphDecorator.getInstance();
 
 	/** This maps all visible nodes to their model element. */
 	private HashMap<IFigure, GraphItem> figure2ItemMap = null;
@@ -216,7 +256,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	 */
 	public Graph(Composite parent, int style, boolean enableHideNodes) {
 		super(parent, style | SWT.DOUBLE_BUFFERED);
-		this.setBackground(ColorConstants.white);
+		this.getGraphDecorator().decorateGraph(this);
 
 		LIGHT_BLUE = new Color(216, 228, 248);
 		LIGHT_BLUE_CYAN = new Color(213, 243, 255);
@@ -1808,5 +1848,25 @@ public class Graph extends FigureCanvas implements IContainer2 {
 			zoomManager = new ZoomManager(getRootLayer(), getViewport());
 		}
 		return zoomManager;
+	}
+
+	/**
+	 * Sets the decorator used for styling all nodes and connections that are part
+	 * of this graph. If {@code null} is passed as argument, the graph reverts back
+	 * to its "default" decorator.
+	 *
+	 * @param graphDecorator The new decorator instance. May be {@code null}.
+	 * @since 1.19
+	 */
+	public void setGraphDecorator(IGraphDecorator graphDecorator) {
+		if (graphDecorator == null) {
+			this.graphDecorator = BasicGraphDecorator.getInstance();
+			return;
+		}
+		this.graphDecorator = graphDecorator;
+	}
+
+	/* package */ IGraphDecorator getGraphDecorator() {
+		return graphDecorator;
 	}
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -30,7 +30,6 @@ import org.eclipse.zest.layouts.interfaces.ConnectionLayout;
 import org.eclipse.zest.layouts.interfaces.NodeLayout;
 
 import org.eclipse.draw2d.ChopboxAnchor;
-import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Connection;
 import org.eclipse.draw2d.ConnectionRouter;
 import org.eclipse.draw2d.Graphics;
@@ -97,7 +96,6 @@ public class GraphConnection extends GraphItem {
 
 	private ConnectionRouter router = null;
 
-	@SuppressWarnings("removal")
 	public GraphConnection(Graph graphModel, int style, GraphNode source, GraphNode destination) {
 		super(graphModel, style);
 
@@ -106,13 +104,11 @@ public class GraphConnection extends GraphItem {
 		this.sourceNode = source;
 		this.destinationNode = destination;
 		this.visible = true;
-		this.color = ColorConstants.lightGray;
-		this.foreground = ColorConstants.lightGray;
-		this.highlightColor = graphModel.DARK_BLUE;
 		this.lineWidth = 1;
 		this.lineStyle = Graphics.LINE_SOLID;
 		setWeight(weight);
 		this.graphModel = graphModel;
+		this.graphModel.getGraph().getGraphDecorator().decorateConnection(this);
 		this.curveDepth = 0;
 		this.layoutConnection = new GraphLayoutConnection();
 		this.font = Display.getDefault().getSystemFont();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -31,7 +31,6 @@ import org.eclipse.zest.layouts.LayoutEntity;
 import org.eclipse.zest.layouts.constraints.LayoutConstraint;
 
 import org.eclipse.draw2d.Animation;
-import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.FigureListener;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
@@ -184,24 +183,18 @@ public class GraphNode extends GraphItem {
 
 	static int count = 0;
 
-	@SuppressWarnings("removal")
 	protected void initModel(IContainer parent, String text, Image image) {
 		this.nodeStyle |= parent.getGraph().getNodeStyle();
 		this.parent = parent;
 		this.sourceConnections = new ArrayList<>();
 		this.targetConnections = new ArrayList<>();
-		this.foreColor = parent.getGraph().DARK_BLUE;
-		this.foreHighlightColor = null;
-		this.backColor = parent.getGraph().LIGHT_BLUE;
-		this.backHighlightColor = parent.getGraph().HIGHLIGHT_COLOR;
 		this.nodeStyle = SWT.NONE;
-		this.borderColor = ColorConstants.lightGray;
-		this.borderHighlightColor = ColorConstants.blue;
 		this.borderWidth = 1;
 		this.currentLocation = new PrecisionPoint(0, 0);
 		this.size = new Dimension(-1, -1);
 		this.font = Display.getDefault().getSystemFont();
 		this.graph = parent.getGraph();
+		this.graph.getGraphDecorator().decorateNode(this);
 		this.cacheLabel = false;
 		this.setText(text);
 		this.layoutEntity = new LayoutGraphNode();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/decorators/GraphDecorator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/decorators/GraphDecorator.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.zest.core.widgets.decorators;
 
+import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 
@@ -29,6 +30,11 @@ public class GraphDecorator implements IGraphDecorator {
 
 	@Override
 	public void decorateNode(GraphNode node) {
+		// Default implementation does nothing
+	}
+
+	@Override
+	public void decorateGraph(Graph graph) {
 		// Default implementation does nothing
 	}
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/decorators/IGraphDecorator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/decorators/IGraphDecorator.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.zest.core.widgets.decorators;
 
+import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 
@@ -37,4 +38,9 @@ public interface IGraphDecorator {
 	 * Decorate a node.
 	 */
 	void decorateNode(GraphNode node);
+
+	/**
+	 * Decorate a graph.
+	 */
+	void decorateGraph(Graph graph);
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/BasicGraphDecorator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/BasicGraphDecorator.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.zest.core.widgets.internal;
+
+import org.eclipse.zest.core.widgets.Graph;
+import org.eclipse.zest.core.widgets.GraphConnection;
+import org.eclipse.zest.core.widgets.GraphNode;
+import org.eclipse.zest.core.widgets.decorators.IGraphDecorator;
+
+import org.eclipse.draw2d.ColorConstants;
+
+/**
+ * Default implementation used for decorating a {@link Graph} and its nodes if
+ * no other decorator is specified.
+ */
+public class BasicGraphDecorator implements IGraphDecorator {
+	private static final IGraphDecorator INSTANCE = new BasicGraphDecorator();
+
+	private BasicGraphDecorator() {
+		// should never be called from outside in a singleton
+	}
+
+	public static IGraphDecorator getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	@SuppressWarnings("removal")
+	public void decorateConnection(GraphConnection connection) {
+		connection.setLineColor(ColorConstants.lightGray);
+		connection.setHighlightColor(connection.getGraphModel().DARK_BLUE);
+	}
+
+	@Override
+	@SuppressWarnings("removal")
+	public void decorateNode(GraphNode node) {
+		node.setForegroundColor(node.getGraphModel().DARK_BLUE);
+		node.setForegroundHighlightColor(null);
+		node.setBackgroundColor(node.getGraphModel().LIGHT_BLUE);
+		node.setBackgroundHighlightColor(node.getGraphModel().HIGHLIGHT_COLOR);
+		node.setBorderColor(ColorConstants.lightGray);
+		node.setBorderHighlightColor(ColorConstants.blue);
+	}
+
+	@Override
+	public void decorateGraph(Graph graph) {
+		graph.setBackground(ColorConstants.white);
+	}
+}


### PR DESCRIPTION
This moves the hard-coded colors used for the `Graph` class and its items to an internal `BasicGraphDecorator` class. Clients can provide their own colors (and also perform additional styling) using via the new `setGraphDecorator(...)` method on the `Graph` object.

Note that when this `Graph` is used with a `GraphViewer`, the decorations done by the `GraphLabelDecorator` take priority.

To allow styling the graph itself, a new `decorateGraph(...)` method has been added to the `IGraphDecorator` interface.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/1090