### PR TITLE
Don't rely on `Display.getActiveShell()` to get the active shell

### DIFF
--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/DirectEditManagerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/DirectEditManagerTest.java
@@ -47,7 +47,7 @@ public class DirectEditManagerTest {
 
 	@BeforeEach
 	public void setUp() {
-		shell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
+		shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
 		editDomain = new EditDomain();
 		throwables = new ArrayList<>();
 		editManager = null;


### PR DESCRIPTION
The value returned by this method depends on e.g. focus. Use the workbench shell instead.