### PR TITLE
Cleanup deprecated SelectionRange handling in Text example

### DIFF
--- a/org.eclipse.gef.examples.text/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.text; singleton:=true
-Bundle-Version: 3.16.400.qualifier
+Bundle-Version: 3.17.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.gef.examples.text,

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/GraphicalTextViewer.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/GraphicalTextViewer.java
@@ -104,7 +104,7 @@ public class GraphicalTextViewer extends ScrollingGraphicalViewer {
 		SelectionModel newModel = null;
 		if (newRange != null) {
 			newModel = createSelectionModel(null, newRange,
-					selectionModel == null ? null : selectionModel.getSelectedEditParts(), null);
+					selectionModel == null ? Collections.emptyList() : selectionModel.getSelectedEditParts());
 		}
 		setSelectionModel(newModel);
 	}
@@ -129,7 +129,7 @@ public class GraphicalTextViewer extends ScrollingGraphicalViewer {
 
 	@Override
 	public void appendSelection(EditPart editpart) {
-		if (focusPart != editpart) {
+		if (getFocusEditPart() != editpart) {
 			setFocus(null);
 		}
 		if (selectionModel != null) {
@@ -153,12 +153,12 @@ public class GraphicalTextViewer extends ScrollingGraphicalViewer {
 
 	@Override
 	public void select(EditPart editpart) {
-		if (focusPart != editpart) {
+		if (getFocusEditPart() != editpart) {
 			setFocus(null);
 		}
 		ArrayList<EditPart> list = new ArrayList<>();
 		list.add(editpart);
-		setSelectionModel(createSelectionModel(null, null, list, null));
+		setSelectionModel(createSelectionModel(null, null, list));
 	}
 
 	// @TODO:Pratik Hack. This shouldn't be here. CommandStack should be doing
@@ -174,11 +174,11 @@ public class GraphicalTextViewer extends ScrollingGraphicalViewer {
 			TextCommand command = (TextCommand) event.getCommand();
 			if (command != null) {
 				if (event.getDetail() == CommandStack.POST_EXECUTE) {
-					setSelectionRange(command.getExecuteSelectionRange(GraphicalTextViewer.this));
+					setSelectionModel(command.getExecuteSelectionModel(GraphicalTextViewer.this));
 				} else if (event.getDetail() == CommandStack.POST_REDO) {
-					setSelectionRange(command.getRedoSelectionRange(GraphicalTextViewer.this));
+					setSelectionModel(command.getRedoSelectionModel(GraphicalTextViewer.this));
 				} else if (event.getDetail() == CommandStack.POST_UNDO) {
-					setSelectionRange(command.getUndoSelectionRange(GraphicalTextViewer.this));
+					setSelectionModel(command.getUndoSelectionModel(GraphicalTextViewer.this));
 				}
 			}
 		});
@@ -187,7 +187,7 @@ public class GraphicalTextViewer extends ScrollingGraphicalViewer {
 	@Override
 	public void setSelection(ISelection newSelection) {
 		if (newSelection != null) {
-			setSelectionModel(createSelectionModel(newSelection, null, null, null));
+			setSelectionModel(createSelectionModel(newSelection, null, Collections.emptyList()));
 		} else {
 			setSelectionModel(null);
 		}
@@ -201,12 +201,11 @@ public class GraphicalTextViewer extends ScrollingGraphicalViewer {
 		return new StructuredSelection(getContents());
 	}
 
-	private static SelectionModel createSelectionModel(ISelection selection, SelectionRange range, List<EditPart> parts,
-			EditPart container) {
-		if (selection instanceof IStructuredSelection) {
-			return new SelectionModel(selection);
+	private static SelectionModel createSelectionModel(ISelection selection, SelectionRange range, List<EditPart> parts) {
+		if (selection instanceof IStructuredSelection structuredSelection) {
+			return new SelectionModel(structuredSelection);
 		}
-		return new SelectionModel(range, parts, container);
+		return new SelectionModel(range, parts);
 	}
 
 	/**

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/SelectionModel.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/SelectionModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2010 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,19 +36,30 @@ import org.eclipse.gef.examples.text.edit.TextEditPart;
 public class SelectionModel {
 
 	private final SelectionRange selectionRange;
-	private final EditPart selectionContainer;
 	private final List<EditPart> constantSelection;
 
 	@SuppressWarnings("unchecked")
-	public SelectionModel(ISelection selection) {
-		this(null, selection instanceof IStructuredSelection structSel ? structSel.toList() : null, null);
+	public SelectionModel(IStructuredSelection selection) {
+		this(null, selection.toList());
 	}
 
-	public SelectionModel(SelectionRange range, List<EditPart> selectedParts, EditPart container) {
+	/**
+	 * Constructs a selection model combining an optional text selection range and
+	 * an (optional) ordered list of EditParts to be selected. Passing an empty list
+	 * leaves the current selection unchanged.
+	 *
+	 * @param range         the {@link SelectionRange} describing text selection
+	 *                      (caret and range). May be {@code null} when there is no
+	 *                      text selection.
+	 * @param selectedParts a list of {@link EditPart}s to be selected; the last
+	 *                      element in the list will be treated as the focus/primary
+	 *                      selection. The list must not be {@code null}. If no edit
+	 *                      parts should be selected supply an empty list (e.g.
+	 *                      {@code Collections.emptyList()}).
+	 */
+	public SelectionModel(SelectionRange range, List<EditPart> selectedParts) {
 		selectionRange = range;
-		selectionContainer = container;
-		constantSelection = selectedParts == null ? Collections.emptyList()
-				: Collections.unmodifiableList(selectedParts);
+		constantSelection = Collections.unmodifiableList(selectedParts);
 	}
 
 	protected void applySelectedParts() {
@@ -103,11 +114,8 @@ public class SelectionModel {
 	public boolean equals(Object obj) {
 		boolean result = obj == this;
 		if (!result && obj instanceof SelectionModel other) {
-			EditPart otherContainer = other.getSelectionContainer();
 			SelectionRange otherRange = other.getSelectionRange();
 			result = constantSelection.equals(other.getSelectedEditParts())
-					&& (selectionContainer == otherContainer
-							|| (selectionContainer != null && selectionContainer.equals(otherContainer)))
 					&& (selectionRange == otherRange || (selectionRange != null && selectionRange.equals(otherRange)));
 		}
 		return result;
@@ -117,13 +125,13 @@ public class SelectionModel {
 		ArrayList<EditPart> list = new ArrayList<>(constantSelection);
 		list.remove(newPart);
 		list.add(newPart);
-		return new SelectionModel(selectionRange, list, selectionContainer);
+		return new SelectionModel(selectionRange, list);
 	}
 
 	public SelectionModel getExcludedSelection(EditPart exclude) {
 		ArrayList<EditPart> list = new ArrayList<>(constantSelection);
 		list.remove(exclude);
-		return new SelectionModel(selectionRange, list, selectionContainer);
+		return new SelectionModel(selectionRange, list);
 	}
 
 	public EditPart getFocusPart() {
@@ -139,10 +147,6 @@ public class SelectionModel {
 
 	public ISelection getSelection() {
 		return new StructuredSelection(constantSelection);
-	}
-
-	public EditPart getSelectionContainer() {
-		return selectionContainer;
 	}
 
 	public SelectionRange getSelectionRange() {

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/TextCommand.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/TextCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2010 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,23 +19,29 @@ package org.eclipse.gef.examples.text;
 public interface TextCommand {
 
 	/**
-	 * Returns the viewer's selection range for the state after execution or redo.
+	 * Returns the viewer's selection model for the state after redo.
 	 *
 	 * @since 3.1
 	 * @param viewer the viewer
-	 * @return the range
+	 * @return the model
 	 */
-	SelectionRange getRedoSelectionRange(GraphicalTextViewer viewer);
-
-	SelectionRange getExecuteSelectionRange(GraphicalTextViewer viewer);
+	SelectionModel getRedoSelectionModel(GraphicalTextViewer viewer);
 
 	/**
-	 * Returns the viewer's selection range for the state prior to execution.
+	 * Returns the viewer's selection model for the state after execution.
+	 *
+	 * @param viewer the viewer
+	 * @return the model
+	 */
+	SelectionModel getExecuteSelectionModel(GraphicalTextViewer viewer);
+
+	/**
+	 * Returns the viewer's selection model for the state after undo.
 	 *
 	 * @since 3.1
 	 * @param viewer the viewer
-	 * @return the range
+	 * @return the model
 	 */
-	SelectionRange getUndoSelectionRange(GraphicalTextViewer viewer);
+	SelectionModel getUndoSelectionModel(GraphicalTextViewer viewer);
 
 }

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/TextEditor.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/TextEditor.java
@@ -272,11 +272,11 @@ public class TextEditor extends GraphicalEditor {
 			if (command != null) {
 				GraphicalTextViewer textViewer = (GraphicalTextViewer) getGraphicalViewer();
 				if (event.getDetail() == CommandStack.POST_EXECUTE) {
-					textViewer.setSelectionRange(command.getExecuteSelectionRange(textViewer));
+					textViewer.setSelectionModel(command.getExecuteSelectionModel(textViewer));
 				} else if (event.getDetail() == CommandStack.POST_REDO) {
-					textViewer.setSelectionRange(command.getRedoSelectionRange(textViewer));
+					textViewer.setSelectionModel(command.getRedoSelectionModel(textViewer));
 				} else if (event.getDetail() == CommandStack.POST_UNDO) {
-					textViewer.setSelectionRange(command.getUndoSelectionRange(textViewer));
+					textViewer.setSelectionModel(command.getUndoSelectionModel(textViewer));
 				}
 			}
 		});

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/CompoundEditCommand.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/CompoundEditCommand.java
@@ -14,12 +14,14 @@
 package org.eclipse.gef.examples.text.model.commands;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.runtime.Assert;
 
 import org.eclipse.gef.examples.text.AppendableCommand;
 import org.eclipse.gef.examples.text.GraphicalTextViewer;
+import org.eclipse.gef.examples.text.SelectionModel;
 import org.eclipse.gef.examples.text.SelectionRange;
 import org.eclipse.gef.examples.text.edit.TextEditPart;
 import org.eclipse.gef.examples.text.model.ModelLocation;
@@ -81,27 +83,30 @@ public class CompoundEditCommand extends ExampleTextCommand implements Appendabl
 	}
 
 	@Override
-	public SelectionRange getExecuteSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getExecuteSelectionModel(GraphicalTextViewer viewer) {
 		ModelLocation loc = edits.get(edits.size() - 1).getResultingLocation();
 		if (loc == null) {
-			return getUndoSelectionRange(viewer);
+			return getUndoSelectionModel(viewer);
 		}
-		return new SelectionRange(lookupModel(viewer, loc.model), loc.offset);
+		SelectionRange range = new SelectionRange(lookupModel(viewer, loc.model), loc.offset);
+		return new SelectionModel(range, Collections.emptyList());
 	}
 
 	@Override
-	public SelectionRange getRedoSelectionRange(GraphicalTextViewer viewer) {
-		return getExecuteSelectionRange(viewer);
+	public SelectionModel getRedoSelectionModel(GraphicalTextViewer viewer) {
+		return getExecuteSelectionModel(viewer);
 	}
 
 	@Override
-	public SelectionRange getUndoSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getUndoSelectionModel(GraphicalTextViewer viewer) {
 		TextEditPart begin = lookupModel(viewer, beginLocation.model);
 		if (endLocation == null) {
-			return new SelectionRange(begin, beginLocation.offset);
+			SelectionRange range = new SelectionRange(begin, beginLocation.offset);
+			return new SelectionModel(range, Collections.emptyList());
 		}
 		TextEditPart end = lookupModel(viewer, endLocation.model);
-		return new SelectionRange(begin, beginLocation.offset, end, endLocation.offset);
+		SelectionRange range = new SelectionRange(begin, beginLocation.offset, end, endLocation.offset);
+		return new SelectionModel(range, Collections.emptyList());
 	}
 
 	public void pendEdit(MiniEdit edit) {

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/CompoundTextCommand.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/CompoundTextCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2024 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,7 @@ import org.eclipse.gef.commands.Command;
 
 import org.eclipse.gef.examples.text.AppendableCommand;
 import org.eclipse.gef.examples.text.GraphicalTextViewer;
-import org.eclipse.gef.examples.text.SelectionRange;
+import org.eclipse.gef.examples.text.SelectionModel;
 import org.eclipse.gef.examples.text.TextCommand;
 
 public class CompoundTextCommand extends Command implements TextCommand, AppendableCommand {
@@ -86,11 +86,11 @@ public class CompoundTextCommand extends Command implements TextCommand, Appenda
 	}
 
 	@Override
-	public SelectionRange getExecuteSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getExecuteSelectionModel(GraphicalTextViewer viewer) {
 		if (applied.isEmpty()) {
 			return null;
 		}
-		return getAppliedTextCommand(applied.size() - 1).getExecuteSelectionRange(viewer);
+		return getAppliedTextCommand(applied.size() - 1).getExecuteSelectionModel(viewer);
 	}
 
 	private TextCommand getAppliedTextCommand(int i) {
@@ -98,19 +98,19 @@ public class CompoundTextCommand extends Command implements TextCommand, Appenda
 	}
 
 	@Override
-	public SelectionRange getRedoSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getRedoSelectionModel(GraphicalTextViewer viewer) {
 		if (applied.isEmpty()) {
 			return null;
 		}
-		return getAppliedTextCommand(applied.size() - 1).getExecuteSelectionRange(viewer);
+		return getAppliedTextCommand(applied.size() - 1).getExecuteSelectionModel(viewer);
 	}
 
 	@Override
-	public SelectionRange getUndoSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getUndoSelectionModel(GraphicalTextViewer viewer) {
 		if (applied.isEmpty()) {
 			return null;
 		}
-		return getAppliedTextCommand(0).getUndoSelectionRange(viewer);
+		return getAppliedTextCommand(0).getUndoSelectionModel(viewer);
 	}
 
 	@Override

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/ConvertElementCommand.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/ConvertElementCommand.java
@@ -13,7 +13,10 @@
 
 package org.eclipse.gef.examples.text.model.commands;
 
+import java.util.Collections;
+
 import org.eclipse.gef.examples.text.GraphicalTextViewer;
+import org.eclipse.gef.examples.text.SelectionModel;
 import org.eclipse.gef.examples.text.SelectionRange;
 import org.eclipse.gef.examples.text.model.Container;
 import org.eclipse.gef.examples.text.model.ModelElement;
@@ -52,17 +55,18 @@ public class ConvertElementCommand extends ExampleTextCommand {
 	}
 
 	@Override
-	public SelectionRange getRedoSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getRedoSelectionModel(GraphicalTextViewer viewer) {
 		return null;
 	}
 
 	@Override
-	public SelectionRange getExecuteSelectionRange(GraphicalTextViewer viewer) {
-		return new SelectionRange(lookupModel(viewer, caret.model), caret.offset);
+	public SelectionModel getExecuteSelectionModel(GraphicalTextViewer viewer) {
+		SelectionRange range = new SelectionRange(lookupModel(viewer, caret.model), caret.offset);
+		return new SelectionModel(range, Collections.emptyList());
 	}
 
 	@Override
-	public SelectionRange getUndoSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getUndoSelectionModel(GraphicalTextViewer viewer) {
 		return null;
 	}
 

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/NestElementCommand.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/NestElementCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2023 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,10 @@
 
 package org.eclipse.gef.examples.text.model.commands;
 
+import java.util.Collections;
+
 import org.eclipse.gef.examples.text.GraphicalTextViewer;
+import org.eclipse.gef.examples.text.SelectionModel;
 import org.eclipse.gef.examples.text.SelectionRange;
 import org.eclipse.gef.examples.text.edit.TextEditPart;
 import org.eclipse.gef.examples.text.model.Container;
@@ -54,18 +57,19 @@ public class NestElementCommand extends ExampleTextCommand {
 	}
 
 	@Override
-	public SelectionRange getExecuteSelectionRange(GraphicalTextViewer viewer) {
-		return new SelectionRange(lookupModel(viewer, run), caretOffset);
+	public SelectionModel getExecuteSelectionModel(GraphicalTextViewer viewer) {
+		SelectionRange range = new SelectionRange(lookupModel(viewer, run), caretOffset);
+		return new SelectionModel(range, Collections.emptyList());
 	}
 
 	@Override
-	public SelectionRange getRedoSelectionRange(GraphicalTextViewer viewer) {
-		return getExecuteSelectionRange(viewer);
+	public SelectionModel getRedoSelectionModel(GraphicalTextViewer viewer) {
+		return getExecuteSelectionModel(viewer);
 	}
 
 	@Override
-	public SelectionRange getUndoSelectionRange(GraphicalTextViewer viewer) {
-		return getExecuteSelectionRange(viewer);
+	public SelectionModel getUndoSelectionModel(GraphicalTextViewer viewer) {
+		return getExecuteSelectionModel(viewer);
 	}
 
 }

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/ProcessMacroCommand.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/ProcessMacroCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2023 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@
 package org.eclipse.gef.examples.text.model.commands;
 
 import org.eclipse.gef.examples.text.GraphicalTextViewer;
-import org.eclipse.gef.examples.text.SelectionRange;
+import org.eclipse.gef.examples.text.SelectionModel;
 import org.eclipse.gef.examples.text.model.ModelElement;
 import org.eclipse.gef.examples.text.model.ModelLocation;
 import org.eclipse.gef.examples.text.model.TextRun;
@@ -39,26 +39,26 @@ public class ProcessMacroCommand extends CompoundEditCommand {
 	}
 
 	/**
-	 * @see org.eclipse.gef.examples.text.TextCommand#getRedoSelectionRange(org.eclipse.gef.examples.text.GraphicalTextViewer)
+	 * @see org.eclipse.gef.examples.text.TextCommand#getRedoSelectionModel(org.eclipse.gef.examples.text.GraphicalTextViewer)
 	 */
 	@Override
-	public SelectionRange getRedoSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getRedoSelectionModel(GraphicalTextViewer viewer) {
 		return null;
 	}
 
 	/**
-	 * @see org.eclipse.gef.examples.text.TextCommand#getExecuteSelectionRange(org.eclipse.gef.examples.text.GraphicalTextViewer)
+	 * @see org.eclipse.gef.examples.text.TextCommand#getExecuteSelectionModel(org.eclipse.gef.examples.text.GraphicalTextViewer)
 	 */
 	@Override
-	public SelectionRange getExecuteSelectionRange(GraphicalTextViewer viewer) {
-		return super.getExecuteSelectionRange(viewer);
+	public SelectionModel getExecuteSelectionModel(GraphicalTextViewer viewer) {
+		return super.getExecuteSelectionModel(viewer);
 	}
 
 	/**
-	 * @see org.eclipse.gef.examples.text.TextCommand#getUndoSelectionRange(org.eclipse.gef.examples.text.GraphicalTextViewer)
+	 * @see org.eclipse.gef.examples.text.TextCommand#getUndoSelectionModel(org.eclipse.gef.examples.text.GraphicalTextViewer)
 	 */
 	@Override
-	public SelectionRange getUndoSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getUndoSelectionModel(GraphicalTextViewer viewer) {
 		return null;
 	}
 

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/PromoteElementCommand.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/PromoteElementCommand.java
@@ -13,7 +13,10 @@
 
 package org.eclipse.gef.examples.text.model.commands;
 
+import java.util.Collections;
+
 import org.eclipse.gef.examples.text.GraphicalTextViewer;
+import org.eclipse.gef.examples.text.SelectionModel;
 import org.eclipse.gef.examples.text.SelectionRange;
 import org.eclipse.gef.examples.text.edit.TextEditPart;
 import org.eclipse.gef.examples.text.model.Container;
@@ -59,18 +62,19 @@ public class PromoteElementCommand extends ExampleTextCommand {
 	}
 
 	@Override
-	public SelectionRange getExecuteSelectionRange(GraphicalTextViewer viewer) {
-		return new SelectionRange(lookupModel(viewer, run), caretOffset);
+	public SelectionModel getExecuteSelectionModel(GraphicalTextViewer viewer) {
+		SelectionRange range = new SelectionRange(lookupModel(viewer, run), caretOffset);
+		return new SelectionModel(range, Collections.emptyList());
 	}
 
 	@Override
-	public SelectionRange getRedoSelectionRange(GraphicalTextViewer viewer) {
-		return getExecuteSelectionRange(viewer);
+	public SelectionModel getRedoSelectionModel(GraphicalTextViewer viewer) {
+		return getExecuteSelectionModel(viewer);
 	}
 
 	@Override
-	public SelectionRange getUndoSelectionRange(GraphicalTextViewer viewer) {
-		return getExecuteSelectionRange(viewer);
+	public SelectionModel getUndoSelectionModel(GraphicalTextViewer viewer) {
+		return getExecuteSelectionModel(viewer);
 	}
 
 }

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/SingleEditCommand.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/SingleEditCommand.java
@@ -13,7 +13,10 @@
 
 package org.eclipse.gef.examples.text.model.commands;
 
+import java.util.Collections;
+
 import org.eclipse.gef.examples.text.GraphicalTextViewer;
+import org.eclipse.gef.examples.text.SelectionModel;
 import org.eclipse.gef.examples.text.SelectionRange;
 import org.eclipse.gef.examples.text.TextLocation;
 import org.eclipse.gef.examples.text.model.ModelLocation;
@@ -43,24 +46,26 @@ public class SingleEditCommand extends ExampleTextCommand {
 	}
 
 	@Override
-	public SelectionRange getExecuteSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getExecuteSelectionModel(GraphicalTextViewer viewer) {
 		ModelLocation loc = edit.getResultingLocation();
 		if (loc != null) {
-			return new SelectionRange(lookupModel(viewer, loc.model), loc.offset);
+			SelectionRange range = new SelectionRange(lookupModel(viewer, loc.model), loc.offset);
+			return new SelectionModel(range, Collections.emptyList());
 		}
-		return getUndoSelectionRange(viewer);
+		return getUndoSelectionModel(viewer);
 	}
 
 	@Override
-	public SelectionRange getRedoSelectionRange(GraphicalTextViewer viewer) {
-		return getExecuteSelectionRange(viewer);
+	public SelectionModel getRedoSelectionModel(GraphicalTextViewer viewer) {
+		return getExecuteSelectionModel(viewer);
 	}
 
 	@Override
-	public SelectionRange getUndoSelectionRange(GraphicalTextViewer viewer) {
+	public SelectionModel getUndoSelectionModel(GraphicalTextViewer viewer) {
 		TextLocation startLoc = new TextLocation(lookupModel(viewer, start.model), start.offset);
 		TextLocation endLoc = new TextLocation(lookupModel(viewer, end.model), end.offset);
-		return new SelectionRange(startLoc, endLoc);
+		SelectionRange range = new SelectionRange(startLoc, endLoc);
+		return new SelectionModel(range, Collections.emptyList());
 	}
 
 	@Override

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/tools/TextTool.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/tools/TextTool.java
@@ -664,7 +664,7 @@ public class TextTool extends SelectionTool implements StyleProvider {
 			}
 			pendingCommand.executePending();
 			GraphicalTextViewer viewer = getTextualViewer();
-			viewer.setSelectionRange(((TextCommand) pendingCommand).getExecuteSelectionRange(viewer));
+			viewer.setSelectionModel(((TextCommand) pendingCommand).getExecuteSelectionModel(viewer));
 		}
 
 		return true;

--- a/org.eclipse.gef.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.tests
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.15.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.jface;bundle-version="[3.2.0,4.0.0)",
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.jface;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.gef.examples;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.gef.examples.logic;bundle-version="[3.14.400,4.0.0)",
  org.eclipse.gef.examples.shapes;bundle-version="[3.15.300,4.0.0)",
+ org.eclipse.gef.examples.text;bundle-version="[3.17.0,4.0.0)",
  org.eclipse.swtbot.eclipse.gef.finder;bundle-version="[4.2.0,5.0.0)",
  junit-jupiter-api;bundle-version="[5.10.2,6.0.0)",
  junit-platform-suite-api;bundle-version="[1.10.2,2.0.0)",

--- a/org.eclipse.gef.tests/pom.xml
+++ b/org.eclipse.gef.tests/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.tests</artifactId>
-	<version>3.14.200-SNAPSHOT</version>
+	<version>3.15.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<name>[bundle] GEF Classic GEF Tests</name>
 	<profiles>

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/GraphicalTextViewerTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/GraphicalTextViewerTests.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.test.swtbot;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
+import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditor;
+import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotCanvas;
+
+import org.junit.jupiter.api.Test;
+
+public class GraphicalTextViewerTests extends AbstractSWTBotEditorTests {
+
+	@Test
+	public void testSelectDeleteRestoreImportDeclaration() {
+		SWTBotGefEditor editor = bot.gefEditor("new_file.text"); //$NON-NLS-1$
+
+		SWTBotGefEditPart importPart = editor.getEditPart("org.eclipse.draw2d"); //$NON-NLS-1$
+		importPart.doubleClick();
+
+		SWTBotCanvas canvas = editor.bot().canvas();
+
+		canvas.pressShortcut(Keystrokes.DELETE);
+		waitEventLoop(0);
+		assertNull(editor.getEditPart("org.eclipse.draw2d"), "Import Declaration wasn't deleted"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		bot.menu("Edit").menu("Undo typing").click(); //$NON-NLS-1$ //$NON-NLS-2$
+		waitEventLoop(0);
+		assertNotNull(editor.getEditPart("org.eclipse.draw2d"), "Import Declaration wasn't restored"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Override
+	protected String getWizardId() {
+		return "org.eclipse.gef.examples.text.wizard.TextEditorWizard"; //$NON-NLS-1$
+	}
+
+	@Override
+	protected String getFileName() {
+		return "new_file.text"; //$NON-NLS-1$
+	}
+}

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/SWTBotTestSuite.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/SWTBotTestSuite.java
@@ -26,7 +26,8 @@ import org.junit.platform.suite.api.Suite;
 	LogicDiagramTests.class,
 	ShapesDiagramTests.class,
 	PaletteSettingsDialogTests.class,
-	PaletteSnippetTests.class
+	PaletteSnippetTests.class,
+	GraphicalTextViewerTests.class
 })
 public class SWTBotTestSuite {
 }


### PR DESCRIPTION
The `setSelectionRange()` method in the `GraphicalTextViewer` is deprecated in favor of the `setSelectionModel()` method. Former is called by e.g. all of the edit commands.

As a first step, the `SelectionModel` has been refactored to remove the unused `selectionContainer` field and to improve the handling of JFace selection. Next the commands have been adapted to internally convert the range to a model, so that the deprecated method no longer needs to be called.

To reduce the chance of regression, a small test case has been added which tests the basic editing functionality of this editor.

Contributes to https://github.com/eclipse-gef/gef-classic/pull/1182