### PR TITLE
Determine Maven compiler settings based on BREE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,6 @@
 	<!-- this is the parent POM from which all modules inherit common settings -->
 	<properties>
 		<maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>		
 		<cbi-plugins.version>1.5.4</cbi-plugins.version>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse-gef/gef-classic.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Explicitly setting the Maven compiler settings in the POM may cause issues when they differ from the BREE. For example if Java 21 language features are used in bundles with a Java 21 BREE.