### PR TITLE
Handle null ImageDescriptor in PaletteEditPart

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
@@ -433,7 +433,7 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart implemen
 			resourceManager.destroy(imgDescriptor);
 		}
 		imgDescriptor = desc;
-		setImageInFigure(resourceManager.create(imgDescriptor));
+		setImageInFigure(imgDescriptor == null ? null : resourceManager.create(imgDescriptor));
 	}
 
 	/**


### PR DESCRIPTION
A NPE can occur if desc is null. This can happen if the ImageDesciptor is not found. The null ImageDescriptor was passed on to the ResourceManager resulting in a NPE. This checks for a null ImageDesciptor.

See https://github.com/eclipse-gef/gef-classic/issues/1185